### PR TITLE
attach_audio_stream_processor_to_music: attach one or more closures as audio processors

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -26,7 +26,6 @@ specs = { version = "0.16.1", default = false, optional = true }
 specs-derive = { version = "0.4.1", optional = true }
 thiserror = "1.0.61"
 
-lazy_static = "1.5.0"
 paste = "1.0"
 seq-macro = "0.3.5"
 

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0.61"
 
 lazy_static = "1.5.0"
 paste = "1.0"
+seq-macro = "0.3.5"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -26,6 +26,9 @@ specs = { version = "0.16.1", default = false, optional = true }
 specs-derive = { version = "0.4.1", optional = true }
 thiserror = "1.0.61"
 
+lazy_static = "1.5.0"
+paste = "1.0"
+
 [dev-dependencies]
 structopt = "0.3"
 rand = "0.8.5"

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -209,6 +209,8 @@ pub fn set_load_file_text_callback<'a>(cb: fn(&str) -> String) -> Result<(), Set
 
 /// This struct encapsulates a rust callback
 /// and guarantees the lifetime to be long enough ('a)
+/// (once `get_as_user_data` is called, it the struct
+/// should not be moved again! -> use Pin<..>)
 pub struct AudioStreamProcessorCallback<'a, F>
 where
     F: FnMut(&mut [f32], u32) -> (),

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -205,6 +205,10 @@ pub fn set_load_file_text_callback<'a>(cb: fn(&str) -> String) -> Result<(), Set
     )
 }
 
+// region: -- AudioStreamProcessorCallback --
+
+/// This struct encapsulates a rust callback
+/// and guarantees the lifetime to be long enough ('a)
 pub struct AudioStreamProcessorCallback<'a, F>
 where
     F: FnMut(&mut [f32], u32) -> (),
@@ -269,6 +273,8 @@ where
         }
     }
 }
+
+// endregion: -- AudioStreamProcessorCallback --
 
 pub fn attach_audio_stream_processor_to_music<'a, F>(
     music: &'a Music<'a>,

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -290,7 +290,7 @@ where
     stream_processor_callback.callback_index = Some(attach_audio_stream_processor_with_user_data(
         music.stream,
         AudioCallbackWithUserData::new(
-            stream_processor_callback.get_as_user_data(),
+            stream_processor_callback.get_as_user_data(), // pass the address of the stream_processor_callback as void*
             stream_processor_callback.get_c_callback(),
         ),
     ));

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -14,7 +14,7 @@ use std::{
 };
 mod stream_processor_with_user_data_wrapper;
 use super::audio::Music;
-pub use stream_processor_with_user_data_wrapper::*;
+use stream_processor_with_user_data_wrapper::*;
 
 type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
 extern "C" {
@@ -281,7 +281,7 @@ pub fn attach_audio_stream_processor_to_music<'a, F>(
     processor: &'a mut F,
 ) -> Pin<Box<AudioStreamProcessorCallback<'a, F>>>
 where
-    F: FnMut(&mut [f32], u32) -> () + 'static, // static because the function is executed in another thread
+    F: FnMut(&mut [f32], u32) -> () + Send + 'static, // static because the function is executed in another thread
 {
     let mut stream_processor_callback =
         Box::new(AudioStreamProcessorCallback::<'a, F>::new(processor, 2));

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -132,6 +132,7 @@ macro_rules! generate_functions {
   }
 }
 
+// here, you can control how many callbacks are supported
 seq!(I in 1..30 {
     generate_functions!( 0#(,I)* );
 });

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -3,6 +3,8 @@ use paste::paste;
 use raylib_sys::{AttachAudioStreamProcessor, AudioStream};
 use std::sync::Mutex;
 
+// region: -- AudioCallbackWithUserData --
+
 type RawAudioCallbackWithUserData = extern "C" fn(
     user_data: *mut ::std::os::raw::c_void,
     data_ptr: *mut ::std::os::raw::c_void,
@@ -36,6 +38,11 @@ impl Default for AudioCallbackWithUserData {
         }
     }
 }
+
+// endregion: -- AudioCallbackWithUserData --
+
+// region: -- raw callbacks and linkage
+// raw callback and linkage to AudioCallbackWithUserData
 
 macro_rules! generate_functions {
   ( $( $n:literal ),* ) => {
@@ -109,6 +116,8 @@ generate_functions!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
 lazy_static! {
     static ref CURRENT_IDX: Mutex<usize> = Mutex::new(0);
 }
+
+// endregion: -- raw callbacks and linkage
 
 pub fn attach_audio_stream_processor_with_user_data(
     //    user_data: *mut ::std::os::raw::c_void,

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -1,8 +1,7 @@
-use lazy_static::lazy_static;
 use paste::paste;
 use raylib_sys::{AttachAudioStreamProcessor, AudioStream};
 use seq_macro::seq;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 // region: -- AudioCallbackWithUserData --
 
@@ -60,14 +59,12 @@ impl Default for AudioCallbackWithUserData {
 
 macro_rules! generate_functions {
   ( $( $n:literal ),* ) => {
-      paste! {
-          lazy_static! {
-              $(
-                /// For each supported callback the data for our context.
-                /// (here we have N "slots" with context data)
-                static ref [< CLOSURE_ $n >]: Mutex<AudioCallbackWithUserData> = Mutex::new(AudioCallbackWithUserData::default());
-              )*
-          }
+    paste! {
+        $(
+            /// For each supported callback the data for our context.
+            /// (here we have N "slots" with context data)
+            static [< CLOSURE_ $n >]:  LazyLock<Mutex<AudioCallbackWithUserData>> = LazyLock::new(|| Mutex::new(AudioCallbackWithUserData::default()));
+        )*
 
           /// Function to set our context
           /// and returns the slot used to store the context.

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -96,7 +96,7 @@ macro_rules! generate_functions {
                       return;
                   }
               )*
-              panic!(format!("clear_context: index {} out of bounds", index));
+              panic!("clear_context: index {} out of bounds", index);
           }
 
           $(

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -1,0 +1,127 @@
+use lazy_static::lazy_static;
+use paste::paste;
+use raylib_sys::{AttachAudioStreamProcessor, AudioStream};
+use std::sync::Mutex;
+
+type RawAudioCallbackWithUserData = extern "C" fn(
+    user_data: *mut ::std::os::raw::c_void,
+    data_ptr: *mut ::std::os::raw::c_void,
+    frames: u32,
+) -> ();
+
+pub struct AudioCallbackWithUserData {
+    user_data: *mut ::std::os::raw::c_void,
+    callback: Option<RawAudioCallbackWithUserData>,
+}
+
+unsafe impl Send for AudioCallbackWithUserData {} //??
+
+impl AudioCallbackWithUserData {
+    pub fn new(
+        user_data: *mut ::std::os::raw::c_void,
+        raw_callback: RawAudioCallbackWithUserData,
+    ) -> Self {
+        AudioCallbackWithUserData {
+            user_data: user_data,
+            callback: Some(raw_callback),
+        }
+    }
+}
+
+impl Default for AudioCallbackWithUserData {
+    fn default() -> Self {
+        AudioCallbackWithUserData {
+            user_data: std::ptr::null_mut(),
+            callback: None,
+        }
+    }
+}
+
+macro_rules! generate_functions {
+  ( $( $n:literal ),* ) => {
+      paste! {
+          lazy_static! {
+              $(
+                  static ref [< CLOSURE_ $n >]: Mutex<AudioCallbackWithUserData> = Mutex::new(AudioCallbackWithUserData::default());
+              )*
+          }
+
+          // Function to set the closure
+          fn set_closure(audio_callback: AudioCallbackWithUserData) -> usize {
+              $(
+                  {
+                      let mut guard = [< CLOSURE_ $n >].lock().unwrap();
+                      if (*guard).callback == None {
+                        *guard = audio_callback;
+                        return $n;
+                      }
+                  }
+              )*
+              panic!("index out of bounds");
+          }
+
+          // Function to set the closure
+          fn clear_closure(index: usize) {
+              $(
+                  if index == $n {
+                      let mut guard = [< CLOSURE_ $n >].lock().unwrap();
+                      if (*guard).callback == None {
+                          panic!(
+                              "No callbacks registered under this number ({}).",
+                              index
+                          );
+                      }
+                      *guard = AudioCallbackWithUserData::default();
+                  }
+              )*
+              panic!("index out of bounds");
+          }
+
+          $(
+            #[no_mangle]
+            pub extern "C" fn [< callback_ $n >](data_ptr: *mut ::std::os::raw::c_void, frames: u32) -> () {
+              println!("raw callback $n");
+              let guard = [< CLOSURE_ $n >].lock().unwrap();
+              let audio_callback = &(*guard);
+              if let Some(callback) = audio_callback.callback {
+                (callback)(audio_callback.user_data, data_ptr, frames);
+              } else {
+                  panic!("unexpected: no callback $n set")
+              }
+            }
+          )*
+
+          // Function to get the callback
+          fn get_callback(index: usize) -> extern "C" fn(data_ptr: *mut ::std::os::raw::c_void, frames: u32) {
+            $(
+                if index == $n {
+                    return [< callback_ $n >];
+                }
+            )*
+            panic!("index out of bounds");
+          }
+        }
+  }
+}
+
+const N: usize = 20;
+generate_functions!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+lazy_static! {
+    static ref CURRENT_IDX: Mutex<usize> = Mutex::new(0);
+}
+
+pub fn attach_audio_stream_processor_with_user_data(
+    //    user_data: *mut ::std::os::raw::c_void,
+    stream: AudioStream,
+    callback: AudioCallbackWithUserData,
+) -> usize {
+    let idx = set_closure(callback);
+    unsafe {
+        AttachAudioStreamProcessor(stream, Some(get_callback(idx)));
+    }
+    idx
+}
+
+pub fn detach_audio_stream_processor_with_user_data(index: usize) {
+    clear_closure(index);
+}

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -18,10 +18,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 imgui = {version = "0.12.0", optional = true}
 imgui-sys = {version = "0.12.0", optional = true}
-ringbuf = "0.4.7"
+ringbuf = {version = "0.4.7", optional = true}
 
 [features]
 imgui = ["raylib/imgui","dep:imgui","dep:imgui-sys"]
+ringbuf = ["dep:ringbuf"]
 
 [dependencies.specs]
 version = "0.16.1"
@@ -105,3 +106,4 @@ required-features = ["imgui"]
 [[bin]]
 name = "music_effects"
 path = "music_effects.rs"
+required-features = ["ringbuf"]

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 imgui = {version = "0.12.0", optional = true}
 imgui-sys = {version = "0.12.0", optional = true}
+ringbuf = "0.4.7"
 
 [features]
 imgui = ["raylib/imgui","dep:imgui","dep:imgui-sys"]
@@ -100,3 +101,7 @@ path = "./shader_multisample.rs"
 name = "imgui"
 path = "imgui.rs"
 required-features = ["imgui"]
+
+[[bin]]
+name = "music_effects"
+path = "music_effects.rs"

--- a/samples/music_effects.rs
+++ b/samples/music_effects.rs
@@ -1,0 +1,123 @@
+use raylib::prelude::*;
+use ringbuf::{
+    traits::{Consumer, Observer, RingBuffer},
+    HeapRb,
+};
+use std::{
+    cell::RefCell,
+    env, f32,
+    sync::{Arc, Mutex},
+};
+
+fn main() {
+    // get file name
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        panic!("usage {} <music file>", args[0]);
+    }
+    let filename = args[1].as_str();
+
+    // open window
+    let (mut rl, thread) = raylib::init()
+        .size(640, 480)
+        .title("Music Player")
+        .resizable()
+        .vsync()
+        .build();
+
+    // open audio file
+    let audio = raylib::core::audio::RaylibAudio::init_audio_device().unwrap();
+    let music = audio.new_music(filename).unwrap();
+    music.play_stream();
+
+    let mut effects = vec![];
+    let mut effects_control = vec![];
+
+    // create effects
+    for (k, key) in [
+        (1, KeyboardKey::KEY_ONE),
+        (2, KeyboardKey::KEY_TWO),
+        (3, KeyboardKey::KEY_THREE),
+    ] {
+        let hall_switch = Arc::new(Mutex::new(RefCell::new(false)));
+        let hall_switch_for_callback = Arc::clone(&hall_switch);
+        let dist = k * 10000;
+        let mut hall_buffer = HeapRb::<f32>::new(dist);
+        let hall_callback = move |data: &mut [f32], _nb_channels: u32| {
+            let hall_buffer = &mut hall_buffer;
+            let hall_switch = hall_switch_for_callback.lock().unwrap();
+            let delta = dist;
+            let delta_alpha: f32 = 0.5;
+            if *hall_switch.borrow_mut() {
+                (0..data.len()).for_each(|idx| {
+                    hall_buffer.push_overwrite(data[idx]);
+                    while hall_buffer.occupied_len() > delta {
+                        hall_buffer.try_pop().unwrap();
+                    }
+                    if hall_buffer.occupied_len() == delta {
+                        data[idx] = data[idx] + delta_alpha * hall_buffer.try_pop().unwrap();
+                    }
+                });
+            }
+        };
+        effects.push(hall_callback);
+        effects_control.push((hall_switch, key));
+    }
+
+    let mut _keep_alive = vec![];
+    for callback in effects.iter_mut() {
+        _keep_alive.push(attach_audio_stream_processor_to_music(&music, callback));
+    }
+
+    // run main loop (use key to control music and effects)
+    while !rl.window_should_close() {
+        if rl.is_key_pressed(KeyboardKey::KEY_RIGHT) {
+            let new_pos = f32::min(music.get_time_played() + 10.0, music.get_time_length());
+            music.seek_stream(new_pos);
+        }
+        if rl.is_key_pressed(KeyboardKey::KEY_LEFT) {
+            let new_pos = f32::max(music.get_time_played() - 10.0, 0.0);
+            music.seek_stream(new_pos);
+        }
+        for (switch, key) in effects_control.iter_mut() {
+            if rl.is_key_pressed(*key) {
+                let switch = switch.lock().unwrap();
+                let mut b = switch.borrow_mut();
+                *b = !(*b);
+            }
+        }
+
+        music.update_stream();
+
+        let mut d = rl.begin_drawing(&thread);
+        let info_color = Color::get_color(0xffff00ff);
+        let light_info_color = Color::get_color(0xa0a000ff);
+        d.clear_background(Color::get_color(0x006040ff));
+        d.draw_text(filename, 12, 42, 20, info_color);
+        d.draw_fps(d.get_render_width() - 90, 12);
+        let time_y = 80;
+        let time_x = ((d.get_render_width() - 20) as f32
+            * (music.get_time_played() / music.get_time_length())) as i32;
+        d.draw_line(
+            10,
+            time_y,
+            d.get_render_width() - 10,
+            time_y,
+            light_info_color,
+        );
+        d.draw_circle(time_x, time_y, 5.0, light_info_color);
+        {
+            let switch_states = effects_control
+                .iter()
+                .map(|(switch, _)| *RefCell::borrow(&switch.lock().unwrap()))
+                .collect::<Vec<_>>();
+            d.draw_text(
+                &format!("Press <-, ->, 1,2,3...: {:?}", switch_states),
+                12,
+                90,
+                20,
+                light_info_color,
+            );
+        }
+    }
+}


### PR DESCRIPTION
After having clarified, that we always get two channels (stereo) in the callback I feel ok to submit this PR (see https://github.com/raysan5/raylib/pull/4753).

Here, we allow to attach a `FnMut(&mut [f32], u32) -> ()` as audio processor (receiving and also potentially modifying audio data). We can attach up to 30 such functions.

The maximum number of 30 callbacks is selected in `stream_processor_with_user_data_wrapper.rs`: here we provide a real C function for each callback. We then allocate the callbacks (closures) to one of these C functions. This implementation is necessary, since no "user_data" is provided by raylib here (https://github.com/raysan5/raylib/pull/4744). 

With this workaround we can use raylib in a natural way and just pass closures.

I could add an example - but maybe in a separate PR (and maybe different - also simple - examples: from a simple media player to some simple audio effects):
![image](https://github.com/user-attachments/assets/3d659ebd-d33e-4a7b-a7aa-51b01248b943)

