### PR TITLE
Mirror the opengl features to the raylib crate, bump the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
-# Remember to fix the examples befor creating a pullrequest, also rename the branch to 2.5.0
-![logo](logo/raylib-rust_256x256.png)
-
-![rust](https://img.shields.io/badge/rust-1.31+-orange.svg?style=flat-square&logo=rust)
+<p align="center">
+    
+![rust](https://img.shields.io/badge/rust-1.77+-orange.svg?style=flat-square&logo=rust)
 [![crates.io](https://img.shields.io/crates/v/raylib.svg?style=flat-square)](https://crates.io/crates/raylib)
 [![docs](https://docs.rs/raylib/badge.svg)](https://docs.rs/raylib)
-[discord](https://discord.gg/VkzNHUE)
+[![discord](https://img.shields.io/discord/426912293134270465)](https://discord.gg/VkzNHUE)
 
+</p>
 
-# NOTE 4.x version in progress. 
+<table border="0">
+<tr>
+<td>
 
-Raylib 4.2 is currenlty a work in progress. In the meantime you can use a fork: https://github.com/litten2up/raylib-rs
+![logo](logo/raylib-rust_256x256.png)
 
-Add this to your Cargo.toml
-```toml
-[dependencies.raylib]
-version = "4.5.0"
-git = "https://github.com/litten2up/raylib-rs"
-branch = "4.5.0"
-```
+</td>
+<td>
 
 # raylib-rs
 
-raylib-rs is a Rust binding for [raylib](http://www.raylib.com/) 4.5.0-dev. It currently targets the _stable_ Rust toolchain, version 1.31 or higher.
+raylib-rs is a Rust binding for [raylib](http://www.raylib.com/) 5.0. It currently targets the _stable_ Rust toolchain, version 1.77 or higher.
 
 Please checkout the showcase directory to find usage examples!
 
 Though this binding tries to stay close to the simple C API, it makes some changes to be more idiomatic for Rust.
+
+</td>
+</tr>
+</table>
+
 
 - Resources are automatically cleaned up when they go out of scope (or when `std::mem::drop` is called). This is essentially RAII. This means that "Unload" functions are not exposed (and not necessary unless you obtain a `Weak` resource using make_weak()).
 - Most of the Raylib API is exposed through `RaylibHandle`, which is for enforcing that Raylib is only initialized once, and for making sure the window is closed properly. RaylibHandle has no size and goes away at compile time. Because of mutability rules, Raylib-rs is thread safe!
@@ -34,8 +36,6 @@ Though this binding tries to stay close to the simple C API, it makes some chang
 - `Model::set_material`, `Material::set_shader`, and `MaterialMap::set_texture` methods were added since one cannot set the fields directly. Also enforces correct ownership semantics.
 - `Font::from_data`, `Font::set_chars`, and `Font::set_texture` methods were added to create a `Font` from loaded `CharInfo` data.
 - `SubText` and `FormatText` are omitted, and are instead covered by Rust's string slicing and Rust's `format!` macro, respectively.
-
-**Disclaimer: I created this binding as a way to learn Rust. There may be some things I can do better, or make more ergonomic for users. Feel free to make suggestions!**
 
 # Installation
 
@@ -57,7 +57,7 @@ Follow instructions for building raylib for your platform [here](https://github.
 
 ```toml
 [dependencies]
-raylib = { version = "3.7" }
+raylib = { version = "5.0" }
 ```
 
 2. Start coding!
@@ -82,10 +82,11 @@ fn main() {
 
 # Tech Notes
 
-- Structs holding resources have RAII/move semantics, including: `Image`, `Texture2D`, `RenderTexture2D`, `Font`, `Mesh`, `Shader`, `Material`, `Model`, `Wave`, `Sound`, `Music`, and `AudioStream`.
+- Structs holding resources have RAII/move semantics, including: `Image`, `Texture2D`, `RenderTexture2D`, `Font`, `Mesh`, `Shader`, `Material`, and `Model`.
+- `Wave`, `Sound`, `Music`, and `AudioStream` have lifetimes bound to `AudioHandle`. 
 - Functions dealing with string data take in `&str` and/or return an owned `String`, for the sake of safety. The exception to this is the gui draw functions which take &CStr to avoid per frame allocations. The `rstr!` macro helps make this easy.
 - In C, `LoadFontData` returns a pointer to a heap-allocated array of `CharInfo` structs. In this Rust binding, said array is copied into an owned `Vec<CharInfo>`, the original data is freed, and the owned Vec is returned.
-- In C, `LoadDroppedFiles` returns a pointer to an array of strings owned by raylib. Again, for safety and also ease of use, this binding copies said array into a `Vec<String>` which is returned to the caller.
+- In C, `GetDroppedFiles` returns a pointer to an array of strings owned by raylib. Again, for safety and also ease of use, this binding copies said array into a `Vec<String>` which is returned to the caller.
 - I've tried to make linking automatic, though I've only tested on Windows 10, Ubuntu, and MacOS 15. Other platforms may have other considerations.
 - OpenGL 3.3, 2.1, and ES 2.0 may be forced via adding `["opengl_33"]`, `["opengl_21"]` or `["opengl_es_20]` to the `features` array in your Cargo.toml dependency definition.
 

--- a/raylib-sys/binding/binding.h
+++ b/raylib-sys/binding/binding.h
@@ -1,5 +1,6 @@
 #include "raygui.h"
 #include "../raylib/src/rlgl.h"
+#include "utils_log.h"
 
 typedef enum
 {

--- a/raylib-sys/binding/utils_log.c
+++ b/raylib-sys/binding/utils_log.c
@@ -1,0 +1,20 @@
+#include "raylib.h"
+#include "utils_log.h"
+#include <stdio.h>	// Required for: vprintf()
+#include <string.h> // Required for: strcpy(), strcat()
+
+#define MAX_TRACELOG_BUFFER_SIZE 128 // As defined in utils.c from raylib
+
+void rayLogWrapperCallback(char *logType, const char *text, va_list args)
+{
+	char buffer[MAX_TRACELOG_BUFFER_SIZE] = {0};
+
+	vsprintf(buffer, text, args);
+
+	custom_trace_log_callback(logType, buffer, strlen(buffer));
+}
+
+void setLogCallbackWrapper(void)
+{
+	SetTraceLogCallback(rayLogWrapperCallback);
+}

--- a/raylib-sys/binding/utils_log.c
+++ b/raylib-sys/binding/utils_log.c
@@ -1,4 +1,7 @@
-#include "raylib.h"
+#if !defined(RAYGUI_STANDALONE)
+#include "../raylib/src/raylib.h"
+#endif
+
 #include "utils_log.h"
 #include <stdio.h>	// Required for: vprintf()
 #include <string.h> // Required for: strcpy(), strcat()

--- a/raylib-sys/binding/utils_log.h
+++ b/raylib-sys/binding/utils_log.h
@@ -1,0 +1,11 @@
+#if defined(__cplusplus)
+extern "C"
+{ // Prevents name mangling of functions
+#endif
+
+    void setLogCallbackWrapper(void); // enable the call-back
+    void custom_trace_log_callback(int logType, const char *text, int len);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -221,7 +221,7 @@ fn gen_rgui() {
     #[cfg(target_os = "windows")]
     {
         cc::Build::new()
-            .file("binding/rgui_wrapper.cpp")
+            .files(vec!["binding/rgui_wrapper.cpp", "binding/utils_log.c"])
             .include("binding")
             .warnings(false)
             // .flag("-std=c99")
@@ -231,7 +231,7 @@ fn gen_rgui() {
     #[cfg(not(target_os = "windows"))]
     {
         cc::Build::new()
-            .file("binding/rgui_wrapper.c")
+            .files(vec!["binding/rgui_wrapper.c", "binding/utils_log.c"])
             .include("binding")
             .warnings(false)
             // .flag("-std=c99")

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -22,8 +22,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 /// latest version on github's release page as of time or writing
-const LATEST_RAYLIB_VERSION: &str = "4.2.0";
-const LATEST_RAYLIB_API_VERSION: &str = "4";
+const LATEST_RAYLIB_VERSION: &str = "5.0.0";
+const LATEST_RAYLIB_API_VERSION: &str = "5";
 
 #[derive(Debug)]
 struct IgnoreMacros(HashSet<String>);
@@ -57,6 +57,7 @@ fn build_with_cmake(src_path: &str) {
     }
 
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
+
     let (platform, platform_os) = platform_from_target(&target);
 
     let mut conf = cmake::Config::new(src_path);
@@ -291,9 +292,26 @@ fn link(platform: Platform, platform_os: PlatformOS) {
 }
 
 fn main() {
+    println!("cargo:rustc-env=EMCC_CFLAGS=\"-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap\"");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=./binding/binding.h");
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
+
+    // make sure cmake knows that it should bundle glfw in
+    if target.contains("wasm") {
+        if let Err(e) = env::var("EMCC_CFLAGS") {
+            if e == std::env::VarError::NotPresent {
+                panic!("\nYou must set the following environment variables yourself to compile for WASM. We are sorry for the inconvienence; this will be fixed in 5.1.0.\n{}{}\"\n",{
+                    #[cfg(target_family = "windows")]
+                    {"Paste this before executing the command: set EMCC_CFLAGS="}
+                    #[cfg(not(target_family = "windows"))]
+                    {"Prefix your command with this (you may want to make a build script for obvious reasons...): EMCC_CFLAGS="}
+                },"\"-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_RUNTIME_METHODS=ccallcwrap\"");
+            } else {
+                panic!("\nError regarding EMCC_CFLAGS: {:?}\n", e);
+            }
+        }
+    }
     let (platform, platform_os) = platform_from_target(&target);
 
     // Donwload raylib source
@@ -337,12 +355,7 @@ fn run_command(cmd: &str, args: &[&str]) {
 }
 
 fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
-    let platform = if target.contains("wasm32") {
-        // make sure cmake knows that it should bundle glfw in
-        env::set_var(
-            "EMCC_CFLAGS",
-            "-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
-        );
+    let platform = if target.contains("wasm") {
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -306,7 +306,7 @@ fn main() {
                     {"Paste this before executing the command: set EMCC_CFLAGS="}
                     #[cfg(not(target_family = "windows"))]
                     {"Prefix your command with this (you may want to make a build script for obvious reasons...): EMCC_CFLAGS="}
-                },"\"-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_RUNTIME_METHODS=ccallcwrap\"");
+                },"\"-O3 -sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_RUNTIME_METHODS=ccallcwrap\"");
             } else {
                 panic!("\nError regarding EMCC_CFLAGS: {:?}\n", e);
             }

--- a/raylib-sys/src/lib.rs
+++ b/raylib-sys/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(clippy::approx_constant)]
+
+use std::ffi::c_char;
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(target_os = "macos")]

--- a/raylib-test/src/automation.rs
+++ b/raylib-test/src/automation.rs
@@ -41,7 +41,7 @@ pub(crate) mod automation_test {
                     rl.start_automation_event_recording();
                 } else {
                     rl.stop_automation_event_recording();
-                    aelist.export("test_out/automation.rae".into());
+                    aelist.export("test_out/automation.rae");
                     println!("RECORDED FRAMES: {}", aelist.count());
                     events = aelist.events();
                 }

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
 parking_lot = "0.12.1"
+va_list = "0.1.4"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -33,6 +33,9 @@ with_serde = ["serde", "serde_json"]
 nalgebra_interop = ["nalgebra"]
 wayland = ["raylib-sys/wayland"]
 custom_frame_control = ["raylib-sys/custom_frame_control"]
+opengl_33 = ["raylib-sys/opengl_33"]
+opengl_21 = ["raylib-sys/opengl_21"]￼
+opengl_es_20 = ["raylib-sys/opengl_es_20"]
 
 [[target.'cfg(not(target_os = "windows"))'.example]]
 name = "specs"

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -80,11 +80,14 @@ impl RaylibAudio {
     }
 
     /// Loads a new sound from file.
-    pub fn new_sound<'aud>(&'aud self, filename: &str) -> Result<Sound<'aud>, String> {
-        let c_filename = CString::new(filename).unwrap();
+    pub fn new_sound<'aud>(&'aud self, filename: impl AsRef<Path>) -> Result<Sound<'aud>, String> {
+        let c_filename = CString::new(filename.as_ref().to_string_lossy().as_bytes()).unwrap();
         let s = unsafe { ffi::LoadSound(c_filename.as_ptr()) };
         if s.stream.buffer.is_null() {
-            return Err(format!("failed to load sound {}", filename));
+            return Err(format!(
+                "failed to load sound {}",
+                filename.as_ref().display()
+            ));
         }
 
         Ok(Sound(s, self))
@@ -100,11 +103,11 @@ impl RaylibAudio {
     }
     /// Loads wave data from file into RAM.
     #[inline]
-    pub fn new_wave<'aud>(&'aud self, filename: &str) -> Result<Wave<'aud>, String> {
-        let c_filename = CString::new(filename).unwrap();
+    pub fn new_wave<'aud>(&'aud self, filename: impl AsRef<Path>) -> Result<Wave<'aud>, String> {
+        let c_filename = CString::new(filename.as_ref().to_string_lossy().as_bytes()).unwrap();
         let w = unsafe { ffi::LoadWave(c_filename.as_ptr()) };
         if w.data.is_null() {
-            return Err(format!("Cannot load wave {}", filename));
+            return Err(format!("Cannot load wave {}", filename.as_ref().display()));
         }
         Ok(Wave(w, self))
     }
@@ -127,11 +130,14 @@ impl RaylibAudio {
 
     /// Loads music stream from file.
     // #[inline]
-    pub fn new_music<'aud>(&'aud self, filename: &str) -> Result<Music<'aud>, String> {
-        let c_filename = CString::new(filename).unwrap();
+    pub fn new_music<'aud>(&'aud self, filename: impl AsRef<Path>) -> Result<Music<'aud>, String> {
+        let c_filename = CString::new(filename.as_ref().to_string_lossy().as_bytes()).unwrap();
         let m = unsafe { ffi::LoadMusicStream(c_filename.as_ptr()) };
         if m.stream.buffer.is_null() {
-            return Err(format!("music could not be loaded from file {}", filename));
+            return Err(format!(
+                "music could not be loaded from file {}",
+                filename.as_ref().display()
+            ));
         }
         Ok(Music(m, self))
     }

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -61,7 +61,7 @@ impl RaylibAudio {
 
     /// Checks if audio device is ready.
     #[inline]
-    pub fn ready(&self) -> bool {
+    pub fn is_audio_device_ready(&self) -> bool {
         unsafe { ffi::IsAudioDeviceReady() }
     }
 
@@ -198,7 +198,7 @@ impl<'aud> Wave<'aud> {
         inner
     }
 
-    pub fn ready(&self) -> bool {
+    pub fn is_wave_ready(&self) -> bool {
         unsafe { ffi::IsWaveReady(self.0) }
     }
 
@@ -267,7 +267,7 @@ impl<'aud> AsMut<ffi::AudioStream> for Sound<'aud> {
 }
 
 impl<'aud> Sound<'aud> {
-    pub fn ready(&self) -> bool {
+    pub fn is_sound_ready(&self) -> bool {
         unsafe { ffi::IsSoundReady(self.0) }
     }
 
@@ -354,7 +354,7 @@ impl<'aud> Sound<'aud> {
 }
 
 impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
-    pub fn ready(&self) -> bool {
+    pub fn is_sound_ready(&self) -> bool {
         unsafe { ffi::IsSoundReady(self.0) }
     }
 
@@ -516,7 +516,7 @@ impl<'aud> Music<'aud> {
 }
 
 impl<'aud> AudioStream<'aud> {
-    pub fn ready(&self) -> bool {
+    pub fn is_audio_stream_ready(&self) -> bool {
         unsafe { ffi::IsAudioStreamReady(self.0) }
     }
     pub fn sample_rate(&self) -> u32 {

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -5,6 +5,7 @@ use std::ffi::CString;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
+use std::path::Path;
 
 make_thin_wrapper_lifetime!(Wave, ffi::Wave, RaylibAudio, ffi::UnloadWave);
 
@@ -204,8 +205,8 @@ impl<'aud> Wave<'aud> {
 
     /// Export wave file. Extension must be .wav or .raw
     #[inline]
-    pub fn export(&self, filename: &str) -> bool {
-        let c_filename = CString::new(filename).unwrap();
+    pub fn export(&self, filename: impl AsRef<Path>) -> bool {
+        let c_filename = CString::new(filename.as_ref().to_string_lossy().as_bytes()).unwrap();
         unsafe { ffi::ExportWave(self.0, c_filename.as_ptr()) }
     }
 

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -43,7 +43,7 @@ impl std::error::Error for RaylibAudioInitError {}
 /// This token is used to indicate audio is initialized. It's also used to create [`Wave`], [`Sound`], [`Music`], [`AudioStream`], and [`SoundAlias`].
 /// All of those have a lifetime that is bound to RaylibAudio. The compiler will disallow you from using them without ensuring that the [`RaylibAudio`] is present while doing so.
 #[derive(Debug, Clone)]
-pub struct RaylibAudio(());
+pub struct RaylibAudio(PhantomData<()>);
 
 impl RaylibAudio {
     /// Initializes audio device and context.
@@ -56,7 +56,7 @@ impl RaylibAudio {
             }
             ffi::InitAudioDevice();
         }
-        Ok(RaylibAudio(()))
+        Ok(RaylibAudio(PhantomData))
     }
 
     /// Checks if audio device is ready.

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 
 use crate::{audio::AudioStream, ffi, RaylibHandle};
-use libc::{c_char, c_int, c_void};
+use libc::c_void;
 use parking_lot::Mutex;
 use raylib_sys::TraceLogLevel;
 use std::{
@@ -9,19 +9,10 @@ use std::{
     ptr,
 };
 
+type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
 extern "C" {
-    fn sprintf(st: *mut c_char, fmt: *const c_char, ...) -> c_int;
+    fn SetTraceLogCallback(cb: Option<TraceLogCallback>);
 }
-
-#[cfg(target_family = "wasm")]
-type __va_list_tag = c_void;
-
-#[cfg(target_os = "windows")]
-type __va_list_tag = i8;
-#[cfg(target_os = "linux")]
-type __va_list_tag = raylib_sys::__va_list_tag;
-#[cfg(target_os = "darwin")]
-type __va_list_tag = raylib_sys::__va_list_tag;
 
 type RustTraceLogCallback = Option<fn(TraceLogLevel, &str)>;
 type RustSaveFileDataCallback = Option<fn(&str, &[u8]) -> bool>;
@@ -76,10 +67,11 @@ fn set_audio_stream_callback(f: RustAudioStreamCallback) {
     *__AUDIO_STREAM_CALLBACK.lock() = f
 }
 
+#[no_mangle]
 extern "C" fn custom_trace_log_callback(
     log_level: ::std::os::raw::c_int,
     text: *const ::std::os::raw::c_char,
-    args: *mut __va_list_tag,
+    len: ::std::os::raw::c_int,
 ) {
     if let Some(trace_log) = trace_log_callback() {
         let a = match log_level {
@@ -96,12 +88,10 @@ extern "C" fn custom_trace_log_callback(
         let b = if text.is_null() {
             CStr::from_bytes_until_nul("(MESSAGE WAS NULL)\0".as_bytes()).unwrap()
         } else {
-            const MAX_TRACELOG_MSG_LENGTH: usize = 386; // chosen because 256 is the max length in raylib's own code and 386 is a bit higher then that.
-            let mut buf: [i8; MAX_TRACELOG_MSG_LENGTH] = [0; MAX_TRACELOG_MSG_LENGTH];
-
-            unsafe { sprintf(buf.as_mut_ptr(), text, args) };
-            let b = buf.as_ptr();
-            unsafe { CStr::from_ptr(b) }
+            unsafe {
+                let b = std::slice::from_raw_parts(text, len as usize);
+                CStr::from_ptr(b.as_ptr())
+            }
         };
 
         trace_log(a, b.to_string_lossy().as_ref())
@@ -180,14 +170,13 @@ impl RaylibHandle {
         &mut self,
         cb: fn(TraceLogLevel, &str),
     ) -> Result<(), SetLogError> {
-        safe_callback_set_func!(
-            cb,
-            trace_log_callback,
-            set_trace_log_callback,
-            ffi::SetTraceLogCallback,
-            custom_trace_log_callback,
-            "trace log"
-        );
+        if let None = trace_log_callback() {
+            set_trace_log_callback(Some(cb));
+            unsafe { ffi::setLogCallbackWrapper() };
+            return Ok(());
+        } else {
+            return Err(SetLogError("trace log"));
+        };
     }
     /// Set custom file binary data saver
     pub fn set_save_file_data_callback(

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -10,11 +10,12 @@ use std::{
 };
 
 extern "C" {
-    fn sprintf(fmt: *const c_char, ...) -> c_int;
+    fn sprintf(st: *mut c_char, fmt: *const c_char, ...) -> c_int;
 }
 
-#[cfg(target_os = "wasm32")]
+#[cfg(target_family = "wasm")]
 type __va_list_tag = c_void;
+
 #[cfg(target_os = "windows")]
 type __va_list_tag = i8;
 #[cfg(target_os = "linux")]

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -1,7 +1,7 @@
 /* raylib-rs
    lib.rs - Main library code (the safe layer)
 
-Copyright (c) 2018-2019 Paul Clement (@deltaphc)
+Copyright (c) 2018-2024 raylib-rs team
 
 This software is provided "as-is", without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
 
@@ -55,6 +55,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 //! }
 //! ```
 //#![cfg_attr(feature = "nightly", feature(auto_traits))]
+
 #![allow(dead_code)]
 pub mod consts;
 pub mod core;


### PR DESCRIPTION
Simple PR that does exactly what the title describes. It's so simple and uncontroversial that I'll probably merge it without approval. All this does is mirror the opengl feature flags to raylib, which is how it should be, and adjust the README in preparation for the fact that this is gonna be merged into the main branch eventually.