### PR TITLE
fix matrix rotation on axis

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1456,8 +1456,8 @@ impl Matrix {
         let sinres = angle.sin();
 
         result.m5 = cosres;
-        result.m6 = -sinres;
-        result.m9 = sinres;
+        result.m6 = sinres;
+        result.m9 = -sinres;
         result.m10 = cosres;
         result
     }
@@ -1470,8 +1470,8 @@ impl Matrix {
         let sinres = angle.sin();
 
         result.m0 = cosres;
-        result.m2 = sinres;
-        result.m8 = -sinres;
+        result.m2 = -sinres;
+        result.m8 = sinres;
         result.m10 = cosres;
         result
     }
@@ -1484,8 +1484,8 @@ impl Matrix {
         let sinres = angle.sin();
 
         result.m0 = cosres;
-        result.m1 = -sinres;
-        result.m4 = sinres;
+        result.m1 = sinres;
+        result.m4 = -sinres;
         result.m5 = cosres;
         result
     }


### PR DESCRIPTION
I'm not actually using the library directly, but pulled `math.rs` to use in my own 3D repo. I noticed that these did not work properly. Upon further inspection, they differed from the [original raylib source](https://github.com/raysan5/raylib/blob/master/src/raymath.h#L1700-L1758).

After updating these, matrix rotation worked fine for me.