### PR TITLE
Move Rectangle from raylib-sys -> raylib safe bindings and Add Rectangle methods

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -64,7 +64,6 @@ impl ParseCallbacks for TypeOverrideCallback {
             "Vector4",
             "Matrix",
             "Quaternion",
-            "Rectangle",
             "Color",
         ];
 
@@ -284,7 +283,6 @@ fn gen_bindings() {
         .blocklist_type("Vector4")
         .blocklist_type("Matrix")
         .blocklist_type("Quaternion")
-        .blocklist_type("Rectangle")
         .blocklist_type("Color")
         .parse_callbacks(Box::new(TypeOverrideCallback))
         // Tell cargo to invalidate the built crate whenever any of the

--- a/raylib-sys/src/math.rs
+++ b/raylib-sys/src/math.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 // pub use glam;
 // pub type Vector2 = glam::f32::Vec2;
 // pub type Vector3 = glam::f32::Vec3;
@@ -8,69 +6,9 @@ use serde::{Deserialize, Serialize};
 // glam Matrix and Quat are not align compat with raylib so we write our own in math.rs
 // pub type Matrix = glam::Mat4;
 // pub type Quaternion = glam::Quat;
-
 pub use mint;
 pub type Vector2 = mint::Vector2<f32>;
 pub type Vector3 = mint::Vector3<f32>;
 pub type Vector4 = mint::Vector4<f32>;
 pub type Matrix = mint::RowMatrix4<f32>;
 pub type Quaternion = mint::Vector4<f32>; // raylib does this same alias so we match it
-
-#[repr(C)]
-#[derive(Default, Debug, Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Rectangle {
-    pub x: f32,
-    pub y: f32,
-    pub width: f32,
-    pub height: f32,
-}
-
-impl Rectangle {
-    #[must_use]
-    pub fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
-        Self {
-            x,
-            y,
-            width,
-            height,
-        }
-    }
-
-    /// Check collision between two rectangles
-    #[inline]
-    #[must_use]
-    pub fn check_collision_recs(&self, other: Rectangle) -> bool {
-        unsafe { crate::CheckCollisionRecs(*self, other) }
-    }
-
-    /// Checks collision between circle and rectangle.
-    #[inline]
-    #[must_use]
-    pub fn check_collision_circle_rec(&self, center: impl Into<Vector2>, radius: f32) -> bool {
-        unsafe { crate::CheckCollisionCircleRec(center.into(), radius, *self) }
-    }
-
-    /// Gets the overlap between two colliding rectangles.
-    /// ```rust
-    /// use raylib_sys::Rectangle;
-    ///
-    /// let r1 = Rectangle::new(0.0, 0.0, 10.0, 10.0);
-    /// let r2 = Rectangle::new(20.0, 20.0, 10.0, 10.0);
-    /// assert_eq!(None, r1.get_collision_rec(r2));
-    /// assert_eq!(Some(r1), r1.get_collision_rec(r1));
-    /// ```
-    #[inline]
-    #[must_use]
-    pub fn get_collision_rec(&self, other: Rectangle) -> Option<Rectangle> {
-        self.check_collision_recs(other)
-            .then(|| unsafe { crate::GetCollisionRec(*self, other) })
-    }
-
-    /// Checks if point is inside rectangle.
-    #[inline]
-    #[must_use]
-    pub fn check_collision_point_rec(&self, point: impl Into<Vector2>) -> bool {
-        unsafe { crate::CheckCollisionPointRec(point.into(), *self) }
-    }
-}

--- a/raylib-sys/src/math.rs
+++ b/raylib-sys/src/math.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "serde")]
 // pub use glam;
 // pub type Vector2 = glam::f32::Vec2;
 // pub type Vector3 = glam::f32::Vec3;

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1245,8 +1245,10 @@ impl From<&Rectangle> for ffi::Rectangle {
 }
 
 impl Rectangle {
+    /// Rectangle with all components set to zero
     pub const ZERO: Self = Rectangle::new(0.0, 0.0, 0.0, 0.0);
-    /// Creates a new rectangle from position and size.
+   
+    /// Creates a new rectangle from position and size
     #[must_use]
     #[inline(always)]
     pub const fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
@@ -1258,7 +1260,7 @@ impl Rectangle {
         }
     }
 
-    /// Creates a rectangle from position and size vectors.
+    /// Creates a rectangle from position and size vectors
     #[must_use]
     #[inline(always)]
     pub fn v2(pos: impl Into<MintVec2>, dims: impl Into<MintVec2>) -> Self {
@@ -1272,8 +1274,9 @@ impl Rectangle {
         }
     }
 
-    /// Returns the position as a `Vector2`.
-    /// Alt name: [Self::pos]
+    /// Returns the position as a [`Vector2`]
+    ///
+    /// Alias: [`Self::pos`]
     #[must_use]
     #[inline(always)]
     pub const fn xy(self) -> Vector2 {
@@ -1283,15 +1286,16 @@ impl Rectangle {
         }
     }
 
-    /// Returns the position as a `Vector2`.
+    /// Returns the position as a [`Vector2`]
+    ///
+    /// Alias: [`Self::xy`]
     #[must_use]
     #[inline(always)]
-    /// Alt name: [Self::xy]
     pub const fn pos(self) -> Vector2 {
         self.xy()
     }
 
-    /// Returns the width & height as a `Vector2`.
+    /// Returns the width & height as a [`Vector2`]
     #[must_use]
     #[inline(always)]
     pub const fn size(self) -> Vector2 {
@@ -1301,7 +1305,7 @@ impl Rectangle {
         }
     }
 
-    /// Returns the bottom right corner by adding x&y to w&h
+    /// Returns the bottom right corner by adding x & y to width & height
     #[must_use]
     #[inline(always)]
     pub const fn max(self) -> Vector2 {
@@ -1311,9 +1315,9 @@ impl Rectangle {
         }
     }
 
+    /// Returns the half the width & height as a [`Vector2`]
     #[must_use]
     #[inline(always)]
-    /// Returns the half the width & height as a `Vector2`.
     pub fn half_size(self) -> Vector2 {
         self.size() / 2.0
     }
@@ -1330,7 +1334,8 @@ impl Rectangle {
             height: self.height,
         }
     }
-    /// Returns a copy with the given `x` and `y`.
+
+    /// Returns a copy with the given `x` and `y`
     #[must_use]
     #[inline(always)]
     pub const fn with_xy(self, x: f32, y: f32) -> Self {
@@ -1355,7 +1360,7 @@ impl Rectangle {
         }
     }
 
-    /// Returns a copy with the given `width` and `height`.
+    /// Returns a copy with the given `width` and `height`
     #[must_use]
     #[inline(always)]
     pub const fn with_wh(self, width: f32, height: f32) -> Self {
@@ -1368,134 +1373,93 @@ impl Rectangle {
     }
 
     /// Check collision between two rectangles
-    /// Shorter alias name: [Self::overlap]
+    ///
+    /// Alias: [`Self::overlap`]
     #[inline(always)]
     #[must_use]
     pub fn check_collision_recs(self, other: impl Into<ffi::Rectangle>) -> bool {
-        //unsafe { ffi::CheckCollisionRecs(self.into(), other.into()) }
-        let rec1 = self;
-        let rec2 = other.into();
-        (rec1.x < (rec2.x + rec2.width) && (rec1.x + rec1.width) > rec2.x)
-            && (rec1.y < (rec2.y + rec2.height) && (rec1.y + rec1.height) > rec2.y)
+        unsafe { ffi::CheckCollisionRecs(self.into(), other.into()) }
     }
 
     /// Check collision between two rectangles
-    /// Alias of [Self::check_collision_recs]
-    /// Use [Self::get_overlap_area] if you want the region of collision
+    ///
+    /// Alias: [`Self::check_collision_recs`]
+    ///
+    /// Use [`Self::get_overlap_area`] if you want the region of collision
     #[inline(always)]
     #[must_use]
     pub fn overlap(self, other: impl Into<ffi::Rectangle>) -> bool {
         self.check_collision_recs(other)
     }
 
-    /// Checks collision between circle and rectangle.
-    /// Shorter alias name: [Self::overlaps_circle]
+    /// Checks collision between circle and rectangle
+    ///
+    /// Alias: [`Self::overlaps_circle`]
     #[inline(always)]
     #[must_use]
     pub fn check_collision_circle_rec(self, center: impl Into<MintVec2>, radius: f32) -> bool {
-        //unsafe { ffi::CheckCollisionCircleRec(center.into(), radius, self.into()) }
-        let rec = self;
-        let center = center.into();
-        let collision;
-
-        let rec_center_x = rec.x + rec.width / 2.0;
-        let rec_center_y = rec.y + rec.height / 2.0;
-
-        let dx = (center.x - rec_center_x).abs();
-        let dy = (center.y - rec_center_y).abs();
-
-        if dx > (rec.width / 2.0 + radius) {
-            return false;
-        }
-        if dy > (rec.height / 2.0 + radius) {
-            return false;
-        }
-
-        if dx <= (rec.width / 2.0) {
-            return true;
-        }
-        if dy <= (rec.height / 2.0) {
-            return true;
-        }
-
-        let corner_distance_sq = (dx - rec.width / 2.0) * (dx - rec.width / 2.0)
-            + (dy - rec.height / 2.0) * (dy - rec.height / 2.0);
-
-        collision = corner_distance_sq <= (radius * radius);
-
-        return collision;
+        unsafe { ffi::CheckCollisionCircleRec(center.into(), radius, self.into()) }
     }
 
+    /// Checks collision between circle and rectangle
+    ///
+    /// Alias: [`Self::check_collision_circle_rec`]
     #[inline(always)]
     #[must_use]
-    /// Checks collision between circle and rectangle.
-    /// alias for [Self::check_collision_circle_rec]
     pub fn overlaps_circle(self, center: impl Into<MintVec2>, radius: f32) -> bool {
         self.check_collision_circle_rec(center, radius)
     }
 
-    /// Checks if point is inside rectangle.
-    /// Shorter alias name: [Self::contains_point]
+    /// Checks if point is inside rectangle
+    ///
+    /// Alias: [`Self::contains_point`]
     #[inline(always)]
     #[must_use]
     pub fn check_collision_point_rec(self, point: impl Into<MintVec2>) -> bool {
-        //unsafe { ffi::CheckCollisionPointRec(point.into(), self.into()) }
-        let point = point.into();
-        (point.x >= self.x)
-            && (point.x < (self.x + self.width))
-            && (point.y >= self.y)
-            && (point.y < (self.y + self.height))
+        unsafe { ffi::CheckCollisionPointRec(point.into(), self.into()) }
     }
 
-    /// Checks if point is inside rectangle.
-    /// alias for [Self::check_collision_point_rec]
+    /// Checks if point is inside rectangle
+    ///
+    /// Alias: [`Self::check_collision_point_rec`]
     #[inline(always)]
     #[must_use]
     pub fn contains_point(self, point: impl Into<MintVec2>) -> bool {
         self.check_collision_point_rec(point)
     }
-    /// Gets the overlap between two colliding rectangles.
-    /// Shorter alias name: [Self::get_overlap_area]
-    /// ```rust
-    /// use raylib::core::math::Rectangle;
+
+    /// Gets the overlap between two colliding rectangles
+    ///
+    /// Alias: [`Self::get_overlap_area`]
+    ///
+    /// # Example
+    /// ```
+    /// #use raylib::core::math::Rectangle;
     /// let r1 = Rectangle::new(0.0, 0.0, 10.0, 10.0);
     /// let r2 = Rectangle::new(20.0, 20.0, 10.0, 10.0);
-    /// assert_eq!(None, r1.get_collision_rec(r2));
-    /// assert_eq!(Some(r1), r1.get_collision_rec(r1));
+    /// assert_eq!(r1.get_collision_rec(r2), None);
+    /// assert_eq!(r1.get_collision_rec(r1), Some(r1));
     /// ```
     #[inline]
     #[must_use]
     pub fn get_collision_rec(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
-        //unsafe { ffi::GetCollisionRec(self.into(), other.into()) }
-        let rec1 = self;
-        let rec2 = other.into();
-
-        let left = if rec1.x > rec2.x { rec1.x } else { rec2.x };
-        let right1 = rec1.x + rec1.width;
-        let right2 = rec2.x + rec2.width;
-        let right = if right1 < right2 { right1 } else { right2 };
-        let top = if rec1.y > rec2.y { rec1.y } else { rec2.y };
-        let bottom1 = rec1.y + rec1.height;
-        let bottom2 = rec2.y + rec2.height;
-        let bottom = if bottom1 < bottom2 { bottom1 } else { bottom2 };
-
-        if (left < right) && (top < bottom) {
-            let overlap = Rectangle::new(left, top, right - left, bottom - top);
-            return Some(overlap);
-        }
-        return None;
+        let rec = unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() }
+        (rec != Self::ZERO).then_some(rec)
     }
+
+    /// Gets the overlap between two colliding rectangles
+    ///
+    /// Alias: [`Self::get_collision_rec`]
+    ///
+    /// Use [`Self::overlap`] if you don't care about the overlap area
     #[inline]
     #[must_use]
-    /// Gets the overlap between two colliding rectangles.
-    /// Shorter alias name: [Self::get_collision_rec]
-    /// Use [Self::overlap] if you don't care about the overlap area
     pub fn get_overlap_area(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
         self.get_collision_rec(other)
     }
 }
 
-/// Creates a [Rectangle] from any number type by loosely casting "as f32"
+/// Creates a [`Rectangle`] from any number type by loosely casting `as f32`
 #[must_use]
 #[inline(always)]
 pub fn rrect<T1: AsF32, T2: AsF32, T3: AsF32, T4: AsF32>(
@@ -1507,16 +1471,16 @@ pub fn rrect<T1: AsF32, T2: AsF32, T3: AsF32, T4: AsF32>(
     Rectangle::new(x.as_f32(), y.as_f32(), width.as_f32(), height.as_f32())
 }
 
+/// Shorthand for creating a [`Rectangle`] from `f32`s
 #[must_use]
 #[inline(always)]
-/// Shorthand for creating a rectangle [Rectangle]
 pub const fn rectf(x: f32, y: f32, width: f32, height: f32) -> Rectangle {
     Rectangle::new(x, y, width, height)
 }
 
+/// Shorthand for creating a [`Rectangle`] from vectors
 #[must_use]
 #[inline(always)]
-/// Shorthand for creating a rectangle [Rectangle] with [Vector2]'s
 pub fn rectv(pos: impl Into<MintVec2>, size: impl Into<MintVec2>) -> Rectangle {
     Rectangle::v2(pos, size)
 }

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -15,7 +15,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 */
 
 use crate::misc::AsF32;
-use crate::{ffi, MintVec3};
+use crate::{MintVec2, MintVec3, ffi};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Range, Sub, SubAssign};
 
 #[cfg(feature = "serde")]
@@ -1088,8 +1088,6 @@ impl Ray {
     }
 }
 
-pub type Rectangle = ffi::Rectangle;
-
 optional_serde_struct! {
     /// BoundingBox
     pub struct BoundingBox {
@@ -1213,6 +1211,314 @@ impl From<&Transform> for ffi::Transform {
     fn from(v: &Transform) -> ffi::Transform {
         unsafe { std::mem::transmute(*v) }
     }
+}
+
+optional_serde_struct! {
+    /// Rectangle, 4 components
+    pub struct Rectangle {
+        pub x: f32,
+        pub y: f32,
+        pub width: f32,
+        pub height: f32,
+    }
+}
+
+impl From<ffi::Rectangle> for Rectangle {
+    #[inline(always)]
+    fn from(r: ffi::Rectangle) -> Self {
+        unsafe { std::mem::transmute(r) }
+    }
+}
+
+impl From<Rectangle> for ffi::Rectangle {
+    #[inline(always)]
+    fn from(v: Rectangle) -> Self {
+        unsafe { std::mem::transmute(v) }
+    }
+}
+
+impl From<&Rectangle> for ffi::Rectangle {
+    #[inline(always)]
+    fn from(v: &Rectangle) -> Self {
+        unsafe { std::mem::transmute(*v) }
+    }
+}
+
+impl Rectangle {
+    pub const ZERO: Self = Rectangle::new(0.0, 0.0, 0.0, 0.0);
+    /// Creates a new rectangle from position and size.
+    #[must_use]
+    #[inline(always)]
+    pub const fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Creates a rectangle from position and size vectors.
+    #[must_use]
+    #[inline(always)]
+    pub fn v2(pos: impl Into<MintVec2>, dims: impl Into<MintVec2>) -> Self {
+        let pos = pos.into();
+        let dims = dims.into();
+        Self {
+            x: pos.x,
+            y: pos.y,
+            width: dims.x,
+            height: dims.y,
+        }
+    }
+
+    /// Returns the position as a `Vector2`.
+    /// Alt name: [Self::pos]
+    #[must_use]
+    #[inline(always)]
+    pub const fn xy(self) -> Vector2 {
+        Vector2 {
+            x: self.x,
+            y: self.y,
+        }
+    }
+
+    /// Returns the position as a `Vector2`.
+    #[must_use]
+    #[inline(always)]
+    /// Alt name: [Self::xy]
+    pub const fn pos(self) -> Vector2 {
+        self.xy()
+    }
+
+    /// Returns the width & height as a `Vector2`.
+    #[must_use]
+    #[inline(always)]
+    pub const fn size(self) -> Vector2 {
+        Vector2 {
+            x: self.width,
+            y: self.height,
+        }
+    }
+
+    /// Returns the bottom right corner by adding x&y to w&h
+    #[must_use]
+    #[inline(always)]
+    pub const fn max(self) -> Vector2 {
+        Vector2 {
+            x: self.x + self.width,
+            y: self.y + self.height,
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    /// Returns the half the width & height as a `Vector2`.
+    pub fn half_size(self) -> Vector2 {
+        self.size() / 2.0
+    }
+
+    /// Returns a copy with changed x & y given the vector
+    #[must_use]
+    #[inline(always)]
+    pub fn with_pos(self, pos: impl Into<MintVec2>) -> Self {
+        let pos = pos.into();
+        Self {
+            x: pos.x,
+            y: pos.y,
+            width: self.width,
+            height: self.height,
+        }
+    }
+    /// Returns a copy with the given `x` and `y`.
+    #[must_use]
+    #[inline(always)]
+    pub const fn with_xy(self, x: f32, y: f32) -> Self {
+        Self {
+            x,
+            y,
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    /// Returns a copy with changed width & height given the vector
+    #[must_use]
+    #[inline(always)]
+    pub fn with_size(self, size: impl Into<MintVec2>) -> Self {
+        let size = size.into();
+        Self {
+            x: self.x,
+            y: self.y,
+            width: size.x,
+            height: size.y,
+        }
+    }
+
+    /// Returns a copy with the given `width` and `height`.
+    #[must_use]
+    #[inline(always)]
+    pub const fn with_wh(self, width: f32, height: f32) -> Self {
+        Self {
+            x: self.x,
+            y: self.y,
+            width,
+            height,
+        }
+    }
+
+    /// Check collision between two rectangles
+    /// Shorter alias name: [Self::overlap]
+    #[inline(always)]
+    #[must_use]
+    pub fn check_collision_recs(self, other: impl Into<ffi::Rectangle>) -> bool {
+        //unsafe { ffi::CheckCollisionRecs(self.into(), other.into()) }
+        let rec1 = self;
+        let rec2 = other.into();
+        (rec1.x < (rec2.x + rec2.width) && (rec1.x + rec1.width) > rec2.x)
+            && (rec1.y < (rec2.y + rec2.height) && (rec1.y + rec1.height) > rec2.y)
+    }
+
+    /// Check collision between two rectangles
+    /// Alias of [Self::check_collision_recs]
+    /// Use [Self::get_overlap_area] if you want the region of collision
+    #[inline(always)]
+    #[must_use]
+    pub fn overlap(self, other: impl Into<ffi::Rectangle>) -> bool {
+        self.check_collision_recs(other)
+    }
+
+    /// Checks collision between circle and rectangle.
+    /// Shorter alias name: [Self::overlaps_circle]
+    #[inline(always)]
+    #[must_use]
+    pub fn check_collision_circle_rec(self, center: impl Into<MintVec2>, radius: f32) -> bool {
+        //unsafe { ffi::CheckCollisionCircleRec(center.into(), radius, self.into()) }
+        let rec = self;
+        let center = center.into();
+        let collision;
+
+        let rec_center_x = rec.x + rec.width / 2.0;
+        let rec_center_y = rec.y + rec.height / 2.0;
+
+        let dx = (center.x - rec_center_x).abs();
+        let dy = (center.y - rec_center_y).abs();
+
+        if dx > (rec.width / 2.0 + radius) {
+            return false;
+        }
+        if dy > (rec.height / 2.0 + radius) {
+            return false;
+        }
+
+        if dx <= (rec.width / 2.0) {
+            return true;
+        }
+        if dy <= (rec.height / 2.0) {
+            return true;
+        }
+
+        let corner_distance_sq = (dx - rec.width / 2.0) * (dx - rec.width / 2.0)
+            + (dy - rec.height / 2.0) * (dy - rec.height / 2.0);
+
+        collision = corner_distance_sq <= (radius * radius);
+
+        return collision;
+    }
+
+    #[inline(always)]
+    #[must_use]
+    /// Checks collision between circle and rectangle.
+    /// alias for [Self::check_collision_circle_rec]
+    pub fn overlaps_circle(self, center: impl Into<MintVec2>, radius: f32) -> bool {
+        self.check_collision_circle_rec(center, radius)
+    }
+
+    /// Checks if point is inside rectangle.
+    /// Shorter alias name: [Self::contains_point]
+    #[inline(always)]
+    #[must_use]
+    pub fn check_collision_point_rec(self, point: impl Into<MintVec2>) -> bool {
+        //unsafe { ffi::CheckCollisionPointRec(point.into(), self.into()) }
+        let point = point.into();
+        (point.x >= self.x)
+            && (point.x < (self.x + self.width))
+            && (point.y >= self.y)
+            && (point.y < (self.y + self.height))
+    }
+
+    /// Checks if point is inside rectangle.
+    /// alias for [Self::check_collision_point_rec]
+    #[inline(always)]
+    #[must_use]
+    pub fn contains_point(self, point: impl Into<MintVec2>) -> bool {
+        self.check_collision_point_rec(point)
+    }
+    /// Gets the overlap between two colliding rectangles.
+    /// Shorter alias name: [Self::get_overlap_area]
+    /// ```rust
+    /// use raylib::core::math::Rectangle;
+    /// let r1 = Rectangle::new(0.0, 0.0, 10.0, 10.0);
+    /// let r2 = Rectangle::new(20.0, 20.0, 10.0, 10.0);
+    /// assert_eq!(None, r1.get_collision_rec(r2));
+    /// assert_eq!(Some(r1), r1.get_collision_rec(r1));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn get_collision_rec(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
+        //unsafe { ffi::GetCollisionRec(self.into(), other.into()) }
+        let rec1 = self;
+        let rec2 = other.into();
+
+        let left = if rec1.x > rec2.x { rec1.x } else { rec2.x };
+        let right1 = rec1.x + rec1.width;
+        let right2 = rec2.x + rec2.width;
+        let right = if right1 < right2 { right1 } else { right2 };
+        let top = if rec1.y > rec2.y { rec1.y } else { rec2.y };
+        let bottom1 = rec1.y + rec1.height;
+        let bottom2 = rec2.y + rec2.height;
+        let bottom = if bottom1 < bottom2 { bottom1 } else { bottom2 };
+
+        if (left < right) && (top < bottom) {
+            let overlap = Rectangle::new(left, top, right - left, bottom - top);
+            return Some(overlap);
+        }
+        return None;
+    }
+    #[inline]
+    #[must_use]
+    /// Gets the overlap between two colliding rectangles.
+    /// Shorter alias name: [Self::get_collision_rec]
+    /// Use [Self::overlap] if you don't care about the overlap area
+    pub fn get_overlap_area(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
+        self.get_collision_rec(other)
+    }
+}
+
+/// Creates a [Rectangle] from any number type by loosely casting "as f32"
+#[must_use]
+#[inline(always)]
+pub fn rrect<T1: AsF32, T2: AsF32, T3: AsF32, T4: AsF32>(
+    x: T1,
+    y: T2,
+    width: T3,
+    height: T4,
+) -> Rectangle {
+    Rectangle::new(x.as_f32(), y.as_f32(), width.as_f32(), height.as_f32())
+}
+
+#[must_use]
+#[inline(always)]
+/// Shorthand for creating a rectangle [Rectangle]
+pub const fn rectf(x: f32, y: f32, width: f32, height: f32) -> Rectangle {
+    Rectangle::new(x, y, width, height)
+}
+
+#[must_use]
+#[inline(always)]
+/// Shorthand for creating a rectangle [Rectangle] with [Vector2]'s
+pub fn rectv(pos: impl Into<MintVec2>, size: impl Into<MintVec2>) -> Rectangle {
+    Rectangle::v2(pos, size)
 }
 
 #[cfg(test)]

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1315,7 +1315,7 @@ impl Rectangle {
         }
     }
 
-    /// Returns the half the width & height as a [`Vector2`]
+    /// Returns half the width & height as a [`Vector2`]
     #[must_use]
     #[inline(always)]
     pub fn half_size(self) -> Vector2 {

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1443,8 +1443,8 @@ impl Rectangle {
     #[inline]
     #[must_use]
     pub fn get_collision_rec(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
-        let rec = unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() };
-        (rec != Self::ZERO).then_some(rec)
+        self.check_collision_recs(other)
+             .then(|| unsafe { crate::GetCollisionRec(self.into(), other.into()).into() })
     }
 
     /// Gets the overlap between two colliding rectangles

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1434,7 +1434,7 @@ impl Rectangle {
     ///
     /// # Example
     /// ```
-    /// #use raylib::core::math::Rectangle;
+    /// # use raylib::core::math::Rectangle;
     /// let r1 = Rectangle::new(0.0, 0.0, 10.0, 10.0);
     /// let r2 = Rectangle::new(20.0, 20.0, 10.0, 10.0);
     /// assert_eq!(r1.get_collision_rec(r2), None);

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1443,7 +1443,7 @@ impl Rectangle {
     #[inline]
     #[must_use]
     pub fn get_collision_rec(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
-        let rec = unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() }
+        let rec = unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() };
         (rec != Self::ZERO).then_some(rec)
     }
 

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1247,7 +1247,7 @@ impl From<&Rectangle> for ffi::Rectangle {
 impl Rectangle {
     /// Rectangle with all components set to zero
     pub const ZERO: Self = Rectangle::new(0.0, 0.0, 0.0, 0.0);
-   
+
     /// Creates a new rectangle from position and size
     #[must_use]
     #[inline(always)]
@@ -1443,8 +1443,9 @@ impl Rectangle {
     #[inline]
     #[must_use]
     pub fn get_collision_rec(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
+        let other = other.into();
         self.check_collision_recs(other)
-             .then(|| unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() })
+             .then(|| unsafe { ffi::GetCollisionRec(self.into(), other).into() })
     }
 
     /// Gets the overlap between two colliding rectangles

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1444,7 +1444,7 @@ impl Rectangle {
     #[must_use]
     pub fn get_collision_rec(self, other: impl Into<ffi::Rectangle>) -> Option<Self> {
         self.check_collision_recs(other)
-             .then(|| unsafe { crate::GetCollisionRec(self.into(), other.into()).into() })
+             .then(|| unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() })
     }
 
     /// Gets the overlap between two colliding rectangles

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -1,9 +1,10 @@
 //! Image and texture related functions
 
 use crate::MintVec2;
-use crate::core::ffi::{Color, Rectangle};
+use crate::core::ffi::Color;
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
+use crate::math::Rectangle;
 use std::convert::TryInto;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;


### PR DESCRIPTION
`build.rs` had to change because before, it blacklisted generation of `Rectangle` to prevent 2 definitions of Rectangle(one in safe bindings for the methods, and another in the raw unsafe ffi bindings.rs). We're back to 2 definitions with conversions between the two like before