### PR TITLE
Remove mention of physac from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Most development happens over at: https://github.com/raylib-rs/raylib-rs
 | ------ | ------------------ | ------------------ | ------------------ | --------------     | ------- |
 | core   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:     |
 | rgui   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | ❔                 | :x:     |
-| physac | :construction:     | :construction:     | :construction:     | ❔                 | :x:     |
 | rlgl   | :heavy_check_mark: | :x:                | :x:                | ❔                 | :x:     |
 
 ## Build Dependencies


### PR DESCRIPTION
The README currently has construction symbols next to physac, implying it will be bound at some point. However, I don't think that anyone (myself included) is ever gonna actually do that, and I don't think it's something that should be promised. If somebody does it, we would reverse this.

However I don't think physac should be bound anyways.  I can't speak for everyone, but my reasons for using Raylib with Rust (and started contributing) was because none of the other graphics libraries for Rust are very nice to use (let alone the ones done in pure Rust). But in this case, there exists [rapier](https://github.com/dimforge/rapier), a pure Rust physics library which is also way more mature/feature-rich then physac. If anything, there should be a feature-flag to allow interop between Raylib types and rapier functions.