### PR TITLE
Relax &mut self requirements on Audio types

### DIFF
--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -67,7 +67,7 @@ impl RaylibAudio {
     }
 
     /// Get master volume (listener)
-    pub fn get_master_volume(&mut self) -> f32 {
+    pub fn get_master_volume(&self) -> f32 {
         unsafe { ffi::GetMasterVolume() }
     }
 
@@ -291,7 +291,7 @@ impl<'aud> Sound<'aud> {
 
     /// Pauses a sound.
     #[inline]
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         unsafe {
             ffi::PauseSound(self.0);
         }
@@ -299,7 +299,7 @@ impl<'aud> Sound<'aud> {
 
     /// Resumes a paused sound.
     #[inline]
-    pub fn resume(&mut self) {
+    pub fn resume(&self) {
         unsafe {
             ffi::ResumeSound(self.0);
         }
@@ -307,7 +307,7 @@ impl<'aud> Sound<'aud> {
 
     /// Stops playing a sound.
     #[inline]
-    pub fn stop(&mut self) {
+    pub fn stop(&self) {
         unsafe {
             ffi::StopSound(self.0);
         }
@@ -321,7 +321,7 @@ impl<'aud> Sound<'aud> {
 
     /// Sets volume for a sound (`1.0` is max level).
     #[inline]
-    pub fn set_volume(&mut self, volume: f32) {
+    pub fn set_volume(&self, volume: f32) {
         unsafe {
             ffi::SetSoundVolume(self.0, volume);
         }
@@ -329,12 +329,12 @@ impl<'aud> Sound<'aud> {
 
     /// Sets pitch for a sound (`1.0` is base level).
     #[inline]
-    pub fn set_pitch(&mut self, pitch: f32) {
+    pub fn set_pitch(&self, pitch: f32) {
         unsafe {
             ffi::SetSoundPitch(self.0, pitch);
         }
     }
-    pub fn set_pan(&mut self, pan: f32) {
+    pub fn set_pan(&self, pan: f32) {
         unsafe {
             ffi::SetSoundPan(self.0, pan);
         }
@@ -378,7 +378,7 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
 
     /// Pauses a sound.
     #[inline]
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         unsafe {
             ffi::PauseSound(self.0);
         }
@@ -386,7 +386,7 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
 
     /// Resumes a paused sound.
     #[inline]
-    pub fn resume(&mut self) {
+    pub fn resume(&self) {
         unsafe {
             ffi::ResumeSound(self.0);
         }
@@ -394,7 +394,7 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
 
     /// Stops playing a sound.
     #[inline]
-    pub fn stop(&mut self) {
+    pub fn stop(&self) {
         unsafe {
             ffi::StopSound(self.0);
         }
@@ -408,7 +408,7 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
 
     /// Sets volume for a sound (`1.0` is max level).
     #[inline]
-    pub fn set_volume(&mut self, volume: f32) {
+    pub fn set_volume(&self, volume: f32) {
         unsafe {
             ffi::SetSoundVolume(self.0, volume);
         }
@@ -416,12 +416,12 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
 
     /// Sets pitch for a sound (`1.0` is base level).
     #[inline]
-    pub fn set_pitch(&mut self, pitch: f32) {
+    pub fn set_pitch(&self, pitch: f32) {
         unsafe {
             ffi::SetSoundPitch(self.0, pitch);
         }
     }
-    pub fn set_pan(&mut self, pan: f32) {
+    pub fn set_pan(&self, pan: f32) {
         unsafe {
             ffi::SetSoundPan(self.0, pan);
         }
@@ -431,7 +431,7 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
 impl<'aud> Music<'aud> {
     /// Starts music playing.
     #[inline]
-    pub fn play_stream(&mut self) {
+    pub fn play_stream(&self) {
         unsafe {
             ffi::PlayMusicStream(self.0);
         }
@@ -439,7 +439,7 @@ impl<'aud> Music<'aud> {
 
     /// Updates buffers for music streaming.
     #[inline]
-    pub fn update_stream(&mut self) {
+    pub fn update_stream(&self) {
         unsafe {
             ffi::UpdateMusicStream(self.0);
         }
@@ -447,7 +447,7 @@ impl<'aud> Music<'aud> {
 
     /// Stops music playing.
     #[inline]
-    pub fn stop_stream(&mut self) {
+    pub fn stop_stream(&self) {
         unsafe {
             ffi::StopMusicStream(self.0);
         }
@@ -455,7 +455,7 @@ impl<'aud> Music<'aud> {
 
     /// Pauses music playing.
     #[inline]
-    pub fn pause_stream(&mut self) {
+    pub fn pause_stream(&self) {
         unsafe {
             ffi::PauseMusicStream(self.0);
         }
@@ -463,7 +463,7 @@ impl<'aud> Music<'aud> {
 
     /// Resumes playing paused music.
     #[inline]
-    pub fn resume_stream(&mut self) {
+    pub fn resume_stream(&self) {
         unsafe {
             ffi::ResumeMusicStream(self.0);
         }
@@ -477,7 +477,7 @@ impl<'aud> Music<'aud> {
 
     /// Sets volume for music (`1.0` is max level).
     #[inline]
-    pub fn set_volume(&mut self, volume: f32) {
+    pub fn set_volume(&self, volume: f32) {
         unsafe {
             ffi::SetMusicVolume(self.0, volume);
         }
@@ -485,7 +485,7 @@ impl<'aud> Music<'aud> {
 
     /// Sets pitch for music (`1.0` is base level).
     #[inline]
-    pub fn set_pitch(&mut self, pitch: f32) {
+    pub fn set_pitch(&self, pitch: f32) {
         unsafe {
             ffi::SetMusicPitch(self.0, pitch);
         }
@@ -503,13 +503,13 @@ impl<'aud> Music<'aud> {
         unsafe { ffi::GetMusicTimePlayed(self.0) }
     }
 
-    pub fn seek_stream(&mut self, position: f32) {
+    pub fn seek_stream(&self, position: f32) {
         unsafe {
             ffi::SeekMusicStream(self.0, position);
         }
     }
 
-    pub fn set_pan(&mut self, pan: f32) {
+    pub fn set_pan(&self, pan: f32) {
         unsafe {
             ffi::SetMusicPan(self.0, pan);
         }
@@ -550,7 +550,7 @@ impl<'aud> AudioStream<'aud> {
 
     /// Plays audio stream.
     #[inline]
-    pub fn play(&mut self) {
+    pub fn play(&self) {
         unsafe {
             ffi::PlayAudioStream(self.0);
         }
@@ -558,7 +558,7 @@ impl<'aud> AudioStream<'aud> {
 
     /// Pauses audio stream.
     #[inline]
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         unsafe {
             ffi::PauseAudioStream(self.0);
         }
@@ -566,7 +566,7 @@ impl<'aud> AudioStream<'aud> {
 
     /// Resumes audio stream.
     #[inline]
-    pub fn resume(&mut self) {
+    pub fn resume(&self) {
         unsafe {
             ffi::ResumeAudioStream(self.0);
         }
@@ -580,7 +580,7 @@ impl<'aud> AudioStream<'aud> {
 
     /// Stops audio stream.
     #[inline]
-    pub fn stop(&mut self) {
+    pub fn stop(&self) {
         unsafe {
             ffi::StopAudioStream(self.0);
         }
@@ -588,7 +588,7 @@ impl<'aud> AudioStream<'aud> {
 
     /// Sets volume for audio stream (`1.0` is max level).
     #[inline]
-    pub fn set_volume(&mut self, volume: f32) {
+    pub fn set_volume(&self, volume: f32) {
         unsafe {
             ffi::SetAudioStreamVolume(self.0, volume);
         }
@@ -596,7 +596,7 @@ impl<'aud> AudioStream<'aud> {
 
     /// Sets pitch for audio stream (`1.0` is base level).
     #[inline]
-    pub fn set_pitch(&mut self, pitch: f32) {
+    pub fn set_pitch(&self, pitch: f32) {
         unsafe {
             ffi::SetAudioStreamPitch(self.0, pitch);
         }
@@ -604,11 +604,11 @@ impl<'aud> AudioStream<'aud> {
 
     /// Sets pitch for audio stream (`1.0` is base level).
     #[inline]
-    pub fn is_processed(&mut self) -> bool {
+    pub fn is_processed(&self) -> bool {
         unsafe { ffi::IsAudioStreamProcessed(self.0) }
     }
 
-    pub fn set_pan(&mut self, pan: f32) {
+    pub fn set_pan(&self, pan: f32) {
         unsafe {
             ffi::SetAudioStreamPan(self.0, pan);
         }

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -106,20 +106,12 @@ impl RaylibHandle {
             *camera = fficam.into();
         }
     }
-
-    pub fn update_camera_pro(
-        &self,
-        camera: &mut Camera3D,
-        movement: Vector3,
-        rotation: Vector3,
-        zoom: f32,
-    ) {
-        let mut fficam: ffi::Camera3D = (*camera).into();
-        let ffimov: ffi::Vector3 = (movement).into();
-        let ffirot: ffi::Vector3 = (rotation).into();
-
+    
+    pub fn update_camera_pro(&self, camera: &mut Camera3D, movement: Vector3, rotation: Vector3, zoom: f32) {
         unsafe {
-            ffi::UpdateCameraPro(&mut fficam, ffimov, ffirot, zoom);
+            let mut fficam: ffi::Camera3D = (*camera).into();
+            ffi::UpdateCameraPro(&mut fficam, movement.into(), rotation.into(), zoom);
+            *camera = fficam.into();
         }
     }
 }


### PR DESCRIPTION
&mut self is not required, because behind, raylib uses mutexes and miniaudio atomics.

fixes https://github.com/raylib-rs/raylib-rs/issues/65

https://github.com/raysan5/raylib/blob/master/src/raudio.c
https://github.com/mackron/miniaudio/blob/master/miniaudio.h

```c
// raudio.c
void SetAudioBufferVolume(AudioBuffer *buffer, float volume)
{
    if (buffer != NULL)
    {
        ma_mutex_lock(&AUDIO.System.lock); // <-- mutex lock
        buffer->volume = volume;
        ma_mutex_unlock(&AUDIO.System.lock);
    }
}
void SetMasterVolume(float volume)
{
    ma_device_set_master_volume(&AUDIO.System.device, volume);
}
// miniaudio.h
MA_API ma_result ma_device_set_master_volume(ma_device* pDevice, float volume)
{
    if (pDevice == NULL) {
        return MA_INVALID_ARGS;
    }
    if (volume < 0.0f) {
        return MA_INVALID_ARGS;
    }
    ma_atomic_float_set(&pDevice->masterVolumeFactor, volume); // <-- atomic operation used here
    return MA_SUCCESS;
}
```

Relaxing &mut makes it easier to work with these types, as after you create Sound, you no longer can borrow &mut on RaylibAudio, because Rust treats bounded lifetime as borrow. Similarly with Sound and SoundAlias.

This is safe to relax, as this is thread safe interior mutability pattern.