### PR TITLE
make raylib-sys/raylib submodule shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = raylib-sys/raylib
 	url = https://github.com/raysan5/raylib
 	commit = "039df36f"
+	shallow = true


### PR DESCRIPTION
in theory this should make it so when raylib gets pulled, it will only pull the first few commits instead of wasting bandwidth