### PR TITLE
remove unused dependencies

### DIFF
--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2018"
 exclude = ["raylib/examples/*", "raylib/projects/*", "raylib/templates/*"]
 
 [build-dependencies]
-fs_extra = "1.2"
-cmake = "0.1.49"
+cmake = "0.1.51"
 cc = "1.0"
 bindgen = "0.70"
 

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["raylib/examples/*", "raylib/projects/*", "raylib/templates/*"]
 fs_extra = "1.2"
 cmake = "0.1.49"
 cc = "1.0"
-bindgen = "0.69.0"
+bindgen = "0.70"
 
 [features]
 default = []

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -14,7 +14,6 @@ autoexamples = false
 
 [dependencies]
 raylib-sys = { version = "5.5.0", path = "../raylib-sys" }
-libc = "0.2.45"
 lazy_static = "1.2.0"
 cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -20,16 +20,13 @@ serde_json = { version = "1.0.64", optional = true }
 
 mint = { version = "0.5.9", optional = true }
 
-specs-derive = { version = "0.4.1", optional = true}
+specs = { version = "0.16.1", default = false, optional = true }
+specs-derive = { version = "0.4.1", optional = true }
 thiserror = "1.0.61"
 
 [dev-dependencies]
 structopt = "0.3"
 rand = "0.8.5"
-
-[dependencies.specs]
-version = "0.16.1"
-default-features = false
 
 [features]
 nightly = []

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -14,21 +14,18 @@ autoexamples = false
 
 [dependencies]
 raylib-sys = { version = "5.5.0", path = "../raylib-sys" }
-lazy_static = "1.2.0"
 cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 
 mint = { version = "0.5.9", optional = true }
-parking_lot = "0.12.1"
 
-specs-derive = "0.4.1"
+specs-derive = { version = "0.4.1", optional = true}
 thiserror = "1.0.61"
 
 [dev-dependencies]
 structopt = "0.3"
 rand = "0.8.5"
-arr_macro = "0.1.3"
 
 [dependencies.specs]
 version = "0.16.1"

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -32,37 +32,37 @@ static LOAD_FILE_TEXT_CALLBACK: AtomicUsize = AtomicUsize::new(0);
 static AUDIO_STREAM_CALLBACK: AtomicUsize = AtomicUsize::new(0);
 
 fn trace_log_callback() -> Option<RustTraceLogCallback> {
-    const { assert!(size_of::<RustTraceLogCallback>() == size_of::<usize>()) };
+    debug_assert!(size_of::<RustTraceLogCallback>() == size_of::<usize>());
     unsafe { transmute(TRACE_LOG_CALLBACK.load(Ordering::Relaxed)) }
 }
 
 fn save_file_data_callback() -> Option<RustSaveFileDataCallback> {
-    const { assert!(size_of::<RustSaveFileDataCallback>() == size_of::<usize>()) };
+    debug_assert!(size_of::<RustSaveFileDataCallback>() == size_of::<usize>());
     unsafe { transmute(SAVE_FILE_DATA_CALLBACK.load(Ordering::Relaxed)) }
 }
 
 fn load_file_data_callback() -> Option<RustLoadFileDataCallback> {
-    const { assert!(size_of::<RustLoadFileDataCallback>() == size_of::<usize>()) };
+    debug_assert!(size_of::<RustLoadFileDataCallback>() == size_of::<usize>());
     unsafe { transmute(LOAD_FILE_DATA_CALLBACK.load(Ordering::Relaxed)) }
 }
 
 fn save_file_text_callback() -> Option<RustSaveFileTextCallback> {
-    const { assert!(size_of::<RustSaveFileTextCallback>() == size_of::<usize>()) };
+    debug_assert!(size_of::<RustSaveFileTextCallback>() == size_of::<usize>());
     unsafe { transmute(SAVE_FILE_TEXT_CALLBACK.load(Ordering::Relaxed)) }
 }
 
 fn load_file_text_callback() -> Option<RustLoadFileTextCallback> {
-    const { assert!(size_of::<RustLoadFileTextCallback>() == size_of::<usize>()) };
+    debug_assert!(size_of::<RustLoadFileTextCallback>() == size_of::<usize>());
     unsafe { transmute(LOAD_FILE_TEXT_CALLBACK.load(Ordering::Relaxed)) }
 }
 
 fn audio_stream_callback() -> Option<RustAudioStreamCallback> {
-    const { assert!(size_of::<RustAudioStreamCallback>() == size_of::<usize>()) };
+    debug_assert!(size_of::<RustAudioStreamCallback>() == size_of::<usize>());
     unsafe { transmute(AUDIO_STREAM_CALLBACK.load(Ordering::Relaxed)) }
 }
 
 #[no_mangle]
-pub extern "C" fn custom_trace_log_callback(level: TraceLogLevel, text: *const c_char) {
+pub unsafe extern "C" fn custom_trace_log_callback(level: TraceLogLevel, text: *const c_char) {
     if let Some(trace_log) = trace_log_callback() {
         let text = if text.is_null() {
             Cow::Borrowed("(MESSAGE WAS NULL)")

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -100,7 +100,7 @@ impl RaylibHandle {
             }
         }
         unsafe {
-            ffi::MemFree(m_ptr as *mut libc::c_void);
+            ffi::MemFree(m_ptr as *mut ::std::os::raw::c_void);
         }
         Ok(m_vec)
     }
@@ -470,7 +470,7 @@ impl Material {
             }
         }
         unsafe {
-            ffi::MemFree(m_ptr as *mut libc::c_void);
+            ffi::MemFree(m_ptr as *mut ::std::os::raw::c_void);
         }
         Ok(m_vec)
     }

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -9,7 +9,7 @@ use crate::error::{error, Error};
 use crate::ffi;
 use crate::math::Rectangle;
 
-use std::convert::{AsMut, AsRef};
+use std::convert::{AsMut, AsRef, TryInto};
 use std::ffi::{CString, OsString};
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
@@ -371,7 +371,7 @@ impl Font {
         unsafe {
             self.glyphCount = chars.len() as i32;
             let data_size = self.glyphCount as usize * std::mem::size_of::<ffi::GlyphInfo>();
-            let ci_arr_ptr = libc::malloc(data_size); // raylib frees this data in UnloadFont
+            let ci_arr_ptr = ffi::MemAlloc(data_size.try_into().unwrap()); // raylib frees this data in UnloadFont
             std::ptr::copy(
                 chars.as_ptr(),
                 ci_arr_ptr as *mut ffi::GlyphInfo,
@@ -415,7 +415,7 @@ pub fn gen_image_font_atlas(
         #[allow(clippy::uninit_vec)]
         recs.set_len(chars.len());
         std::ptr::copy(ptr, recs.as_mut_ptr(), chars.len());
-        ffi::MemFree(ptr as *mut libc::c_void);
+        ffi::MemFree(ptr as *mut ::std::os::raw::c_void);
         return (img, recs);
     }
 }

--- a/samples/3d_camera_first_person.rs
+++ b/samples/3d_camera_first_person.rs
@@ -1,10 +1,10 @@
-use arr_macro::arr;
 use rand::prelude::*;
 use raylib::prelude::*;
 
 const WINDOW_WIDTH: i32 = 1280;
 const WINDOW_HEIGHT: i32 = 720;
 
+#[derive(Copy, Clone, Default)]
 struct Column {
     height: f32,
     position: Vector3,
@@ -14,13 +14,13 @@ struct Column {
 impl Column {
     fn create_random() -> Column {
         let mut rng = rand::thread_rng();
-        let height: f32 = rng.gen_range(1.0, 12.0);
+        let height: f32 = rng.gen_range(1.0..12.0);
         let position = Vector3::new(
-            rng.gen_range(-15.0, 15.0),
+            rng.gen_range(-15.0..15.0),
             height / 2.0,
-            rng.gen_range(-15.0, 15.0),
+            rng.gen_range(-15.0..15.0),
         );
-        let color = Color::new(rng.gen_range(20, 255), rng.gen_range(10, 55), 30, 255);
+        let color = Color::new(rng.gen_range(20..255), rng.gen_range(10..55), 30, 255);
 
         Column {
             height,
@@ -42,7 +42,10 @@ fn main() {
         Vector3::new(0.0, 1.0, 0.0),
         60.0,
     );
-    let columns: [Column; 20] = arr![Column::create_random(); 20];
+    let mut columns = [Column::default(); 20];
+    for col in columns.iter_mut() {
+        *col = Column::create_random();
+    }
 
     rl.set_target_fps(60);
 

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -16,7 +16,6 @@ rand = "0.7"
 #tcod = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-arr_macro = "0.1.3"
 
 [dependencies.specs]
 version = "0.16.1"


### PR DESCRIPTION
Make specs and various dependencies optional(specs dependency are for the examples but at some point it got pulled in even if you wanted nothing to do with specs)
Outright remove unused dependencies