### PR TITLE
feat(error)!: add designated error type

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
 specs-derive = "0.4.1"
+thiserror = "1.0.61"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -1,5 +1,6 @@
 //! Contains code related to audio. [`RaylibAudio`] plays sounds and music.
 
+use crate::error::{error, Error};
 use crate::ffi;
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -80,31 +81,31 @@ impl RaylibAudio {
     }
 
     /// Loads a new sound from file.
-    pub fn new_sound<'aud>(&'aud self, filename: &str) -> Result<Sound<'aud>, String> {
+    pub fn new_sound<'aud>(&'aud self, filename: &str) -> Result<Sound<'aud>, Error> {
         let c_filename = CString::new(filename).unwrap();
         let s = unsafe { ffi::LoadSound(c_filename.as_ptr()) };
         if s.stream.buffer.is_null() {
-            return Err(format!("failed to load sound {}", filename));
+            return Err(error!("failed to load sound", filename));
         }
 
         Ok(Sound(s, self))
     }
 
     /// Loads sound from wave data.
-    pub fn new_sound_from_wave<'aud>(&'aud self, wave: &Wave) -> Result<Sound<'aud>, String> {
+    pub fn new_sound_from_wave<'aud>(&'aud self, wave: &Wave) -> Result<Sound<'aud>, Error> {
         let s = unsafe { ffi::LoadSoundFromWave(wave.0) };
         if s.stream.buffer.is_null() {
-            return Err(format!("failed to load sound from wave"));
+            return Err(error!("failed to load sound from wave"));
         }
         Ok(Sound(s, self))
     }
     /// Loads wave data from file into RAM.
     #[inline]
-    pub fn new_wave<'aud>(&'aud self, filename: &str) -> Result<Wave<'aud>, String> {
+    pub fn new_wave<'aud>(&'aud self, filename: &str) -> Result<Wave<'aud>, Error> {
         let c_filename = CString::new(filename).unwrap();
         let w = unsafe { ffi::LoadWave(c_filename.as_ptr()) };
         if w.data.is_null() {
-            return Err(format!("Cannot load wave {}", filename));
+            return Err(error!("Cannot load wave {}", filename));
         }
         Ok(Wave(w, self))
     }
@@ -114,24 +115,24 @@ impl RaylibAudio {
         &'aud self,
         filetype: &str,
         bytes: &[u8],
-    ) -> Result<Wave<'aud>, String> {
+    ) -> Result<Wave<'aud>, Error> {
         let c_filetype = CString::new(filetype).unwrap();
         let c_bytes = bytes.as_ptr();
         let w =
             unsafe { ffi::LoadWaveFromMemory(c_filetype.as_ptr(), c_bytes, bytes.len() as i32) };
         if w.data.is_null() {
-            return Err(format!("Wave data is null. Check provided buffer data"));
+            return Err(error!("Wave data is null. Check provided buffer data"));
         };
         Ok(Wave(w, self))
     }
 
     /// Loads music stream from file.
     // #[inline]
-    pub fn new_music<'aud>(&'aud self, filename: &str) -> Result<Music<'aud>, String> {
+    pub fn new_music<'aud>(&'aud self, filename: &str) -> Result<Music<'aud>, Error> {
         let c_filename = CString::new(filename).unwrap();
         let m = unsafe { ffi::LoadMusicStream(c_filename.as_ptr()) };
         if m.stream.buffer.is_null() {
-            return Err(format!("music could not be loaded from file {}", filename));
+            return Err(error!("music could not be loaded from file", filename));
         }
         Ok(Music(m, self))
     }
@@ -141,14 +142,14 @@ impl RaylibAudio {
         &'aud self,
         filetype: &str,
         bytes: &Vec<u8>,
-    ) -> Result<Music<'aud>, String> {
+    ) -> Result<Music<'aud>, Error> {
         let c_filetype = CString::new(filetype).unwrap();
         let c_bytes = bytes.as_ptr();
         let w = unsafe {
             ffi::LoadMusicStreamFromMemory(c_filetype.as_ptr(), c_bytes, bytes.len() as i32)
         };
         if w.stream.buffer.is_null() {
-            return Err(format!(
+            return Err(error!(
                 "Music's buffer data data is null. Check provided buffer data"
             ));
         };
@@ -622,10 +623,10 @@ impl<'aud> AudioStream<'aud> {
 }
 
 impl<'bind> Sound<'_> {
-    pub fn alias<'snd>(&'snd self) -> Result<SoundAlias<'bind, 'snd>, String> {
+    pub fn alias<'snd>(&'snd self) -> Result<SoundAlias<'bind, 'snd>, Error> {
         let s = unsafe { ffi::LoadSoundAlias(self.0) };
         if s.stream.buffer.is_null() {
-            return Err("failed to load sound from wave".to_string());
+            return Err(error!("failed to load sound from wave"));
         }
         Ok(SoundAlias(s, PhantomData))
     }

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -1,7 +1,10 @@
 //! Data manipulation functions. Compress and Decompress with DEFLATE
 use std::{ffi::CString, path::Path};
 
-use crate::ffi;
+use crate::{
+    error::{error, Error},
+    ffi,
+};
 
 /// Compress data (DEFLATE algorythm)
 /// ```rust
@@ -10,14 +13,14 @@ use crate::ffi;
 /// let expected: &[u8] = &[1, 5, 0, 250, 255, 49, 49, 49, 49, 49];
 /// assert_eq!(data, Ok(expected));
 /// ```
-pub fn compress_data(data: &[u8]) -> Result<&'static [u8], String> {
+pub fn compress_data(data: &[u8]) -> Result<&'static [u8], Error> {
     let mut out_length: i32 = 0;
     // CompressData doesn't actually modify the data, but the header is wrong
     let buffer = {
         unsafe { ffi::CompressData(data.as_ptr() as *mut _, data.len() as i32, &mut out_length) }
     };
     if buffer.is_null() {
-        return Err("could not compress data".to_string());
+        return Err(error!("could not compress data"));
     }
     let buffer = unsafe { std::slice::from_raw_parts(buffer, out_length as usize) };
     return Ok(buffer);
@@ -31,7 +34,7 @@ pub fn compress_data(data: &[u8]) -> Result<&'static [u8], String> {
 /// let data = decompress_data(input);
 /// assert_eq!(data, Ok(expected));
 /// ```
-pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], String> {
+pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], Error> {
     println!("{:?}", data.len());
 
     let mut out_length: i32 = 0;
@@ -40,7 +43,7 @@ pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], String> {
         unsafe { ffi::DecompressData(data.as_ptr() as *mut _, data.len() as i32, &mut out_length) }
     };
     if buffer.is_null() {
-        return Err("could not compress data".to_string());
+        return Err(error!("could not compress data"));
     }
     let buffer = unsafe { std::slice::from_raw_parts(buffer, out_length as usize) };
     return Ok(buffer);

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -1,0 +1,41 @@
+//! Definitions for error types used throught the crate
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(
+    "{message}{path}",
+    path = path.as_ref().map(|p| format!("\npath: {}", p.display())).unwrap_or("".to_owned()),
+)]
+pub struct Error {
+    // NOTE(alexmozaidze): There is not a single instance of the message being dynamic in this crate,
+    // so if there occurs an instance where the message is to be determined at runtime, then
+    // use `Cow<'static, str>`.
+    //
+    // One could also use generics, but that would make the error type much more complex to use
+    // and to reason about for the user.
+    pub(crate) message: &'static str,
+    pub(crate) path: Option<PathBuf>,
+}
+
+impl Error {
+    pub(crate) const fn new(message: &'static str, path: Option<PathBuf>) -> Self {
+        Self { message, path }
+    }
+}
+
+macro_rules! error {
+    ($message:expr $(,)?) => {{
+        $crate::core::error::Error::new($message, ::core::option::Option::None)
+    }};
+    ($message:expr, $path:expr $(,)?) => {{
+        $crate::core::error::Error::new(
+            $message,
+            ::core::option::Option::Some(::std::path::PathBuf::from($path)),
+        )
+    }};
+}
+
+pub(crate) use error;

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -9,6 +9,7 @@ pub mod collision;
 pub mod color;
 pub mod data;
 pub mod drawing;
+pub mod error;
 pub mod file;
 pub mod input;
 pub mod logging;

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -2,6 +2,7 @@
 use crate::core::math::{BoundingBox, Vector3};
 use crate::core::texture::Image;
 use crate::core::{RaylibHandle, RaylibThread};
+use crate::error::{error, Error};
 use crate::{consts, ffi};
 use std::ffi::CString;
 use std::os::raw::c_void;
@@ -53,12 +54,12 @@ impl Clone for WeakModelAnimation {
 impl RaylibHandle {
     /// Loads model from files (mesh and material).
     // #[inline]
-    pub fn load_model(&mut self, _: &RaylibThread, filename: &str) -> Result<Model, String> {
+    pub fn load_model(&mut self, _: &RaylibThread, filename: &str) -> Result<Model, Error> {
         let c_filename = CString::new(filename).unwrap();
         let m = unsafe { ffi::LoadModel(c_filename.as_ptr()) };
         if m.meshes.is_null() && m.materials.is_null() && m.bones.is_null() && m.bindPose.is_null()
         {
-            return Err(format!("could not load model {}", filename));
+            return Err(error!("could not load model", filename));
         }
         // TODO check if null pointer checks are necessary.
         Ok(Model(m))
@@ -69,11 +70,11 @@ impl RaylibHandle {
         &mut self,
         _: &RaylibThread,
         mesh: WeakMesh,
-    ) -> Result<Model, String> {
+    ) -> Result<Model, Error> {
         let m = unsafe { ffi::LoadModelFromMesh(mesh.0) };
 
         if m.meshes.is_null() || m.materials.is_null() {
-            return Err("Could not load model from mesh".to_owned());
+            return Err(error!("Could not load model from mesh"));
         }
 
         Ok(Model(m))
@@ -83,12 +84,12 @@ impl RaylibHandle {
         &mut self,
         _: &RaylibThread,
         filename: &str,
-    ) -> Result<Vec<ModelAnimation>, String> {
+    ) -> Result<Vec<ModelAnimation>, Error> {
         let c_filename = CString::new(filename).unwrap();
         let mut m_size = 0;
         let m_ptr = unsafe { ffi::LoadModelAnimations(c_filename.as_ptr(), &mut m_size) };
         if m_size <= 0 {
-            return Err(format!("No model animations loaded from {}", filename));
+            return Err(error!("No model animations loaded", filename));
         }
         let mut m_vec = Vec::with_capacity(m_size as usize);
         for i in 0..m_size {
@@ -417,12 +418,12 @@ impl Material {
         m
     }
 
-    pub fn load_materials(filename: &str) -> Result<Vec<Material>, String> {
+    pub fn load_materials(filename: &str) -> Result<Vec<Material>, Error> {
         let c_filename = CString::new(filename).unwrap();
         let mut m_size = 0;
         let m_ptr = unsafe { ffi::LoadMaterials(c_filename.as_ptr(), &mut m_size) };
         if m_size <= 0 {
-            return Err(format!("No materials loaded from {}", filename));
+            return Err(error!("No materials loaded", filename));
         }
         let mut m_vec = Vec::with_capacity(m_size as usize);
         for i in 0..m_size {

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -1,4 +1,6 @@
 //! Code for the safe manipulation of shaders
+use thiserror::Error;
+
 use crate::consts::ShaderUniformDataType;
 use crate::core::math::Matrix;
 use crate::core::math::{Vector2, Vector3, Vector4};
@@ -23,7 +25,7 @@ impl RaylibHandle {
         _: &RaylibThread,
         vs_filename: Option<&str>,
         fs_filename: Option<&str>,
-    ) -> Result<Shader, String> {
+    ) -> Shader {
         let c_vs_filename = vs_filename.map(|f| CString::new(f).unwrap());
         let c_fs_filename = fs_filename.map(|f| CString::new(f).unwrap());
 
@@ -36,7 +38,7 @@ impl RaylibHandle {
             (None, None) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), std::ptr::null())) },
         };
 
-        return Ok(shader);
+        return shader;
     }
 
     /// Loads shader from code strings and binds default locations.
@@ -188,9 +190,7 @@ impl Shader {
     #[inline]
     pub fn is_ready(&self) {
         unsafe {
-            ffi::IsShaderReady(
-                self.0,
-                );
+            ffi::IsShaderReady(self.0);
         }
     }
 

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -5,6 +5,7 @@ use raylib_sys::LoadUTF8;
 use crate::core::math::Vector2;
 use crate::core::texture::{Image, Texture2D};
 use crate::core::{RaylibHandle, RaylibThread};
+use crate::error::{error, Error};
 use crate::ffi;
 use crate::math::Rectangle;
 
@@ -118,13 +119,13 @@ impl RaylibHandle {
 
     /// Loads font from file into GPU memory (VRAM).
     #[inline]
-    pub fn load_font(&mut self, _: &RaylibThread, filename: &str) -> Result<Font, String> {
+    pub fn load_font(&mut self, _: &RaylibThread, filename: &str) -> Result<Font, Error> {
         let c_filename = CString::new(filename).unwrap();
         let f = unsafe { ffi::LoadFont(c_filename.as_ptr()) };
         if f.glyphs.is_null() || f.texture.id == 0 {
-            return Err(format!(
-                "Error loading font {}. Does it exist? Is it the right type?",
-                filename
+            return Err(error!(
+                "Error loading font. Check if the file exists and if it's the right type",
+                filename,
             ));
         }
         Ok(Font(f))
@@ -139,7 +140,7 @@ impl RaylibHandle {
         filename: &str,
         font_size: i32,
         chars: Option<&str>,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, Error> {
         let c_filename = CString::new(filename).unwrap();
         let f = unsafe {
             match chars {
@@ -156,9 +157,9 @@ impl RaylibHandle {
             }
         };
         if f.glyphs.is_null() || f.texture.id == 0 {
-            return Err(format!(
-                "Error loading font {}. Does it exist? Is it the right type?",
-                filename
+            return Err(error!(
+                "Error loading font. Check if the file exists and if it's the right type",
+                filename,
             ));
         }
         Ok(Font(f))
@@ -172,10 +173,10 @@ impl RaylibHandle {
         image: &Image,
         key: impl Into<ffi::Color>,
         first_char: i32,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, Error> {
         let f = unsafe { ffi::LoadFontFromImage(image.0, key.into(), first_char) };
         if f.glyphs.is_null() {
-            return Err(format!("Error loading font from image."));
+            return Err(error!("Error loading font from image."));
         }
         Ok(Font(f))
     }
@@ -190,7 +191,7 @@ impl RaylibHandle {
         file_data: &[u8],
         font_size: i32,
         chars: Option<&str>,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, Error> {
         let c_file_type = CString::new(file_type).unwrap();
         let f = unsafe {
             match chars {
@@ -216,8 +217,8 @@ impl RaylibHandle {
             }
         };
         if f.glyphs.is_null() || f.texture.id == 0 {
-            return Err(format!(
-                "Error loading font from memory. Is it the right type?"
+            return Err(error!(
+                "Error loading font from memory. Check if the file's type is correct"
             ));
         }
         Ok(Font(f))
@@ -340,7 +341,7 @@ impl Font {
         base_size: i32,
         padding: i32,
         pack_method: i32,
-    ) -> Result<Font, String> {
+    ) -> Result<Font, Error> {
         let f = unsafe {
             let mut f = std::mem::zeroed::<Font>();
             f.baseSize = base_size;
@@ -359,7 +360,7 @@ impl Font {
             f
         };
         if f.0.glyphs.is_null() || f.0.texture.id == 0 {
-            return Err(format!("Error loading font from image."));
+            return Err(error!("Error loading font from image."));
         }
         Ok(f)
     }

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -3,6 +3,7 @@
 use crate::core::color::Color;
 use crate::core::math::Rectangle;
 use crate::core::{RaylibHandle, RaylibThread};
+use crate::error::{error, Error};
 use crate::ffi;
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -724,13 +725,13 @@ impl Image {
     }
 
     /// Loads image from file into CPU memory (RAM).
-    pub fn load_image(filename: &str) -> Result<Image, String> {
+    pub fn load_image(filename: &str) -> Result<Image, Error> {
         let c_filename = CString::new(filename).unwrap();
         let i = unsafe { ffi::LoadImage(c_filename.as_ptr()) };
         if i.data.is_null() {
-            return Err(format!(
-            "Image data is null. Either the file doesnt exist or the image type is unsupported."
-        ));
+            return Err(error!(
+                "Image data is null. Either the file doesnt exist or the image type is unsupported."
+            ));
         }
         Ok(Image(i))
     }
@@ -738,7 +739,7 @@ impl Image {
     /// Loads image from a given memory buffer
     /// The input data is expected to be in a supported file format such as png. Which formats are
     /// supported depend on the build flags used for the raylib (C) library.
-    pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, String> {
+    pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, Error> {
         let c_filetype = CString::new(filetype).unwrap();
         let i = unsafe {
             ffi::LoadImageFromMemory(
@@ -748,7 +749,7 @@ impl Image {
             )
         };
         if i.data.is_null() {
-            return Err(format!("Image data is null. Check provided buffer data"));
+            return Err(error!("Image data is null. Check provided buffer data"));
         };
         Ok(Image(i))
     }
@@ -760,14 +761,14 @@ impl Image {
         height: i32,
         format: i32,
         header_size: i32,
-    ) -> Result<Image, String> {
+    ) -> Result<Image, Error> {
         let c_filename = CString::new(filename).unwrap();
         let i =
             unsafe { ffi::LoadImageRaw(c_filename.as_ptr(), width, height, format, header_size) };
         if i.data.is_null() {
-            return Err(format!(
-            "Image data is null. Either the file doesnt exist or the image type is unsupported."
-        ));
+            return Err(error!(
+                "Image data is null. Either the file doesnt exist or the image type is unsupported."
+            ));
         }
         Ok(Image(i))
     }
@@ -863,10 +864,10 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
     /// Gets pixel data from GPU texture and returns an `Image`.
     /// Fairly sure this would never fail. If it does wrap in result.
     #[inline]
-    fn load_image(&self) -> Result<Image, String> {
+    fn load_image(&self) -> Result<Image, Error> {
         let i = unsafe { ffi::LoadImageFromTexture(*self.as_ref()) };
         if i.data.is_null() {
-            return Err(format!("Texture cannot be rendered to an image"));
+            return Err(error!("Texture cannot be rendered to an image"));
         }
         Ok(Image(i))
     }
@@ -908,11 +909,11 @@ pub fn get_pixel_data_size(width: i32, height: i32, format: ffi::PixelFormat) ->
 
 impl RaylibHandle {
     /// Loads texture from file into GPU memory (VRAM).
-    pub fn load_texture(&mut self, _: &RaylibThread, filename: &str) -> Result<Texture2D, String> {
+    pub fn load_texture(&mut self, _: &RaylibThread, filename: &str) -> Result<Texture2D, Error> {
         let c_filename = CString::new(filename).unwrap();
         let t = unsafe { ffi::LoadTexture(c_filename.as_ptr()) };
         if t.id == 0 {
-            return Err(format!("failed to load {} as a texture.", filename));
+            return Err(error!("failed to load the texture.", filename));
         }
         Ok(Texture2D(t))
     }
@@ -923,10 +924,10 @@ impl RaylibHandle {
         _: &RaylibThread,
         image: &Image,
         layout: crate::consts::CubemapLayout,
-    ) -> Result<Texture2D, String> {
+    ) -> Result<Texture2D, Error> {
         let t = unsafe { ffi::LoadTextureCubemap(image.0, layout as i32) };
         if t.id == 0 {
-            return Err(format!("failed to load image as a texture cubemap."));
+            return Err(error!("failed to load image as a texture cubemap."));
         }
         Ok(Texture2D(t))
     }
@@ -937,10 +938,10 @@ impl RaylibHandle {
         &mut self,
         _: &RaylibThread,
         image: &Image,
-    ) -> Result<Texture2D, String> {
+    ) -> Result<Texture2D, Error> {
         let t = unsafe { ffi::LoadTextureFromImage(image.0) };
         if t.id == 0 {
-            return Err(format!("failed to load image as a texture."));
+            return Err(error!("failed to load image as a texture."));
         }
         Ok(Texture2D(t))
     }
@@ -951,10 +952,10 @@ impl RaylibHandle {
         _: &RaylibThread,
         width: u32,
         height: u32,
-    ) -> Result<RenderTexture2D, String> {
+    ) -> Result<RenderTexture2D, Error> {
         let t = unsafe { ffi::LoadRenderTexture(width as i32, height as i32) };
         if t.id == 0 {
-            return Err(format!("failed to create render texture."));
+            return Err(error!("failed to create render texture."));
         }
         Ok(RenderTexture2D(t))
     }


### PR DESCRIPTION
Added an error type that implement the `Error` trait, along with replacing every instance of `Result<_, String>` with `Result<_, Error>`. Also, added `error!` macro to easily construct the error type.

This is a little different than #64 in that the current PR unifies both of the error types into one. That is made to prevent confusion and to ease combining errors using `thiserror` crate. There is no allocation if the `path` field is `None`, so there are no unnecessary allocations.