### PR TITLE
Reclarify WASM message.

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -166,9 +166,7 @@ fn build_with_cmake(src_path: &str) {
                 conf.define("PLATFORM", "Desktop")
             }
         }
-        Platform::Web => conf
-            .define("PLATFORM", "Web")
-            .define("CMAKE_C_FLAGS", "-s ASYNCIFY"),
+        Platform::Web => conf.define("PLATFORM", "Web"),
         Platform::RPI => conf.define("PLATFORM", "Raspberry Pi"),
         Platform::Android => {
             // get required env variables
@@ -382,21 +380,21 @@ fn main() {
     println!("cargo:rerun-if-changed=./binding/binding.h");
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
 
-    // make sure cmake knows that it should bundle glfw in
-    if target.contains("wasm") {
+    if target.contains("wasm32-unknown-emscripten") {
         if let Err(e) = env::var("EMCC_CFLAGS") {
             if e == std::env::VarError::NotPresent {
-                panic!("\nYou must set the following environment variables yourself to compile for WASM. We are sorry for the inconvienence; this will be fixed in 5.1.0.\n{}{}\"\n",{
+                panic!("\nYou must have to set EMCC_CFLAGS yourself to compile for WASM.\n{}{}\"\n",{
                     #[cfg(target_family = "windows")]
-                    {"Paste this before executing the command: set EMCC_CFLAGS="}
+                    {"set EMCC_CFLAGS="}
                     #[cfg(not(target_family = "windows"))]
-                    {"Prefix your command with this (you may want to make a build script for obvious reasons...): EMCC_CFLAGS="}
-                },"\"-O3 -sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_RUNTIME_METHODS=ccallcwrap\"");
+                    {"export EMCC_CFLAGS="}
+                },"\"-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1\"");
             } else {
                 panic!("\nError regarding EMCC_CFLAGS: {:?}\n", e);
             }
         }
     }
+
     let (platform, platform_os) = platform_from_target(&target);
 
     let raylib_src = "./raylib";


### PR DESCRIPTION
Being able to build the WASM port from cmake does not change that Emscripten sucks and requires `EMCC_FLAGS` to be set not for our project, but for the user's project. Remove the message about this being fixed in Raylib 5.1, but also we can at least shorten the flags you need to set as per Raylib's own recommendations.

WebGPU (and WASI's support for it) couldn't be finalized soon enough.

This PR also displays a proper error for other wasm compilation targets; only emscipten works.