### PR TITLE
Rework callback system to use atomic instead of Mutex.

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -20,7 +20,6 @@ cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
-parking_lot = "0.12.1"
 specs-derive = "0.4.1"
 
 [dev-dependencies]


### PR DESCRIPTION
The current system uses a mutex and imply a dependency on parking_lot, use a AtomicUsize instead to store the function pointer instead.
Also do various other changes to make the callback system more robust and valid.

Check some expectations using constant assert (e.g function pointer width being Usize).