### PR TITLE
simplify load_image_from_mem function

### DIFF
--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -3,6 +3,7 @@ use crate::core::color::Color;
 use crate::core::math::{Rectangle, Vector4};
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
+use std::convert::TryInto;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
 
@@ -693,12 +694,17 @@ impl Image {
         Ok(Image(i))
     }
 
-    /// Loads image from a given memory buffer as a vector of arrays
+    /// Loads image from a given memory buffer
     /// ensure filetype is extension, for example, ".png"
-    pub fn load_image_from_mem(filetype: &str, bytes: &Vec<u8>, size: i32) -> Result<Image, String> {
+    pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, String> {
         let c_filetype = CString::new(filetype).unwrap();
-        let c_bytes = bytes.as_ptr();
-        let i = unsafe { ffi::LoadImageFromMemory(c_filetype.as_ptr(), c_bytes, size) };
+        let i = unsafe {
+            ffi::LoadImageFromMemory(
+                c_filetype.as_ptr(),
+                bytes.as_ptr(),
+                bytes.len().try_into().unwrap(),
+            )
+        };
         if i.data.is_null() {
             return Err(format!(
             "Image data is null. Check provided buffer data"

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -695,7 +695,8 @@ impl Image {
     }
 
     /// Loads image from a given memory buffer
-    /// ensure filetype is extension, for example, ".png"
+    /// The input data is expected to be in a supported file format such as png. Which formats are
+    /// supported depend on the build flags used for the raylib (C) library.
     pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, String> {
         let c_filetype = CString::new(filetype).unwrap();
         let i = unsafe {


### PR DESCRIPTION
Original PR: deltaphc/raylib-rs#129

---
A simple but nice to have change to Image::load_image_from_mem:

    Pass the data buffer in as a slice instead of a Vec. We don't really need the vector's functionality here, so we shouldn't force the user to create one (also mentioned in 

    https://github.com/deltaphc/raylib-rs/issues/106).
    Remove the size parameter, we can get the size from the slice/vector.

Points of consideration:

    Use try_into when converting the buffer's size into a i32. Using try_into().unwrap() would panic when the buffers size exceeds i32's range. That doesn't sound very likely, but I think it's better to have the crash happen here, rather than leave raylib to deal with a negative size.

Note. I'm new to Rust as a language so I'm not sure if this is 100% right, feel free to yell at me if this code makes no sense :)

---

> Hi, if you're still interested in working on this, some users of the library are moving over to a [fork of it which aims to be actively maintained.](https://github.com/raylib-rs/raylib-rs/) It would be nice if you reopened the PR there!

@IoIxD I'm not actively using raylib anymore so I'm not sure when I'll get to resolving the merge conflicts. From what I've seen the function signature still passes a vec and a (seperate) size as arguments, so I think the change still makes sense.