### PR TITLE
Fix UAF on load_model_animations

### DIFF
--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -125,7 +125,7 @@ impl RaylibHandle {
             }
         }
         unsafe {
-            ffi::UnloadModelAnimations(m_ptr, m_size);
+            ffi::MemFree(m_ptr as *mut ::std::os::raw::c_void);
         }
         Ok(m_vec)
     }


### PR DESCRIPTION
Fix pr [#103](https://github.com/raylib-rs/raylib-rs/pull/103).
Calling `ffi::UnloadModelAnimations` results in freeing the animation array, along with its subsequent `bones` and `framePoses` fields, which will segfault when accessed.