### PR TITLE
Massive custom build system overhaul, Bump version 5.5.2, Upgrade rust edition

### DIFF
--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raylib-sys"
-version = "5.5.1"
+version = "5.5.2"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 description = "Raw FFI bindings for Raylib"
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/raylib-sys"
 repository = "https://github.com/raylib-rs/raylib-rs"
 keywords = ["bindings", "raylib", "gamedev", "ffi"]
 categories = ["external-ffi-bindings"]
-edition = "2018"
+edition = "2021"
 exclude = ["raylib/examples/*", "raylib/projects/*", "raylib/templates/*"]
 
 [dependencies]
@@ -17,35 +17,157 @@ imgui-sys = { version = "0.12.0", optional = true }
 
 [build-dependencies]
 cmake = "0.1.51"
-cc = "1.0"
+cc = { version = "1.0", features = ["parallel"]}
 bindgen = "0.70"
 
 [features]
-# Build Raylib headless for docs/esoteric platforms. Up to you to link.
-nobuild = []
+# default features follow the cmake version: https://github.com/raysan5/raylib/wiki/CMake-Build-Options
+# NOTE: some are critical, e.g: SUPPORT_STANDARD_FILEIO should always be turned on because many things like `LoadShader()` uses it to read text
+default = [
+  "bindgen",
+  "GLFW_BUILD_X11",
+  "USE_AUDIO",
+  "SUPPORT_MODULE_RSHAPES",
+  "SUPPORT_MODULE_RTEXTURES",
+  "SUPPORT_MODULE_RTEXT",
+  "SUPPORT_MODULE_RMODELS",
+  "SUPPORT_MODULE_RAUDIO",
+  "SUPPORT_CAMERA_SYSTEM",
+  "SUPPORT_GESTURES_SYSTEM",
+  "SUPPORT_RPRAND_GENERATOR",
+  "SUPPORT_MOUSE_GESTURES",
+  "SUPPORT_SSH_KEYBOARD_RPI",
+  "SUPPORT_WINMM_HIGHRES_TIMER",
+  "SUPPORT_SCREEN_CAPTURE",
+  "SUPPORT_GIF_RECORDING",
+  "SUPPORT_COMPRESSION_API",
+  "SUPPORT_AUTOMATION_EVENTS",
+  "SUPPORT_CLIPBOARD_IMAGE",
+  "SUPPORT_QUADS_DRAW_MODE",
+  "SUPPORT_FILEFORMAT_PNG",
+  "SUPPORT_FILEFORMAT_GIF",
+  "SUPPORT_FILEFORMAT_QOI",
+  "SUPPORT_FILEFORMAT_DDS",
+  "SUPPORT_IMAGE_EXPORT",
+  "SUPPORT_IMAGE_GENERATION",
+  "SUPPORT_IMAGE_MANIPULATION",
+  "SUPPORT_DEFAULT_FONT",
+  "SUPPORT_FILEFORMAT_TTF",
+  "SUPPORT_FILEFORMAT_FNT",
+  "SUPPORT_TEXT_MANIPULATION",
+  "SUPPORT_FONT_ATLAS_WHITE_REC",
+  "SUPPORT_FILEFORMAT_OBJ",
+  "SUPPORT_FILEFORMAT_MTL",
+  "SUPPORT_FILEFORMAT_IQM",
+  "SUPPORT_FILEFORMAT_GLTF",
+  "SUPPORT_FILEFORMAT_VOX",
+  "SUPPORT_FILEFORMAT_M3D",
+  "SUPPORT_MESH_GENERATION",
+  "SUPPORT_FILEFORMAT_WAV",
+  "SUPPORT_FILEFORMAT_OGG",
+  "SUPPORT_FILEFORMAT_MP3",
+  "SUPPORT_FILEFORMAT_QOA",
+  "SUPPORT_FILEFORMAT_XM",
+  "SUPPORT_FILEFORMAT_MOD",
+  "SUPPORT_STANDARD_FILEIO",
+  "SUPPORT_TRACELOG",
+]
+raygui = []
 # Generate bindings automatically.
 # You can turn this off if you wanna go into the source and put in your own bindings.rs, which is
 # useful since bindgen doesn't work on esoteric platforms.
 bindgen = []
-# Build for wayland on linux. Should fix #119
-wayland = []
-# Bindgen is default
-default = ["bindgen"]
+imgui = ["dep:imgui", "dep:imgui-sys"]
+
+
+# ----- Copy and paste these from `raylib-sys` for easier maintance
+# Build Raylib headless for docs/esoteric platforms. Up to you to link.
+nobuild = []
 
 # OpenGL stuff, intended for fixing #122
-opengl_33 = []
+opengl_11 = [] # buggy? might not work with wayland
 opengl_21 = []
-# opengl_11 = [] I couldn't get this one working, the others were fine in my limited testing (unsure about wayland compatibility)
+opengl_33 = []
+opengl_43 = []
 opengl_es_20 = []
 opengl_es_30 = []
 sdl = []
+wayland = []
 
-# Allow disabling screenshots and gifs on f12
-noscreenshot = []
-nogif = []
+# extra build profiles:
+release_with_debug_info = []
+min_size_rel = []
 
-# config.h's SUPPORT_CUSTOM_FRAME_CONTROL
-custom_frame_control = []
+ENABLE_ASAN = []
+ENABLE_UBSAN = []
+ENABLE_MSAN = []
+WITH_PIC = []
+BUILD_SHARED_LIBS = []
+USE_EXTERNAL_GLFW = []
+GLFW_BUILD_WAYLAND = []
+GLFW_BUILD_X11 = []
+INCLUDE_EVERYTHING = []
 
-# ImGui support
-imgui = ["dep:imgui", "dep:imgui-sys"]
+USE_AUDIO = []
+SUPPORT_MODULE_RSHAPES  = []
+SUPPORT_MODULE_RTEXTURES = []
+SUPPORT_MODULE_RTEXT = []
+SUPPORT_MODULE_RMODELS = []
+SUPPORT_MODULE_RAUDIO = []
+SUPPORT_BUSY_WAIT_LOOP = []
+SUPPORT_CAMERA_SYSTEM = []
+SUPPORT_GESTURES_SYSTEM = []
+SUPPORT_RPRAND_GENERATOR = []
+SUPPORT_MOUSE_GESTURES = []
+SUPPORT_SSH_KEYBOARD_RPI = []
+SUPPORT_WINMM_HIGHRES_TIMER = []
+SUPPORT_PARTIALBUSY_WAIT_LOOP = []
+SUPPORT_GIF_RECORDING = []
+SUPPORT_COMPRESSION_API = []
+SUPPORT_AUTOMATION_EVENTS = []
+SUPPORT_CUSTOM_FRAME_CONTROL = []
+SUPPORT_CLIPBOARD_IMAGE = []
+SUPPORT_QUADS_DRAW_MODE = []
+SUPPORT_FILEFORMAT_PNG = []
+SUPPORT_FILEFORMAT_BMP = []
+SUPPORT_FILEFORMAT_TGA = []
+SUPPORT_FILEFORMAT_JPG = []
+SUPPORT_FILEFORMAT_GIF = []
+SUPPORT_FILEFORMAT_QOI = []
+SUPPORT_FILEFORMAT_PSD = []
+SUPPORT_FILEFORMAT_DDS = []
+SUPPORT_FILEFORMAT_HDR = []
+SUPPORT_FILEFORMAT_PIC = []
+SUPPORT_FILEFORMAT_KTX = []
+SUPPORT_FILEFORMAT_ASTC = []
+SUPPORT_FILEFORMAT_PKM = []
+SUPPORT_FILEFORMAT_PVR = []
+SUPPORT_IMAGE_EXPORT = []
+SUPPORT_IMAGE_GENERATION = []
+SUPPORT_IMAGE_MANIPULATION = []
+SUPPORT_DEFAULT_FONT = []
+SUPPORT_FILEFORMAT_TTF = []
+SUPPORT_FILEFORMAT_FNT = []
+SUPPORT_FILEFORMAT_BDF = []
+SUPPORT_TEXT_MANIPULATION = []
+SUPPORT_FONT_ATLAS_WHITE_REC = []
+SUPPORT_FILEFORMAT_OBJ = []
+SUPPORT_FILEFORMAT_MTL = []
+SUPPORT_FILEFORMAT_IQM = []
+SUPPORT_FILEFORMAT_GLTF = []
+SUPPORT_FILEFORMAT_VOX = []
+SUPPORT_FILEFORMAT_M3D = []
+SUPPORT_MESH_GENERATION = []
+SUPPORT_FILEFORMAT_WAV = []
+SUPPORT_FILEFORMAT_OGG = []
+SUPPORT_FILEFORMAT_MP3 = []
+SUPPORT_FILEFORMAT_QOA = []
+SUPPORT_FILEFORMAT_FLAC = []
+SUPPORT_FILEFORMAT_XM = []
+SUPPORT_FILEFORMAT_MOD = []
+SUPPORT_STANDARD_FILEIO = []
+SUPPORT_TRACELOG = []
+SUPPORT_SCREEN_CAPTURE = []
+SUPPORT_VR_SIMULATOR = []
+SUPPORT_DISTORTION_SHADER = []
+SUPPORT_FONT_TEXTURE = []

--- a/raylib-test/Cargo.toml
+++ b/raylib-test/Cargo.toml
@@ -2,17 +2,17 @@
 name = "raylib-test"
 version = "5.5.1"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
-edition = "2018"
+edition = "2021"
 license = "Zlib"
 readme = "../README.md"
 repository = "https://github.com/raylib-rs/raylib-rs"
 
 [dependencies]
-raylib = { version = "5.5.1", path = "../raylib" }
-raylib_sys = { version = "5.5.1", path = "../raylib-sys" }
+raylib = { version = "5.5.2", path = "../raylib" }
+raylib_sys = { version = "5.5.2", path = "../raylib-sys" }
 lazy_static = "1.2.0"
-colored = "2.1.0"
+colored = "1.9.1"
 
 [features]
-custom_frame_control = ["raylib/custom_frame_control"]
+SUPPORT_CUSTOM_FRAME_CONTROL  = ["raylib/SUPPORT_CUSTOM_FRAME_CONTROL"]
 automation_event_test = []

--- a/raylib-test/src/lib.rs
+++ b/raylib-test/src/lib.rs
@@ -32,44 +32,44 @@ extern crate test;
 #[macro_use]
 pub mod tests;
 
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod audio;
 #[cfg(not(target_os = "windows"))]
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod callbacks;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod data;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod drawing;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod image;
-#[cfg(feature = "custom_frame_control")]
+#[cfg(feature = "SUPPORT_CUSTOM_FRAME_CONTROL")]
 mod manual;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod misc;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod models;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod random;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod text;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod texture;
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod window;
 
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 #[cfg(not(feature = "automation_event_test"))]
 mod logging;
 

--- a/raylib-test/src/tests.rs
+++ b/raylib-test/src/tests.rs
@@ -66,7 +66,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
     automation_test(&thread);
 }
 
-#[cfg(feature = "custom_frame_control")]
+#[cfg(feature = "SUPPORT_CUSTOM_FRAME_CONTROL")]
 pub fn test_runner(tests: &[&dyn Testable]) {
     use crate::manual::manual_test::test_manual;
 
@@ -81,7 +81,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
     test_manual(&thread);
 }
 #[cfg(not(feature = "automation_event_test"))]
-#[cfg(not(feature = "custom_frame_control"))]
+#[cfg(not(feature = "SUPPORT_CUSTOM_FRAME_CONTROL"))]
 pub fn test_runner(tests: &[&dyn Testable]) {
     use crate::callbacks;
 

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raylib"
-version = "5.5.1"
+version = "5.5.2"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 readme = "../README.md"
@@ -9,11 +9,11 @@ documentation = "https://docs.rs/raylib"
 repository = "https://github.com/raylib-rs/raylib-rs"
 keywords = ["bindings", "raylib", "gamedev"]
 categories = ["api-bindings", "game-engines", "graphics"]
-edition = "2018"
+edition = "2021"
 autoexamples = false
 
 [dependencies]
-raylib-sys = { version = "5.5.1", path = "../raylib-sys" }
+raylib-sys = { version = "5.5.2", path = "../raylib-sys", default-features = false }
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 imgui = { version = "0.12.0", optional = true, features = [] }
@@ -31,19 +31,104 @@ structopt = "0.3"
 rand = "0.8.5"
 
 [features]
-nightly = []
-with_serde = ["serde", "serde_json"]
-wayland = ["raylib-sys/wayland"]
+# use raylib-sys defaults instead of setting it in dependencies so we can turn it off at the raylib crate level since `raylib-sys` is not exposed
+default = ["raylib-sys/default"]
 convert_mint = ["mint"]
-custom_frame_control = ["raylib-sys/custom_frame_control"]
-opengl_33 = ["raylib-sys/opengl_33"]
-opengl_21 = ["raylib-sys/opengl_21"]
-opengl_es_20 = ["raylib-sys/opengl_es_20"]
-opengl_es_30 = ["raylib-sys/opengl_es_30"]
-sdl = ["raylib-sys/sdl"]
-noscreenshot = ["raylib-sys/noscreenshot"]
-nogif = ["raylib-sys/nogif"]
+nightly = []
+serde = ["dep:serde"]
 imgui = ["raylib-sys/imgui", "dep:imgui", "dep:imgui-sys"]
+
+# ----- Copy and paste these from `raylib-sys` for easier maintance
+# Build Raylib headless for docs/esoteric platforms. Up to you to link.
 nobuild = ["raylib-sys/nobuild"]
-bindgen = ["raylib-sys/bindgen"]
-default = ["bindgen"]
+
+# opengl stuff
+opengl_11 = ["raylib-sys/opengl_11"] # buggy? might not work with wayland
+opengl_21 = ["raylib-sys/opengl_21"]
+opengl_33 = ["raylib-sys/opengl_33"]
+opengl_43 = ["raylib-sys/opengl_43"]
+opengl_es_30 = ["raylib-sys/opengl_es_30"]
+opengl_es_20 = ["raylib-sys/opengl_es_20"]
+sdl = ["raylib-sys/sdl"]
+wayland = ["raylib-sys/wayland"]
+
+# extra build profiles:
+release_with_debug_info = ["raylib-sys/release_with_debug_info"]
+min_size_rel = ["raylib-sys/min_size_rel"]
+
+ENABLE_ASAN = ["raylib-sys/ENABLE_ASAN"]
+ENABLE_UBSAN = ["raylib-sys/ENABLE_UBSAN"]
+ENABLE_MSAN = ["raylib-sys/ENABLE_MSAN"]
+WITH_PIC = ["raylib-sys/WITH_PIC"]
+BUILD_SHARED_LIBS = ["raylib-sys/BUILD_SHARED_LIBS"]
+USE_EXTERNAL_GLFW = ["raylib-sys/USE_EXTERNAL_GLFW"]
+GLFW_BUILD_WAYLAND = ["raylib-sys/GLFW_BUILD_WAYLAND"]
+GLFW_BUILD_X11 = ["raylib-sys/GLFW_BUILD_X11"]
+INCLUDE_EVERYTHING = ["raylib-sys/INCLUDE_EVERYTHING"]
+
+USE_AUDIO = ["raylib-sys/USE_AUDIO"]
+SUPPORT_MODULE_RSHAPES  = ["raylib-sys/SUPPORT_MODULE_RSHAPES"]
+SUPPORT_MODULE_RTEXTURES = ["raylib-sys/SUPPORT_MODULE_RTEXTURES"]
+SUPPORT_MODULE_RTEXT = ["raylib-sys/SUPPORT_MODULE_RTEXT"]
+SUPPORT_MODULE_RMODELS = ["raylib-sys/SUPPORT_MODULE_RMODELS"]
+SUPPORT_MODULE_RAUDIO = ["raylib-sys/SUPPORT_MODULE_RAUDIO"]
+SUPPORT_BUSY_WAIT_LOOP = ["raylib-sys/SUPPORT_BUSY_WAIT_LOOP"]
+SUPPORT_CAMERA_SYSTEM = ["raylib-sys/SUPPORT_CAMERA_SYSTEM"]
+SUPPORT_GESTURES_SYSTEM = ["raylib-sys/SUPPORT_GESTURES_SYSTEM"]
+SUPPORT_RPRAND_GENERATOR = ["raylib-sys/SUPPORT_RPRAND_GENERATOR"]
+SUPPORT_MOUSE_GESTURES = ["raylib-sys/SUPPORT_MOUSE_GESTURES"]
+SUPPORT_SSH_KEYBOARD_RPI = ["raylib-sys/SUPPORT_SSH_KEYBOARD_RPI"]
+SUPPORT_WINMM_HIGHRES_TIMER = ["raylib-sys/SUPPORT_WINMM_HIGHRES_TIMER"]
+SUPPORT_PARTIALBUSY_WAIT_LOOP = ["raylib-sys/SUPPORT_PARTIALBUSY_WAIT_LOOP"]
+SUPPORT_GIF_RECORDING = ["raylib-sys/SUPPORT_GIF_RECORDING"]
+SUPPORT_COMPRESSION_API = ["raylib-sys/SUPPORT_COMPRESSION_API"]
+SUPPORT_AUTOMATION_EVENTS = ["raylib-sys/SUPPORT_AUTOMATION_EVENTS"]
+SUPPORT_CUSTOM_FRAME_CONTROL = ["raylib-sys/SUPPORT_CUSTOM_FRAME_CONTROL"]
+SUPPORT_CLIPBOARD_IMAGE = ["raylib-sys/SUPPORT_CLIPBOARD_IMAGE"]
+SUPPORT_QUADS_DRAW_MODE = ["raylib-sys/SUPPORT_QUADS_DRAW_MODE"]
+SUPPORT_FILEFORMAT_PNG = ["raylib-sys/SUPPORT_FILEFORMAT_PNG"]
+SUPPORT_FILEFORMAT_BMP = ["raylib-sys/SUPPORT_FILEFORMAT_BMP"]
+SUPPORT_FILEFORMAT_TGA = ["raylib-sys/SUPPORT_FILEFORMAT_TGA"]
+SUPPORT_FILEFORMAT_JPG = ["raylib-sys/SUPPORT_FILEFORMAT_JPG"]
+SUPPORT_FILEFORMAT_GIF = ["raylib-sys/SUPPORT_FILEFORMAT_GIF"]
+SUPPORT_FILEFORMAT_QOI = ["raylib-sys/SUPPORT_FILEFORMAT_QOI"]
+SUPPORT_FILEFORMAT_PSD = ["raylib-sys/SUPPORT_FILEFORMAT_PSD"]
+SUPPORT_FILEFORMAT_DDS = ["raylib-sys/SUPPORT_FILEFORMAT_DDS"]
+SUPPORT_FILEFORMAT_HDR = ["raylib-sys/SUPPORT_FILEFORMAT_HDR"]
+SUPPORT_FILEFORMAT_PIC = ["raylib-sys/SUPPORT_FILEFORMAT_PIC"]
+SUPPORT_FILEFORMAT_KTX = ["raylib-sys/SUPPORT_FILEFORMAT_KTX"]
+SUPPORT_FILEFORMAT_ASTC = ["raylib-sys/SUPPORT_FILEFORMAT_ASTC"]
+SUPPORT_FILEFORMAT_PKM = ["raylib-sys/SUPPORT_FILEFORMAT_PKM"]
+SUPPORT_FILEFORMAT_PVR = ["raylib-sys/SUPPORT_FILEFORMAT_PVR"]
+SUPPORT_IMAGE_EXPORT = ["raylib-sys/SUPPORT_IMAGE_EXPORT"]
+SUPPORT_IMAGE_GENERATION = ["raylib-sys/SUPPORT_IMAGE_GENERATION"]
+SUPPORT_IMAGE_MANIPULATION = ["raylib-sys/SUPPORT_IMAGE_MANIPULATION"]
+SUPPORT_DEFAULT_FONT = ["raylib-sys/SUPPORT_DEFAULT_FONT"]
+SUPPORT_FILEFORMAT_TTF = ["raylib-sys/SUPPORT_FILEFORMAT_TTF"]
+SUPPORT_FILEFORMAT_FNT = ["raylib-sys/SUPPORT_FILEFORMAT_FNT"]
+SUPPORT_FILEFORMAT_BDF = ["raylib-sys/SUPPORT_FILEFORMAT_BDF"]
+SUPPORT_TEXT_MANIPULATION = ["raylib-sys/SUPPORT_TEXT_MANIPULATION"]
+SUPPORT_FONT_ATLAS_WHITE_REC = ["raylib-sys/SUPPORT_FONT_ATLAS_WHITE_REC"]
+SUPPORT_FILEFORMAT_OBJ = ["raylib-sys/SUPPORT_FILEFORMAT_OBJ"]
+SUPPORT_FILEFORMAT_MTL = ["raylib-sys/SUPPORT_FILEFORMAT_MTL"]
+SUPPORT_FILEFORMAT_IQM = ["raylib-sys/SUPPORT_FILEFORMAT_IQM"]
+SUPPORT_FILEFORMAT_GLTF = ["raylib-sys/SUPPORT_FILEFORMAT_GLTF"]
+SUPPORT_FILEFORMAT_VOX = ["raylib-sys/SUPPORT_FILEFORMAT_VOX"]
+SUPPORT_FILEFORMAT_M3D = ["raylib-sys/SUPPORT_FILEFORMAT_M3D"]
+SUPPORT_MESH_GENERATION = ["raylib-sys/SUPPORT_MESH_GENERATION"]
+SUPPORT_FILEFORMAT_WAV = ["raylib-sys/SUPPORT_FILEFORMAT_WAV"]
+SUPPORT_FILEFORMAT_OGG = ["raylib-sys/SUPPORT_FILEFORMAT_OGG"]
+SUPPORT_FILEFORMAT_MP3 = ["raylib-sys/SUPPORT_FILEFORMAT_MP3"]
+SUPPORT_FILEFORMAT_QOA = ["raylib-sys/SUPPORT_FILEFORMAT_QOA"]
+SUPPORT_FILEFORMAT_FLAC = ["raylib-sys/SUPPORT_FILEFORMAT_FLAC"]
+SUPPORT_FILEFORMAT_XM = ["raylib-sys/SUPPORT_FILEFORMAT_XM"]
+SUPPORT_FILEFORMAT_MOD = ["raylib-sys/SUPPORT_FILEFORMAT_MOD"]
+SUPPORT_STANDARD_FILEIO = ["raylib-sys/SUPPORT_STANDARD_FILEIO"]
+SUPPORT_TRACELOG = ["raylib-sys/SUPPORT_TRACELOG"]
+SUPPORT_SCREEN_CAPTURE = ["raylib-sys/SUPPORT_SCREEN_CAPTURE"]
+SUPPORT_VR_SIMULATOR = ["raylib-sys/SUPPORT_VR_SIMULATOR"]
+SUPPORT_DISTORTION_SHADER = ["raylib-sys/SUPPORT_DISTORTION_SHADER"]
+SUPPORT_FONT_TEXTURE = ["raylib-sys/SUPPORT_FONT_TEXTURE"]
+
+[package.metadata.docs.rs]
+features = ["nobuild"]

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -19,7 +19,7 @@ use crate::misc::AsF32;
 use std::f32::consts::PI;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Range, Sub, SubAssign};
 
-#[cfg(feature = "with_serde")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 make_rslice!(RSliceVec4, Vector4, ffi::MemFree);
@@ -28,7 +28,7 @@ macro_rules! optional_serde_struct {
     ($def:item) => {
         #[repr(C)]
         #[derive(Default, Debug, Copy, Clone, PartialEq)]
-        #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         $def
     };
 }
@@ -568,9 +568,13 @@ impl Vector3 {
 
     /// Calculate angle between two vectors
     pub fn angle_to(&self, v2: Vector3) -> f32 {
-        let cross = Vector3 { x: self.y*v2.z - self.z*v2.y, y: self.z*v2.x - self.x*v2.z, z: self.x*v2.y - self.y*v2.x };
-        let len = (cross.x*cross.x + cross.y*cross.y + cross.z*cross.z).sqrt();
-        let dot = self.x*v2.x + self.y*v2.y + self.z*v2.z;
+        let cross = Vector3 {
+            x: self.y * v2.z - self.z * v2.y,
+            y: self.z * v2.x - self.x * v2.z,
+            z: self.x * v2.y - self.y * v2.x,
+        };
+        let len = (cross.x * cross.x + cross.y * cross.y + cross.z * cross.z).sqrt();
+        let dot = self.x * v2.x + self.y * v2.y + self.z * v2.z;
         return len.atan2(dot);
     }
 

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -848,7 +848,7 @@ impl RaylibHandle {
 // NOTE: Those functions are intended for advanced users that want full control over the frame processing
 // By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
 // To avoid that behaviour and control frame processes manually, enable in config.h: SUPPORT_CUSTOM_FRAME_CONTROL
-#[cfg(feature = "custom_frame_control")]
+#[cfg(feature = "SUPPORT_CUSTOM_FRAME_CONTROL")]
 impl RaylibHandle {
     /// Swap back buffer with front buffer (screen drawing)
     /// This function, by default, is already done when the handle is dropped.

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -74,9 +74,7 @@ pub use crate::core::misc::open_url;
 pub use crate::core::*;
 
 // Re-exports
-#[cfg(feature = "nalgebra_interop")]
-pub use nalgebra as na;
-#[cfg(feature = "with_serde")]
+#[cfg(feature = "serde")]
 pub use serde;
 
 #[cfg(feature = "imgui")]

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raylib-examples"
-version = "5.5.1"
+version = "5.5.2"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 edition = "2021"
 license = "Zlib"
@@ -9,7 +9,7 @@ repository = "https://github.com/raylib-rs/raylib-rs"
 
 
 [dependencies]
-raylib = { path = "../raylib", version = "5.5.1" }
+raylib = { path = "../raylib", version = "5.5.2" }
 structopt = "0.2"
 specs-derive = "0.4.1"
 rand = "0.8"

--- a/showcase/Cargo.toml
+++ b/showcase/Cargo.toml
@@ -2,7 +2,7 @@
 name = "raylib-showcase"
 version = "5.5.1"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
-edition = "2018"
+edition = "2021"
 license = "Zlib"
 readme = "../README.md"
 repository = "https://github.com/raylib-rs/raylib-rs"


### PR DESCRIPTION
# Build overhaul
- Upgrade: edition to 2018 -> 2021
- Removed: `LATEST_RAYLIB_VERSION`and `LATEST_RAYLIB_API_VERSION` as these were un-unused and it was confusing whether these needed to be set or not. Instead, users should look at Cargo.toml or the git checkout submodule
- Added build modes: `release_with_debug_info`, `min_size_rel`
- All customizable raylib config features have been exposed in `Cargo.toml` of `raylib-sys` & `raylib`. This however means we have to turn everything `OFF` by default and that all builds are now custom builds, but it's more flexible and fixes various issues with defaults
- Removed a lot of code that set things `OFF` by default as this should now be done with feature flags
- Added: `opengl_11`, `opengl_43`
- Replaced: `noscreenshot`, `nogif`, in favor of flags closer to raylibs spelling for easier maintenance
- Removed: `nobuild` main.rs duplicate function. Also other build functions already are stubbed out with `nobuild` so doing it for main is unnecessary
- Rename: `with_serde` to just `serde` to align with how other crates expose serde features
overhaul
- Removed: a lot of dead build code, old nalgebra interpo, etc

# Why?
People can start toggling 99% of the cmake config raylib stuff just from their own projects `Cargo.toml` now opposed to needing to dive into `raylib-sys` all the time. For example:
```toml
# Cargo.toml
raylib = { version = "5.5.2", path = "./raylib", default-features = false, features = [
  "serde",
  "GLFW_BUILD_X11",
  "SUPPORT_MODULE_RSHAPES",
  "SUPPORT_MODULE_RTEXTURES",
  "SUPPORT_MODULE_RTEXT",
  "SUPPORT_CAMERA_SYSTEM",
  "SUPPORT_GESTURES_SYSTEM",
  "SUPPORT_MOUSE_GESTURES",
  "SUPPORT_WINMM_HIGHRES_TIMER",
  "SUPPORT_SCREEN_CAPTURE",
  "SUPPORT_GIF_RECORDING",
  "SUPPORT_AUTOMATION_EVENTS",
  "SUPPORT_CLIPBOARD_IMAGE",
  "SUPPORT_QUADS_DRAW_MODE",
  "SUPPORT_FILEFORMAT_PNG",
  "SUPPORT_IMAGE_EXPORT",
  "SUPPORT_IMAGE_GENERATION",
  "SUPPORT_IMAGE_MANIPULATION",
  "SUPPORT_DEFAULT_FONT",
  "SUPPORT_FILEFORMAT_TTF",
  "SUPPORT_TEXT_MANIPULATION",
  "SUPPORT_FONT_ATLAS_WHITE_REC",
  # "SUPPORT_MESH_GENERATION",
  "SUPPORT_STANDARD_FILEIO",
  "SUPPORT_TRACELOG",] }
```
This is what I do for configuring custom builds now, just do `default-features = false` and only list out the ones you want. Because default-features is disabled, everything will be set to `OFF`. I use FMOD audio instead of raylibs audio stuff so I just don't have raudio listed here, thus its removed