### PR TITLE
Fix documentation mistake

### DIFF
--- a/raylib/src/core/input.rs
+++ b/raylib/src/core/input.rs
@@ -318,7 +318,7 @@ impl RaylibHandle {
         unsafe { ffi::GetTouchPointCount() as u32 }
     }
 
-    /// Gets gesture hold time in milliseconds.
+    /// Gets gesture hold time in seconds.
     #[inline]
     pub fn get_gesture_hold_duration(&self) -> f32 {
         unsafe { ffi::GetGestureHoldDuration() }


### PR DESCRIPTION
Related to [get_gesture_hold_duration() returns a value in seconds and not in milliseconds deltaphc/raylib-rs#209](https://github.com/deltaphc/raylib-rs/issues/209) of #137 