### PR TITLE
[rgui] gui_panel handles empty str

### DIFF
--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -218,8 +218,14 @@ pub trait RaylibDrawGui {
     /// Panel control, useful to group controls
     #[inline]
     fn gui_panel(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_filename = CString::new(text).unwrap();
-        unsafe { ffi::GuiPanel(bounds.into(), c_filename.as_ptr()) > 0 }
+        let cstr: CString;
+        let c_text = if text.is_empty() {
+            std::ptr::null()
+        } else {
+            cstr = CString::new(text).unwrap();
+            cstr.as_ptr()
+        };
+        unsafe { ffi::GuiPanel(bounds.into(), c_text) > 0 }
     }
     /// Scroll Panel control
     #[inline]


### PR DESCRIPTION
Restores (**without** changing back the function signature) the `5.0` usage for `gui_panel()`, which allowed `None` (taking `impl IntoCStr`).

Previously, passing `None` would cause a `NULL` pointer to get to `GuiPanel()`, effectively avoiding the rendering of the panel label.

The new API expecting `&str` handles `""` "properly", as in, the underlying C call does not get a `NULL` and the label is drawn with no text.

I'd like to keep the previous behaviour available, since the underlying `GuiPanel()` is/was doing explicit checks to work properly:

https://github.com/raysan5/raygui/blob/566c73f4e469ba83b053a0606188cc6b132c1312/src/raygui.h#L1716-L1727

An idea could be supporting `Option` on the function interface for the label text, but I don't know if it would be appropriate.

This fix is the only behaviour difference I found while upgrading a tool using this crate from `5.0.2`.

I took the liberty of renaming the local variable to c_text since I don't think it's really meant to be a filename, but it may be some convention in the crate I am not aware of.