### PR TITLE
Fixed incorrect dependency version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Follow instructions for building raylib for your platform [here](https://github.
 
 ```toml
 [dependencies]
-raylib = { version = "5.5" }
+raylib = { version = "5.0.2" }
 ```
 
 2. Start coding!


### PR DESCRIPTION
I've tried to use raylib and noticed that version for Cargo.toml is incorrect in README.md