### PR TITLE
android: Enable compiling for x86_64 and x86.

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -185,6 +185,8 @@ fn build_with_cmake(src_path: &str) {
             let android_arch_abi = match target.as_str() {
                 "aarch64-linux-android" => "arm64-v8a",
                 "armv7-linux-androideabi" => "armeabi-v7a",
+                "x86_64-linux-android" => "x86_64",
+                "x86-linux-android" => "x86",
                 _ => panic!("Unsupported target triple for Android"),
             };
             // we'll set as many variables as possible according to:

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -186,7 +186,7 @@ fn build_with_cmake(src_path: &str) {
                 "aarch64-linux-android" => "arm64-v8a",
                 "armv7-linux-androideabi" => "armeabi-v7a",
                 "x86_64-linux-android" => "x86_64",
-                "x86-linux-android" => "x86",
+                "i686-linux-android" => "x86",
                 _ => panic!("Unsupported target triple for Android"),
             };
             // we'll set as many variables as possible according to:


### PR DESCRIPTION
There is no reason to not support it. Without it we cannot run raylib on Android Emulators and Chromebooks.