### PR TITLE
Get `load_shader` and `load_shader_from_memory` working with Option ergonomics

### DIFF
--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -29,14 +29,6 @@ impl RaylibHandle {
         let c_vs_filename = vs_filename.map(|f| CString::new(f).unwrap());
         let c_fs_filename = fs_filename.map(|f| CString::new(f).unwrap());
 
-        // Trust me, I have tried ALL the RUST option ergonamics. This is the only way
-        // to get this to work without raylib breaking for whatever reason
-        // UPDATE FOR 2024 FROM ANOTHER PERSON: Yes this is still true, doing although "for some reason" is likely due to the pointer getting freed too early if you don't do it this way.
-
-        // UPDATE FOR 2025 FROM ANOTHER OTHER PERSON: The reason this wasn't working before is because the pointer returned by `as_ptr()` lives as long as `self`. Because the Rust Option
-        // ergonomics take ownership of `self`, it only lives as long as the closure. However, `as_ptr()` only needs a reference, so putting `as_ref()` in front of the ergonomic allows
-        // `self` to keep its outer lifetime instead of taking ownership and dropping it. I don't know why the compiler didn't warn about that, it normally detects when that happens...
-
         let vs = c_vs_filename.as_ref().map_or_else(std::ptr::null, |s| s.as_ptr());
         let fs = c_fs_filename.as_ref().map_or_else(std::ptr::null, |s| s.as_ptr());
 

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -32,14 +32,15 @@ impl RaylibHandle {
         // Trust me, I have tried ALL the RUST option ergonamics. This is the only way
         // to get this to work without raylib breaking for whatever reason
         // UPDATE FOR 2024 FROM ANOTHER PERSON: Yes this is still true, doing although "for some reason" is likely due to the pointer getting freed too early if you don't do it this way.
-        let shader = match (c_vs_filename, c_fs_filename) {
-            (Some(vs), Some(fs)) => unsafe { Shader(ffi::LoadShader(vs.as_ptr(), fs.as_ptr())) },
-            (None, Some(fs)) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), fs.as_ptr())) },
-            (Some(vs), None) => unsafe { Shader(ffi::LoadShader(vs.as_ptr(), std::ptr::null())) },
-            (None, None) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), std::ptr::null())) },
-        };
 
-        return shader;
+        // UPDATE FOR 2025 FROM ANOTHER OTHER PERSON: The reason this wasn't working before is because the pointer returned by `as_ptr()` lives as long as `self`. Because the Rust Option
+        // ergonomics take ownership of `self`, it only lives as long as the closure. However, `as_ptr()` only needs a reference, so putting `as_ref()` in front of the ergonomic allows
+        // `self` to keep its outer lifetime instead of taking ownership and dropping it. I don't know why the compiler didn't warn about that, it normally detects when that happens...
+
+        let vs = c_vs_filename.as_ref().map_or_else(std::ptr::null, |s| s.as_ptr());
+        let fs = c_fs_filename.as_ref().map_or_else(std::ptr::null, |s| s.as_ptr());
+
+        Shader(unsafe { ffi::LoadShader(vs, fs) })
     }
 
     /// Loads shader from code strings and binds default locations.
@@ -51,32 +52,11 @@ impl RaylibHandle {
     ) -> Shader {
         let c_vs_code = vs_code.map(|f| CString::new(f).unwrap());
         let c_fs_code = fs_code.map(|f| CString::new(f).unwrap());
-        return match (c_vs_code, c_fs_code) {
-            (Some(vs), Some(fs)) => unsafe {
-                Shader(ffi::LoadShaderFromMemory(
-                    vs.as_ptr() as *mut c_char,
-                    fs.as_ptr() as *mut c_char,
-                ))
-            },
-            (None, Some(fs)) => unsafe {
-                Shader(ffi::LoadShaderFromMemory(
-                    std::ptr::null_mut(),
-                    fs.as_ptr() as *mut c_char,
-                ))
-            },
-            (Some(vs), None) => unsafe {
-                Shader(ffi::LoadShaderFromMemory(
-                    vs.as_ptr() as *mut c_char,
-                    std::ptr::null_mut(),
-                ))
-            },
-            (None, None) => unsafe {
-                Shader(ffi::LoadShaderFromMemory(
-                    std::ptr::null_mut(),
-                    std::ptr::null_mut(),
-                ))
-            },
-        };
+
+        let vs = c_vs_code.as_ref().map_or_else(std::ptr::null, |s| s.as_ptr());
+        let fs = c_fs_code.as_ref().map_or_else(std::ptr::null, |s| s.as_ptr());
+
+        Shader(unsafe { ffi::LoadShaderFromMemory(vs, fs) })
     }
 
     /// Get default shader. Modifying it modifies everthing that uses that shader


### PR DESCRIPTION
I made certain that `load_shader_from_memory` passed a test which appeared as follows:
```rs
#[cfg(test)]
mod tests {
    use crate::prelude::*;

    const VERT_SHADER_CODE: &str =
r"#version 330

// Input vertex attributes
in vec3 vertexPosition;
in vec2 vertexTexCoord;
in vec3 vertexNormal;
in vec4 vertexColor;

// Input uniform values
uniform mat4 mvp;

// Output vertex attributes (to fragment shader)
out vec2 fragTexCoord;
out vec4 fragColor;

// NOTE: Add here your custom variables

void main()
{
    // Send vertex attributes to fragment shader
    fragTexCoord = vertexTexCoord;
    fragColor = vertexColor;

    // Calculate final vertex position
    gl_Position = mvp*vec4(vertexPosition, 1.0);
}";

    const FRAG_SHADER_CODE: &str =
r"#version 330

// Input vertex attributes (from vertex shader)
in vec2 fragTexCoord;
in vec4 fragColor;

// Input uniform values
uniform sampler2D texture0;
uniform vec4 colDiffuse;

// Output fragment color
out vec4 finalColor;

// NOTE: Add here your custom variables

void main()
{
    // Texel color fetching from texture sampler
    vec4 texelColor = texture(texture0, fragTexCoord);

    // NOTE: Implement here your fragment shader code

    // final color is the color from the texture
    //    times the tint color (colDiffuse)
    //    times the fragment color (interpolated vertex color)
    finalColor = texelColor*colDiffuse*fragColor;
}";

    #[test]
    fn test_load_shader_from_memory() {
        let (mut rl, thread) = init().build();
        let mut shader1 = rl.load_shader_from_memory(&thread, Some(VERT_SHADER_CODE), Some(FRAG_SHADER_CODE));
        let mut shader2 = rl.load_shader_from_memory(&thread, Some(VERT_SHADER_CODE), None);
        let mut shader3 = rl.load_shader_from_memory(&thread, None, Some(FRAG_SHADER_CODE));
        let mut shader4 = rl.load_shader_from_memory(&thread, None, None);
        for shader in [&mut shader1, &mut shader2, &mut shader3, &mut shader4] {
            let mut d = rl.begin_drawing(&thread);
            d.clear_background(Color::WHITE);
            let mut d = d.begin_shader_mode(shader);
            d.draw_rectangle(0, 0, 640, 480, Color::BLACK);
        }
    }
}
```
I removed the test itself because I know that tests involving Raylib can cause false-negatives, since tests may run in parallel and Raylib panics if initialized twice.

However, I have not tested `load_shader`, because it would require adding shader files to the raylib-rs directory that would only be used for testing. However, I trust it should work because the code for it is copy-pasted from `test_load_shader_from_memory`.

I would like to ask that you please confirm whether this covers the cases that were previously concerning. It *works*, but I am unsure of whether the test I performed is a sufficient representative for "raylib breaking for whatever reason".

I can confirm, however, that I am not just taking the fact that a test didn't fail as confirmation. I know for certain that when trying ergonomics without `as_ref()`, the process would consistently exit with a "`STATUS_ACCESS_VIOLATION`", but using `as_ref()` stopped that from occurring. I'm just paranoid I might be missing the actual problem by not testing it in an actual, complete program consuming the raylib-rs API.