### PR TITLE
Fix `RaylibTextureModeExt` impl for `RaylibHandle`

### DIFF
--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -80,7 +80,7 @@ where
 
 // Only the DrawHandle and the RaylibHandle can start a texture
 impl<'a> RaylibTextureModeExt for RaylibDrawHandle<'a> {}
-impl RaylibTextureModeExt for &mut RaylibHandle {}
+impl RaylibTextureModeExt for RaylibHandle {}
 impl<'a, T> RaylibDraw for RaylibTextureMode<'a, T> {}
 
 // VR Stuff


### PR DESCRIPTION
The current version requires you to call the method on an `&mut &mut`, which prevents you from calling it as a method on the `RaylibHandle` Directly.

The raylib example https://www.raylib.com/examples/core/loader.html?name=core_2d_camera_split_screen expects you to be able to do this when calling `BeginTextureMode`. As it stands, the same code in the Rust bindings has to do this:

```rs
let temp = &mut &mut rl;
let _ = temp.begin_texture_mode(&thread, &mut screencamera1);
```

as it won't automatically double reference the `RaylibHandle` for you.