### PR TITLE
feat!: add designated error types

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
 parking_lot = "0.12.1"
 specs-derive = "0.4.1"
+thiserror = "1.0.61"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -1,7 +1,7 @@
 //! Data manipulation functions. Compress and Decompress with DEFLATE
 use std::{ffi::CString, path::Path};
 
-use crate::ffi;
+use crate::{error::RaylibError, ffi};
 
 /// Compress data (DEFLATE algorythm)
 /// ```rust
@@ -10,14 +10,14 @@ use crate::ffi;
 /// let expected: &[u8] = &[1, 5, 0, 250, 255, 49, 49, 49, 49, 49];
 /// assert_eq!(data, Ok(expected));
 /// ```
-pub fn compress_data(data: &[u8]) -> Result<&'static [u8], String> {
+pub fn compress_data(data: &[u8]) -> Result<&'static [u8], RaylibError> {
     let mut out_length: i32 = 0;
     // CompressData doesn't actually modify the data, but the header is wrong
     let buffer = {
         unsafe { ffi::CompressData(data.as_ptr() as *mut _, data.len() as i32, &mut out_length) }
     };
     if buffer.is_null() {
-        return Err("could not compress data".to_string());
+        return Err(RaylibError("could not compress data"));
     }
     let buffer = unsafe { std::slice::from_raw_parts(buffer, out_length as usize) };
     return Ok(buffer);
@@ -31,7 +31,7 @@ pub fn compress_data(data: &[u8]) -> Result<&'static [u8], String> {
 /// let data = decompress_data(input);
 /// assert_eq!(data, Ok(expected));
 /// ```
-pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], String> {
+pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], RaylibError> {
     println!("{:?}", data.len());
 
     let mut out_length: i32 = 0;
@@ -40,7 +40,7 @@ pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], String> {
         unsafe { ffi::DecompressData(data.as_ptr() as *mut _, data.len() as i32, &mut out_length) }
     };
     if buffer.is_null() {
-        return Err("could not compress data".to_string());
+        return Err(RaylibError("could not compress data"));
     }
     let buffer = unsafe { std::slice::from_raw_parts(buffer, out_length as usize) };
     return Ok(buffer);

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -1,0 +1,29 @@
+//! Definitions for error types used throught the crate
+
+// NOTE: These errors assume that all the error strings are known at compile-time.
+// If there is a need to make the contained type hold an owned value - make them generic
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[repr(transparent)]
+#[error("{0}")]
+pub struct RaylibError(pub(crate) &'static str);
+
+#[derive(Error, Debug)]
+#[error(
+    "{message}\npath: {path}",
+    path = path.display(),
+)]
+pub struct RaylibPathError {
+    pub(crate) message: &'static str,
+    pub(crate) path: PathBuf,
+}
+
+impl RaylibPathError {
+    pub(crate) const fn new(message: &'static str, path: PathBuf) -> Self {
+        Self { message, path }
+    }
+}

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -20,6 +20,7 @@ pub mod text;
 pub mod texture;
 pub mod vr;
 pub mod window;
+pub mod error;
 
 use raylib_sys::TraceLogLevel;
 

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -2,6 +2,7 @@
 use crate::core::math::{BoundingBox, Vector3};
 use crate::core::texture::Image;
 use crate::core::{RaylibHandle, RaylibThread};
+use crate::error::{RaylibError, RaylibPathError};
 use crate::{consts, ffi};
 use std::ffi::CString;
 use std::os::raw::c_void;
@@ -53,12 +54,12 @@ impl Clone for WeakModelAnimation {
 impl RaylibHandle {
     /// Loads model from files (mesh and material).
     // #[inline]
-    pub fn load_model(&mut self, _: &RaylibThread, filename: &str) -> Result<Model, String> {
+    pub fn load_model(&mut self, _: &RaylibThread, filename: &str) -> Result<Model, RaylibPathError> {
         let c_filename = CString::new(filename).unwrap();
         let m = unsafe { ffi::LoadModel(c_filename.as_ptr()) };
         if m.meshes.is_null() && m.materials.is_null() && m.bones.is_null() && m.bindPose.is_null()
         {
-            return Err(format!("could not load model {}", filename));
+            return Err(RaylibPathError::new("could not load model", filename.into()));
         }
         // TODO check if null pointer checks are necessary.
         Ok(Model(m))
@@ -69,11 +70,11 @@ impl RaylibHandle {
         &mut self,
         _: &RaylibThread,
         mesh: WeakMesh,
-    ) -> Result<Model, String> {
+    ) -> Result<Model, RaylibError> {
         let m = unsafe { ffi::LoadModelFromMesh(mesh.0) };
 
         if m.meshes.is_null() || m.materials.is_null() {
-            return Err("Could not load model from mesh".to_owned());
+            return Err(RaylibError("Could not load model from mesh"));
         }
 
         Ok(Model(m))
@@ -83,12 +84,12 @@ impl RaylibHandle {
         &mut self,
         _: &RaylibThread,
         filename: &str,
-    ) -> Result<Vec<ModelAnimation>, String> {
+    ) -> Result<Vec<ModelAnimation>, RaylibPathError> {
         let c_filename = CString::new(filename).unwrap();
         let mut m_size = 0;
         let m_ptr = unsafe { ffi::LoadModelAnimations(c_filename.as_ptr(), &mut m_size) };
         if m_size <= 0 {
-            return Err(format!("No model animations loaded from {}", filename));
+            return Err(RaylibPathError::new("No model animations loaded", filename.into()));
         }
         let mut m_vec = Vec::with_capacity(m_size as usize);
         for i in 0..m_size {
@@ -417,12 +418,12 @@ impl Material {
         m
     }
 
-    pub fn load_materials(filename: &str) -> Result<Vec<Material>, String> {
+    pub fn load_materials(filename: &str) -> Result<Vec<Material>, RaylibPathError> {
         let c_filename = CString::new(filename).unwrap();
         let mut m_size = 0;
         let m_ptr = unsafe { ffi::LoadMaterials(c_filename.as_ptr(), &mut m_size) };
         if m_size <= 0 {
-            return Err(format!("No materials loaded from {}", filename));
+            return Err(RaylibPathError::new("No materials loaded", filename.into()));
         }
         let mut m_vec = Vec::with_capacity(m_size as usize);
         for i in 0..m_size {

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -1,4 +1,6 @@
 //! Code for the safe manipulation of shaders
+use thiserror::Error;
+
 use crate::consts::ShaderUniformDataType;
 use crate::core::math::Matrix;
 use crate::core::math::{Vector2, Vector3, Vector4};
@@ -23,7 +25,7 @@ impl RaylibHandle {
         _: &RaylibThread,
         vs_filename: Option<&str>,
         fs_filename: Option<&str>,
-    ) -> Result<Shader, String> {
+    ) -> Shader {
         let c_vs_filename = vs_filename.map(|f| CString::new(f).unwrap());
         let c_fs_filename = fs_filename.map(|f| CString::new(f).unwrap());
 
@@ -36,7 +38,7 @@ impl RaylibHandle {
             (None, None) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), std::ptr::null())) },
         };
 
-        return Ok(shader);
+        return shader;
     }
 
     /// Loads shader from code strings and binds default locations.

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -5,6 +5,7 @@ use raylib_sys::LoadUTF8;
 use crate::core::math::Vector2;
 use crate::core::texture::{Image, Texture2D};
 use crate::core::{RaylibHandle, RaylibThread};
+use crate::error::{RaylibError, RaylibPathError};
 use crate::ffi;
 use crate::math::Rectangle;
 
@@ -118,13 +119,13 @@ impl RaylibHandle {
 
     /// Loads font from file into GPU memory (VRAM).
     #[inline]
-    pub fn load_font(&mut self, _: &RaylibThread, filename: &str) -> Result<Font, String> {
+    pub fn load_font(&mut self, _: &RaylibThread, filename: &str) -> Result<Font, RaylibPathError> {
         let c_filename = CString::new(filename).unwrap();
         let f = unsafe { ffi::LoadFont(c_filename.as_ptr()) };
         if f.glyphs.is_null() || f.texture.id == 0 {
-            return Err(format!(
-                "Error loading font {}. Does it exist? Is it the right type?",
-                filename
+            return Err(RaylibPathError::new(
+                "Error loading font. Check if the file exists and if it's the right type",
+                filename.into(),
             ));
         }
         Ok(Font(f))
@@ -139,7 +140,7 @@ impl RaylibHandle {
         filename: &str,
         font_size: i32,
         chars: Option<&str>,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, RaylibPathError> {
         let c_filename = CString::new(filename).unwrap();
         let f = unsafe {
             match chars {
@@ -156,9 +157,9 @@ impl RaylibHandle {
             }
         };
         if f.glyphs.is_null() || f.texture.id == 0 {
-            return Err(format!(
-                "Error loading font {}. Does it exist? Is it the right type?",
-                filename
+            return Err(RaylibPathError::new(
+                "Error loading font. Check if the file exists and if it's the right type",
+                filename.into(),
             ));
         }
         Ok(Font(f))
@@ -172,10 +173,10 @@ impl RaylibHandle {
         image: &Image,
         key: impl Into<ffi::Color>,
         first_char: i32,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, RaylibError> {
         let f = unsafe { ffi::LoadFontFromImage(image.0, key.into(), first_char) };
         if f.glyphs.is_null() {
-            return Err(format!("Error loading font from image."));
+            return Err(RaylibError("Error loading font from image."));
         }
         Ok(Font(f))
     }
@@ -190,7 +191,7 @@ impl RaylibHandle {
         file_data: &[u8],
         font_size: i32,
         chars: Option<&str>,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, RaylibError> {
         let c_file_type = CString::new(file_type).unwrap();
         let f = unsafe {
             match chars {
@@ -216,9 +217,7 @@ impl RaylibHandle {
             }
         };
         if f.glyphs.is_null() || f.texture.id == 0 {
-            return Err(format!(
-                "Error loading font from memory. Is it the right type?"
-            ));
+            return Err(RaylibError("Error loading font from memory. Check if the file's type is correct"));
         }
         Ok(Font(f))
     }
@@ -340,7 +339,7 @@ impl Font {
         base_size: i32,
         padding: i32,
         pack_method: i32,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, RaylibError> {
         let f = unsafe {
             let mut f = std::mem::zeroed::<Font>();
             f.baseSize = base_size;
@@ -359,7 +358,7 @@ impl Font {
             f
         };
         if f.0.glyphs.is_null() || f.0.texture.id == 0 {
-            return Err(format!("Error loading font from image."));
+            return Err(RaylibError("Error loading font from image."));
         }
         Ok(f)
     }


### PR DESCRIPTION
Added error types that implement `Error` trait, along with replacing every instance of `Result<_, String>` with `Result<_, RaylibError | RaylibPathError>`.

The error types are limited to static strings, since the only instance where the size of the message is unknown is when it takes a path, in which case there's a separate `RaylibPathError` that encapsulates a static string with an owned path.

> [!WARNING]
> I wasn't able to run `cargo test` because of incorrectly set up examples. I, however, imported the thing directly and it seemed to work fine.