### PR TITLE
fix: target flag for wasm32

### DIFF
--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -13,7 +13,7 @@ extern "C" {
     fn sprintf(fmt: *const c_char, ...) -> c_int;
 }
 
-#[cfg(target_os = "wasm32")]
+#[cfg(target_arch = "wasm32")]
 type __va_list_tag = *mut c_void;
 #[cfg(target_os = "windows")]
 type __va_list_tag = *mut i8;


### PR DESCRIPTION
Super simple fix for building wasm32 target.
Solve #41 