### PR TITLE
Implement lazy iterators

### DIFF
--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -6,6 +6,46 @@ use std::{
 
 use crate::{ffi, RaylibHandle};
 
+pub struct AutomationEventIter<'a> {
+    iter: std::slice::Iter<'a, ffi::AutomationEvent>
+}
+impl<'a> AutomationEventIter<'a> {
+    unsafe fn new(events: *mut ffi::AutomationEvent, count: u32) -> Self {
+        // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
+        assert!(!events.is_null(), "automation event array cannot be null");
+        assert!(events.is_aligned(), "automation event array must be aligned");
+        let iter = unsafe { std::slice::from_raw_parts(events, count as usize) }.iter();
+        Self { iter }
+    }
+    fn func(e: &ffi::AutomationEvent) -> AutomationEvent {
+        // This relies on the fact that `ffi::AutomationEvent` is Copy `unload_automation_event` doesn't actually do anything.
+        AutomationEvent(*e)
+    }
+}
+impl<'a> Iterator for AutomationEventIter<'a> {
+    type Item = AutomationEvent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::func)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+impl<'a> DoubleEndedIterator for AutomationEventIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::func)
+    }
+}
+impl<'a> ExactSizeIterator for AutomationEventIter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
 make_thin_wrapper!(
     AutomationEventList,
     ffi::AutomationEventList,
@@ -29,6 +69,10 @@ impl AutomationEventList {
             .iter()
             .map(|f| AutomationEvent(*f))
             .collect()
+    }
+    /// An iterator over the events held in this list.
+    pub fn iter<'a>(&'a self) -> AutomationEventIter<'a> {
+        unsafe { AutomationEventIter::new(self.0.events, self.count()) }
     }
 
     /// Export automation events list as text file

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::{ffi, RaylibHandle};
 
+#[derive(Debug, Clone)]
 pub struct AutomationEventIter<'a> {
     iter: std::slice::Iter<'a, ffi::AutomationEvent>
 }
@@ -33,10 +34,27 @@ impl<'a> Iterator for AutomationEventIter<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.iter.last().map(Self::func)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(Self::func)
+    }
 }
 impl<'a> DoubleEndedIterator for AutomationEventIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(Self::func)
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n).map(Self::func)
     }
 }
 impl<'a> ExactSizeIterator for AutomationEventIter<'a> {

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -2,44 +2,81 @@
 use crate::ffi;
 
 use crate::core::RaylibHandle;
-use std::ffi::{CStr, CString, OsString};
+use std::ffi::{c_char, CStr, CString, OsString};
 
-/// Iterator should not outlive list
-/// ```compile_fail
-/// let mut it;
-/// {
-///     let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
-///         capacity: 1,
-///         count: 1,
-///         paths: std::ptr::null_mut(),
-///     }));
-///     it = list.iter();
-/// }
-/// let _f = it.next(); // error: `list` is no longer in scope
-/// ```
 pub struct FilePathIter<'a> {
-    iter: std::slice::Iter<'a, Option<&'a std::ffi::c_char>>,
+    iter: std::slice::Iter<'a, Option<&'a c_char>>,
 }
 impl<'a> FilePathIter<'a> {
-    fn new(list: *mut *mut std::ffi::c_char, count: u32) -> Self {
+    /// # Safety
+    /// The memory pointed to by `list` must not be mutated for `'a`.
+    /// Every `*mut c_char` in `list` must outlive `'a`.
+    ///
+    /// ## Examples
+    ///
+    /// The following is invalid, because `list` is dropped while `it` is still borrowing it.
+    /// ```compile_fail
+    /// # use raylib::{ffi, file::*};
+    /// # use std::{mem::ManuallyDrop, ffi::CStr};
+    /// let mut it;
+    /// {
+    ///     let mut paths = [
+    ///         CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
+    ///     ];
+    ///     let mut list = ManuallyDrop::new(unsafe {
+    ///         FilePathList::from_raw(ffi::FilePathList {
+    ///             capacity: 1,
+    ///             count: 1,
+    ///             paths: paths.as_mut_ptr(),
+    ///         })
+    ///     });
+    ///     it = list.iter(); // expect error[E0597]
+    ///     let s = it.next();
+    ///     assert_eq!(s, Some("apple"));
+    /// }
+    /// let s = it.next();
+    /// assert_eq!(s, Some("apple"));
+    /// ```
+    ///
+    /// The following is invalid, because `list` is mutated while `it` is still borrowing it.
+    /// ```compile_fail
+    /// # use raylib::{ffi, file::*};
+    /// # use std::{mem::ManuallyDrop, ffi::CStr};
+    /// let mut paths = [
+    ///     CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
+    /// ];
+    /// let mut list = ManuallyDrop::new(unsafe {
+    ///     FilePathList::from_raw(ffi::FilePathList {
+    ///         capacity: 1,
+    ///         count: 1,
+    ///         paths: paths.as_mut_ptr(),
+    ///     })
+    /// });
+    /// let mut it = list.iter();
+    /// let s = it.next();
+    /// assert_eq!(s, Some("apple"));
+    /// unsafe { *(*list.paths) = b'@' as std::ffi::c_char; } // expect error[E0502]
+    /// assert_eq!(s, Some("apple")); // use `s` again after mutation to ensure `'a` is still alive
+    /// ```
+    unsafe fn new(list: *mut *mut c_char, count: u32) -> Self {
         // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
-        assert!(!list.is_null(), "file path pointer cannot be null");
-        assert!(list.is_aligned(), "file path pointer must be aligned");
-        let list = list.cast::<Option<&'a std::ffi::c_char>>();
+        assert!(!list.is_null(), "file path array cannot be null");
+        assert!(list.is_aligned(), "file path array must be aligned");
+        let list = list.cast::<Option<&'a c_char>>();
         let iter = unsafe { std::slice::from_raw_parts(list, count as usize) }.iter();
         Self { iter }
     }
-    fn convert_item(f: &Option<&'a std::ffi::c_char>) -> &'a str {
-        // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
-        let s = f.map(std::slice::from_ref).unwrap();
-        unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap()
-    }
+}
+fn opt_cstr_to_str<'a>(f: &Option<&'a c_char>) -> &'a str {
+    // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
+    let s = f.map(std::slice::from_ref).expect("file path string cannot be null");
+    unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap()
 }
 impl<'a> Iterator for FilePathIter<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(Self::convert_item)
+        self.iter.next().map(opt_cstr_to_str)
     }
 
     #[inline]
@@ -49,7 +86,7 @@ impl<'a> Iterator for FilePathIter<'a> {
 }
 impl<'a> DoubleEndedIterator for FilePathIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Self::convert_item)
+        self.iter.next_back().map(opt_cstr_to_str)
     }
 }
 impl<'a> ExactSizeIterator for FilePathIter<'a> {
@@ -84,8 +121,8 @@ impl FilePathList {
             .collect()
     }
     /// An iterator over the paths held in this list.
-    pub fn iter(&self) -> FilePathIter<'_> {
-        FilePathIter::new(self.0.paths, self.count())
+    pub fn iter<'a>(&'a self) -> FilePathIter<'a> {
+        unsafe { FilePathIter::new(self.0.paths, self.count()) }
     }
 }
 
@@ -107,8 +144,8 @@ impl DroppedFilePathList {
             .collect()
     }
     /// An iterator over the paths held in this list.
-    pub fn iter(&self) -> FilePathIter<'_> {
-        FilePathIter::new(self.0.paths, self.count())
+    pub fn iter<'a>(&'a self) -> FilePathIter<'a> {
+        unsafe { FilePathIter::new(self.0.paths, self.count()) }
     }
 }
 
@@ -202,12 +239,12 @@ impl RaylibHandle {
 }
 
 #[cfg(test)]
-mod file_path_iter_tests {
+mod tests {
     use std::mem::ManuallyDrop;
     use super::*;
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "file path array cannot be null")]
     fn test_null_list() {
         let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
             capacity: 0,
@@ -219,7 +256,7 @@ mod file_path_iter_tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "file path string cannot be null")]
     fn test_null_item() {
         let mut paths = [std::ptr::null_mut()];
         let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
@@ -233,7 +270,7 @@ mod file_path_iter_tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "file path string cannot be null")]
     fn test_null_item_double_ended() {
         let mut paths = [std::ptr::null_mut()];
         let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -4,6 +4,7 @@ use crate::ffi;
 use crate::core::RaylibHandle;
 use std::ffi::{c_char, CStr, CString, OsString};
 
+#[derive(Debug, Clone)]
 pub struct FilePathIter<'a> {
     iter: std::slice::Iter<'a, Option<&'a c_char>>,
 }
@@ -86,10 +87,27 @@ impl<'a> Iterator for FilePathIter<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.iter.last().map(Self::func)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(Self::func)
+    }
 }
 impl<'a> DoubleEndedIterator for FilePathIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(Self::func)
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n).map(Self::func)
     }
 }
 impl<'a> ExactSizeIterator for FilePathIter<'a> {

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -69,17 +69,17 @@ impl<'a> FilePathIter<'a> {
         let iter = unsafe { std::slice::from_raw_parts(list, count as usize) }.iter();
         Self { iter }
     }
-}
-fn opt_cstr_to_str<'a>(f: &Option<&'a c_char>) -> &'a str {
-    // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
-    let s = f.map(std::slice::from_ref).expect("file path string cannot be null");
-    unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap()
+    fn func(f: &Option<&'a c_char>) -> &'a str {
+        // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
+        let s = std::slice::from_ref(f.expect("file path string cannot be null"));
+        unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap()
+    }
 }
 impl<'a> Iterator for FilePathIter<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(opt_cstr_to_str)
+        self.iter.next().map(Self::func)
     }
 
     #[inline]
@@ -89,7 +89,7 @@ impl<'a> Iterator for FilePathIter<'a> {
 }
 impl<'a> DoubleEndedIterator for FilePathIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(opt_cstr_to_str)
+        self.iter.next_back().map(Self::func)
     }
 }
 impl<'a> ExactSizeIterator for FilePathIter<'a> {

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -4,6 +4,61 @@ use crate::ffi;
 use crate::core::RaylibHandle;
 use std::ffi::{CStr, CString, OsString};
 
+/// Iterator should not outlive list
+/// ```compile_fail
+/// let mut it;
+/// {
+///     let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
+///         capacity: 1,
+///         count: 1,
+///         paths: std::ptr::null_mut(),
+///     }));
+///     it = list.iter();
+/// }
+/// let _f = it.next(); // error: `list` is no longer in scope
+/// ```
+pub struct FilePathIter<'a> {
+    iter: std::slice::Iter<'a, Option<&'a std::ffi::c_char>>,
+}
+impl<'a> FilePathIter<'a> {
+    fn new(list: *mut *mut std::ffi::c_char, count: u32) -> Self {
+        // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
+        assert!(!list.is_null(), "file path pointer cannot be null");
+        assert!(list.is_aligned(), "file path pointer must be aligned");
+        let list = list.cast::<Option<&'a std::ffi::c_char>>();
+        let iter = unsafe { std::slice::from_raw_parts(list, count as usize) }.iter();
+        Self { iter }
+    }
+    fn convert_item(f: &Option<&'a std::ffi::c_char>) -> &'a str {
+        // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
+        let s = f.map(std::slice::from_ref).unwrap();
+        unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap()
+    }
+}
+impl<'a> Iterator for FilePathIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::convert_item)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+impl<'a> DoubleEndedIterator for FilePathIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::convert_item)
+    }
+}
+impl<'a> ExactSizeIterator for FilePathIter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
 make_thin_wrapper!(FilePathList, ffi::FilePathList, ffi::UnloadDirectoryFiles);
 make_thin_wrapper!(
     DroppedFilePathList,
@@ -28,6 +83,10 @@ impl FilePathList {
             .map(|f| unsafe { CStr::from_ptr(*f) }.to_str().unwrap())
             .collect()
     }
+    /// An iterator over the paths held in this list.
+    pub fn iter(&self) -> FilePathIter<'_> {
+        FilePathIter::new(self.0.paths, self.count())
+    }
 }
 
 impl DroppedFilePathList {
@@ -46,6 +105,10 @@ impl DroppedFilePathList {
             .iter()
             .map(|f| unsafe { CStr::from_ptr(*f) }.to_str().unwrap())
             .collect()
+    }
+    /// An iterator over the paths held in this list.
+    pub fn iter(&self) -> FilePathIter<'_> {
+        FilePathIter::new(self.0.paths, self.count())
     }
 }
 
@@ -135,5 +198,109 @@ impl RaylibHandle {
     /// Check if a file has been dropped into window
     pub fn load_dropped_files(&self) -> DroppedFilePathList {
         unsafe { DroppedFilePathList(ffi::LoadDroppedFiles()) }
+    }
+}
+
+#[cfg(test)]
+mod file_path_iter_tests {
+    use std::mem::ManuallyDrop;
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_null_list() {
+        let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
+            capacity: 0,
+            count: 0,
+            paths: std::ptr::null_mut(),
+        }));
+        let _it = list.iter();
+        // should have panicked while calling .iter()
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_null_item() {
+        let mut paths = [std::ptr::null_mut()];
+        let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
+            capacity: 1,
+            count: 1,
+            paths: paths.as_mut_ptr(),
+        }));
+        let mut it = list.iter();
+        let _f = it.next();
+        // should have panicked while calling .next()
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_null_item_double_ended() {
+        let mut paths = [std::ptr::null_mut()];
+        let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
+            capacity: 1,
+            count: 1,
+            paths: paths.as_mut_ptr(),
+        }));
+        let mut it = list.iter();
+        let _f = it.next_back();
+        // should have panicked while calling .next_back()
+    }
+
+    #[test]
+    fn test_len() {
+        let mut paths = [
+            CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"orange\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"banana\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"mango\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"pineapple\0").unwrap().as_ptr().cast_mut(),
+        ];
+        let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
+            capacity: 5,
+            count: 5,
+            paths: paths.as_mut_ptr(),
+        }));
+        let mut it = list.iter();
+        assert_eq!(it.len(), 5);
+        assert_eq!(it.next(), Some("apple"));
+        assert_eq!(it.len(), 4);
+        assert_eq!(it.next(), Some("orange"));
+        assert_eq!(it.len(), 3);
+        assert_eq!(it.next(), Some("banana"));
+        assert_eq!(it.len(), 2);
+        assert_eq!(it.next(), Some("mango"));
+        assert_eq!(it.len(), 1);
+        assert_eq!(it.next(), Some("pineapple"));
+        assert_eq!(it.len(), 0);
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn test_len_double_ended() {
+        let mut paths = [
+            CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"orange\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"banana\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"mango\0").unwrap().as_ptr().cast_mut(),
+            CStr::from_bytes_with_nul(b"pineapple\0").unwrap().as_ptr().cast_mut(),
+        ];
+        let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
+            capacity: 5,
+            count: 5,
+            paths: paths.as_mut_ptr(),
+        }));
+        let mut it = list.iter();
+        assert_eq!(it.len(), 5);
+        assert_eq!(it.next_back(), Some("pineapple"));
+        assert_eq!(it.len(), 4);
+        assert_eq!(it.next_back(), Some("mango"));
+        assert_eq!(it.len(), 3);
+        assert_eq!(it.next_back(), Some("banana"));
+        assert_eq!(it.len(), 2);
+        assert_eq!(it.next_back(), Some("orange"));
+        assert_eq!(it.len(), 1);
+        assert_eq!(it.next_back(), Some("apple"));
+        assert_eq!(it.len(), 0);
+        assert_eq!(it.next_back(), None);
     }
 }

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -19,6 +19,7 @@ impl<'a> FilePathIter<'a> {
     /// # use raylib::{ffi, file::*};
     /// # use std::{mem::ManuallyDrop, ffi::CStr};
     /// let mut it;
+    /// let s;
     /// {
     ///     let mut paths = [
     ///         CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
@@ -31,11 +32,11 @@ impl<'a> FilePathIter<'a> {
     ///         })
     ///     });
     ///     it = list.iter(); // expect error[E0597]
-    ///     let s = it.next();
+    ///     //   ^^^^ borrowed value does not live long enough
+    ///     s = it.next();
     ///     assert_eq!(s, Some("apple"));
-    /// }
-    /// let s = it.next();
-    /// assert_eq!(s, Some("apple"));
+    /// } // `list` dropped here while still borrowed
+    /// assert_eq!(s, Some("apple")); // borrow later used here
     /// ```
     ///
     /// The following is invalid, because `list` is mutated while `it` is still borrowing it.
@@ -53,10 +54,12 @@ impl<'a> FilePathIter<'a> {
     ///     })
     /// });
     /// let mut it = list.iter();
+    /// //           ---- immutable borrow occurs here
     /// let s = it.next();
     /// assert_eq!(s, Some("apple"));
     /// unsafe { *(*list.paths) = b'@' as std::ffi::c_char; } // expect error[E0502]
-    /// assert_eq!(s, Some("apple")); // use `s` again after mutation to ensure `'a` is still alive
+    /// //          ^^^^ mutable borrow occurs here
+    /// assert_eq!(s, Some("apple")); // immutable borrow later used here
     /// ```
     unsafe fn new(list: *mut *mut c_char, count: u32) -> Self {
         // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -532,6 +532,75 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
     }
 }
 
+pub struct FramePoseIter<'a> {
+    iter: std::slice::Iter<'a, Option<&'a [crate::math::Transform]>>,
+    bone_count: usize,
+}
+impl<'a> FramePoseIter<'a> {
+    unsafe fn new(frame_poses: *mut *mut ffi::Transform, frame_count: usize, bone_count: usize) -> Self {
+        // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
+        assert!(!frame_poses.is_null(), "frame pose array cannot be null");
+        assert!(frame_poses.is_aligned(), "frame pose array must be aligned");
+        let frame_poses = frame_poses.cast::<Option<&'a [crate::math::Transform]>>();
+        let iter = unsafe { std::slice::from_raw_parts(frame_poses, frame_count) }.iter();
+        Self { iter, bone_count }
+    }
+    fn func(tf: &Option<&'a [crate::math::Transform]>, bone_count: usize) -> &'a [crate::math::Transform] {
+        unsafe { std::slice::from_raw_parts(tf.expect("frame pose transform cannot be null").as_ptr(), bone_count) }
+    }
+}
+impl<'a> Iterator for FramePoseIter<'a> {
+    type Item = &'a [crate::math::Transform];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|tf| Self::func(tf, self.bone_count))
+    }
+}
+impl<'a> DoubleEndedIterator for FramePoseIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|tf| Self::func(tf, self.bone_count))
+    }
+}
+impl<'a> ExactSizeIterator for FramePoseIter<'a> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+pub struct FramePoseIterMut<'a> {
+    iter: std::slice::IterMut<'a, Option<&'a mut [crate::math::Transform]>>,
+    bone_count: usize,
+}
+impl<'a> FramePoseIterMut<'a> {
+    unsafe fn new(frame_poses: *mut *mut ffi::Transform, frame_count: usize, bone_count: usize) -> Self {
+        // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
+        assert!(!frame_poses.is_null(), "frame pose array cannot be null");
+        assert!(frame_poses.is_aligned(), "frame pose array must be aligned");
+        let frame_poses = frame_poses.cast::<Option<&'a mut [crate::math::Transform]>>();
+        let iter = unsafe { std::slice::from_raw_parts_mut(frame_poses, frame_count) }.iter_mut();
+        Self { iter, bone_count }
+    }
+    fn func(tf: &mut Option<&'a mut [crate::math::Transform]>, bone_count: usize) -> &'a mut [crate::math::Transform] {
+        unsafe { std::slice::from_raw_parts_mut(tf.as_mut().expect("frame pose transform cannot be null").as_mut_ptr(), bone_count) }
+    }
+}
+impl<'a> Iterator for FramePoseIterMut<'a> {
+    type Item = &'a mut [crate::math::Transform];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|tf| Self::func(tf, self.bone_count))
+    }
+}
+impl<'a> DoubleEndedIterator for FramePoseIterMut<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|tf| Self::func(tf, self.bone_count))
+    }
+}
+impl<'a> ExactSizeIterator for FramePoseIterMut<'a> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
 impl RaylibModelAnimation for ModelAnimation {}
 impl RaylibModelAnimation for WeakModelAnimation {}
 
@@ -577,6 +646,10 @@ pub trait RaylibModelAnimation: AsRef<ffi::ModelAnimation> + AsMut<ffi::ModelAni
 
         top
     }
+    fn frame_poses_iter<'a>(&'a self) -> FramePoseIter<'a> {
+        let anim = self.as_ref();
+        unsafe { FramePoseIter::new(anim.framePoses, anim.frameCount as usize, anim.boneCount as usize) }
+    }
 
     fn frame_poses_mut(&mut self) -> Vec<&mut [crate::math::Transform]> {
         let anim = self.as_ref();
@@ -592,6 +665,10 @@ pub trait RaylibModelAnimation: AsRef<ffi::ModelAnimation> + AsMut<ffi::ModelAni
         }
 
         top
+    }
+    fn frame_poses_iter_mut<'a>(&'a mut self) -> FramePoseIterMut<'a> {
+        let anim = self.as_ref();
+        unsafe { FramePoseIterMut::new(anim.framePoses, anim.frameCount as usize, anim.boneCount as usize) }
     }
 }
 

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -532,6 +532,7 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct FramePoseIter<'a> {
     iter: std::slice::Iter<'a, Option<&'a [crate::math::Transform]>>,
     bone_count: usize,
@@ -553,19 +554,48 @@ impl<'a> Iterator for FramePoseIter<'a> {
     type Item = &'a [crate::math::Transform];
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|tf| Self::func(tf, self.bone_count))
+        let bone_count = self.bone_count;
+        self.iter.next().map(move |tf| Self::func(tf, bone_count))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        let bone_count = self.bone_count;
+        self.iter.last().map(move |tf| Self::func(tf, bone_count))
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let bone_count = self.bone_count;
+        self.iter.nth(n).map(move |tf| Self::func(tf, bone_count))
     }
 }
 impl<'a> DoubleEndedIterator for FramePoseIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|tf| Self::func(tf, self.bone_count))
+        let bone_count = self.bone_count;
+        self.iter.next_back().map(move |tf| Self::func(tf, bone_count))
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let bone_count = self.bone_count;
+        self.iter.nth_back(n).map(move |tf| Self::func(tf, bone_count))
     }
 }
 impl<'a> ExactSizeIterator for FramePoseIter<'a> {
+    #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
+#[derive(Debug)]
 pub struct FramePoseIterMut<'a> {
     iter: std::slice::IterMut<'a, Option<&'a mut [crate::math::Transform]>>,
     bone_count: usize,
@@ -587,15 +617,43 @@ impl<'a> Iterator for FramePoseIterMut<'a> {
     type Item = &'a mut [crate::math::Transform];
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|tf| Self::func(tf, self.bone_count))
+        let bone_count = self.bone_count;
+        self.iter.next().map(move |tf| Self::func(tf, bone_count))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        let bone_count = self.bone_count;
+        self.iter.last().map(move |tf| Self::func(tf, bone_count))
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let bone_count = self.bone_count;
+        self.iter.nth(n).map(move |tf| Self::func(tf, bone_count))
     }
 }
 impl<'a> DoubleEndedIterator for FramePoseIterMut<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|tf| Self::func(tf, self.bone_count))
+        let bone_count = self.bone_count;
+        self.iter.next_back().map(move |tf| Self::func(tf, bone_count))
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let bone_count = self.bone_count;
+        self.iter.nth_back(n).map(move |tf| Self::func(tf, bone_count))
     }
 }
 impl<'a> ExactSizeIterator for FramePoseIterMut<'a> {
+    #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }


### PR DESCRIPTION
Resolves #170 

The `file.rs` iterator is thoroughly tested, the others are not. This is because `AutomationEventIter` and `FramePoseIter` are copy-pasted from it, so they shouldn't be significantly different.

However, it *may* be prudent to write tests for `FramePoseIterMut`, as it is unique in that it is mutable while the other iterators are not. Let me know if that is something you would like me to do.