### PR TITLE
partial android support

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -82,8 +82,7 @@ fn build_with_cmake(src_path: &str) {
         .define("CMAKE_BUILD_TYPE", profile)
         // turn off until this is fixed
         .define("SUPPORT_BUSY_WAIT_LOOP", "OFF")
-        .define("SUPPORT_FILEFORMAT_JPG", "ON")
-        .define("RAYMATH_STATIC_INLINE", "ON");
+        .define("SUPPORT_FILEFORMAT_JPG", "ON");
 
     #[cfg(feature = "custom_frame_control")]
     {

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -149,6 +149,44 @@ fn build_with_cmake(src_path: &str) {
             .define("PLATFORM", "Web")
             .define("CMAKE_C_FLAGS", "-s ASYNCIFY"),
         Platform::RPI => conf.define("PLATFORM", "Raspberry Pi"),
+        Platform::Android => {
+            // get required env variables
+            let android_ndk_home = env::var("ANDROID_NDK_HOME")
+                .expect("Please set the environment variable: ANDROID_NDK_HOME:(e.g /home/u/Android/Sdk/ndk/VXXX/)");
+            let android_platform = target.split("-").last().expect("fail to parse the android version of the target triple, example:'aarch64-linux-android25'");
+            let abi_version = android_platform
+                .split("-")
+                .last()
+                .expect("Could not get abi version. Is ANDROID_PLATFORM valid?");
+            let toolchain_file =
+                format!("{}/build/cmake/android.toolchain.cmake", &android_ndk_home);
+            // Detect ANDROID_ABI using the target triple
+            let android_arch_abi = match target.as_str() {
+                "aarch64-linux-android" => "arm64-v8a",
+                "armv7-linux-androideabi" => "armeabi-v7a",
+                _ => panic!("Unsupported target triple for Android"),
+            };
+            // we'll set as many variables as possible according to:
+            // https://developer.android.com/ndk/guides/cmake#command-line_1
+            // https://cmake.org/cmake/help/v3.31/manual/cmake-toolchains.7.html#cross-compiling-for-android-with-the-ndk
+            // how to build:
+            // 0) set the correct linker in your game project's Cargo.toml (note: platform number should match):
+            // [target.aarch64-linux-android]
+            // linker = "/home/u/Android/Sdk/ndk/28.0.12433566/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android<PLATFORM_NUMBER>-clang"
+
+            // 1) set env variable ANDROID_NDK_HOME
+            // 2) compile with: `cargo ndk -t <ARCH> -p <PLATFORM_NUMBER> -o ./jniLibs build`
+            // example(cargo ndk -t arm64-v8a -p 25 -o ./jniLibs build)
+
+            conf.define("CMAKE_SYSTEM_NAME", "Android")
+                .define("PLATFORM", "Android")
+                .define("CMAKE_SYSTEM_VERSION", abi_version)
+                .define("ANDROID_ABI", android_arch_abi)
+                .define("CMAKE_ANDROID_ARCH_ABI", android_arch_abi)
+                .define("CMAKE_ANDROID_NDK", &android_ndk_home)
+                .define("ANDROID_PLATFORM", android_platform)
+                .define("CMAKE_TOOLCHAIN_FILE", &toolchain_file)
+        }
     };
 
     let dst = conf.build();
@@ -181,6 +219,15 @@ fn build_with_cmake(src_path: &str) {
     }
     // println!("cmake build {}", c.display());
     println!("cargo:rustc-link-search=native={}", dst_lib.display());
+    if platform == Platform::Android {
+        println!("cargo:rustc-link-lib=log");
+        println!("cargo:rustc-link-lib=android");
+        println!("cargo:rustc-link-lib=EGL");
+        println!("cargo:rustc-link-lib=GLESv2");
+        println!("cargo:rustc-link-lib=OpenSLES");
+        println!("cargo:rustc-link-lib=c");
+        println!("cargo:rustc-link-lib=m");
+    }
 }
 
 fn gen_bindings() {
@@ -190,6 +237,7 @@ fn gen_bindings() {
     let plat = match platform {
         Platform::Desktop => "-DPLATFORM_DESKTOP",
         Platform::RPI => "-DPLATFORM_RPI",
+        Platform::Android => "-DPLATFORM_ANDROID",
         Platform::Web => "-DPLATFORM_WEB",
     };
 
@@ -373,6 +421,8 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI
+    } else if target.contains("android") {
+        Platform::Android
     } else {
         Platform::Desktop
     };
@@ -431,6 +481,7 @@ fn uname() -> String {
 enum Platform {
     Web,
     Desktop,
+    Android,
     RPI, // raspberry pi
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/1bd0febf-1889-4e64-b914-7640e501c5ec

Getting this building might require modifying `rcore_android.c` needs https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_android.c#L270  and commenting out the call for main.

It builds! The next step is to try and turn it into an apk. I tried doing so but the apk instantly crashes on my phone and I'm not sure what it is. I used this as a starting baseline: https://github.com/rust-mobile/rust-android-examples/tree/main/na-mainloop which itself also crashes on app start but unsure if that is intentional