### PR TITLE
Simplify Serde `use` statements in `color.rs` and `window.rs`

### DIFF
--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -5,15 +5,6 @@ use crate::core::math::{Vector3, Vector4};
 use crate::ffi;
 
 use raylib_sys::{ColorIsEqual, GetPixelColor, PixelFormat};
-#[cfg(not(feature = "with_serde"))]
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-#[cfg(not(feature = "serde"))]
-#[cfg(feature = "with_serde")]
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "with_serde")]
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -5,15 +5,6 @@ use crate::ffi;
 use std::ffi::{CStr, CString, IntoStringError, NulError};
 use std::os::raw::c_char;
 
-#[cfg(not(feature = "with_serde"))]
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "with_serde")]
-#[cfg(not(feature = "serde"))]
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "with_serde")]
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Related to #160 