### PR TITLE
fixed raygui textbox not being able to take input

### DIFF
--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -35,6 +35,7 @@ path = "./specs.rs"
 [[bin]]
 name = "rgui"
 path = "./rgui.rs"
+required-features = ["raylib/raygui"]
 
 [[bin]]
 name = "arkanoid"


### PR DESCRIPTION
https://discord.com/channels/426912293134270465/540620507708522517/1379118072878731366
The problem was with not passing in null terminated strings. `gui_text_input_box` now sticks in a null terminator and then pops it back out at the end of the function. This is what dearimguid does so we'll do the same to keep the api nice to deal with in rust