### PR TITLE
Builder: Move the SetLogLevel call above the initial function that creates the RaylibHandle, mimicking previous behavior and reducing user confusion.

### DIFF
--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -196,8 +196,11 @@ impl RaylibBuilder {
         unsafe {
             ffi::SetConfigFlags(flags as u32);
         }
+
+        unsafe {
+            ffi::SetTraceLogLevel(self.log_level as i32);
+        }
         let rl = init_window(self.width, self.height, &self.title);
-        rl.set_trace_log(self.log_level);
         (rl, RaylibThread(PhantomData))
     }
 }


### PR DESCRIPTION
Closes #27 