### PR TITLE
Added binding for SetAudioStreamBufferSizeDefault(int)

### DIFF
--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -87,6 +87,14 @@ impl RaylibAudio {
     pub fn set_master_volume(&self, volume: f32) {
         unsafe { ffi::SetMasterVolume(volume) }
     }
+    
+    /// Sets default audio buffer size for new audio streams.
+    #[inline]
+    pub fn set_audio_stream_buffer_size_default(&self, size: i32) {
+        unsafe {
+            ffi::SetAudioStreamBufferSizeDefault(size);
+        }
+    }    
 
     /// Loads a new sound from file.
     #[inline]


### PR DESCRIPTION
Added a binding for setting default audio buffer size for new audio streams. 

I had a popping sound and increasing the size of audio buffer is actually fixes this issue. Here I found a solution: #https://github.com/raysan5/raylib/issues/4491