### PR TITLE
Clippy Cleanup

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -439,8 +439,8 @@ fn main() {
     gen_utils();
 }
 
-#[must_use]
 /// returns false if the directory does not exist
+#[must_use]
 fn is_directory_empty(path: &str) -> bool {
     match std::fs::read_dir(path) {
         Ok(mut dir) => dir.next().is_none(),

--- a/raylib-sys/src/color.rs
+++ b/raylib-sys/src/color.rs
@@ -160,9 +160,9 @@ impl PartialEq for Color {
 }
 impl Eq for Color {}
 
-#[rustfmt::skip]
 /// Some Basic Colors
 /// NOTE: Custom raylib color palette for amazing visuals on WHITE background
+#[rustfmt::skip]
 pub trait RaylibPalette {
     /** Light Gray                 */ const LIGHTGRAY:  Color = Color::new(200, 200, 200, 255);
     /** Gray                       */ const GRAY:       Color = Color::new(130, 130, 130, 255);
@@ -194,8 +194,8 @@ pub trait RaylibPalette {
 }
 impl RaylibPalette for Color {}
 
-#[rustfmt::skip]
 /// CSS Color constants
+#[rustfmt::skip]
 pub trait CSSPalette {
     /** #f0f8ffff */ const ALICEBLUE:            Color = Color::new(0xf0, 0xf8, 0xff, 0xff);
     /** #faebd7ff */ const ANTIQUEWHITE:         Color = Color::new(0xfa, 0xeb, 0xd7, 0xff);
@@ -349,8 +349,8 @@ pub trait CSSPalette {
 }
 impl CSSPalette for Color {}
 
-#[rustfmt::skip]
 /// Color constants
+#[rustfmt::skip]
 impl Color {
     pub const INDIANRED: Color = Color::new(205, 92, 92, 255);
     pub const LIGHTCORAL: Color = Color::new(240, 128, 128, 255);

--- a/raylib/src/consts.rs
+++ b/raylib/src/consts.rs
@@ -6,6 +6,7 @@ pub use ffi::CameraMode;
 pub use ffi::CameraProjection;
 pub use ffi::ConfigFlags;
 pub use ffi::CubemapLayout;
+pub use ffi::DEG2RAD;
 pub use ffi::GamepadAxis;
 pub use ffi::GamepadButton;
 pub use ffi::Gesture;
@@ -19,9 +20,10 @@ pub use ffi::ShaderUniformDataType;
 pub use ffi::TextureFilter;
 pub use ffi::TextureWrap;
 pub use ffi::TraceLogLevel;
-pub use ffi::DEG2RAD;
 // TODO Fix when rlgl bindings are in
+/// Maximum number of shader maps supported
 pub const MAX_MATERIAL_MAPS: u32 = 12;
+/// Maximum number of shader locations supported
 pub const MAX_SHADER_LOCATIONS: u32 = 32;
 pub use ffi::GuiCheckBoxProperty;
 pub use ffi::GuiColorPickerProperty;

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -55,21 +55,28 @@ impl Drop for WaveSamples {
     }
 }
 
-/// A marker trait specifying an audio sample (`u8`, `i16`, or `f32`).
-pub trait AudioSample {}
-impl AudioSample for u8 {}
-impl AudioSample for i16 {}
-impl AudioSample for f32 {}
+mod sealed {
+    /// A marker trait specifying an audio sample (`u8`, `i16`, or `f32`).
+    pub trait AudioSample {}
+    impl AudioSample for u8 {}
+    impl AudioSample for i16 {}
+    impl AudioSample for f32 {}
+}
+pub use sealed::AudioSample;
 
 /// This token is used to indicate audio is initialized. It's also used to create [`Wave`], [`Sound`], [`Music`], [`AudioStream`], and [`SoundAlias`].
-/// All of those have a lifetime that is bound to RaylibAudio. The compiler will disallow you from using them without ensuring that the [`RaylibAudio`] is present while doing so.
+/// All of those have a lifetime that is bound to [`RaylibAudio`]. The compiler will disallow you from using them without ensuring that the [`RaylibAudio`] is present while doing so.
 #[derive(Debug, Clone)]
 pub struct RaylibAudio(PhantomData<()>);
 
 impl RaylibAudio {
     /// Initializes audio device and context.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`AudioInitError::DoubleInit`] if the audio device is already initialized before calling,
+    /// or [`AudioInitError::InitFailed`] if the audio device fails to be initialized after calling.
     #[inline]
-    #[must_use]
     pub fn init_audio_device() -> Result<RaylibAudio, AudioInitError> {
         unsafe {
             if ffi::IsAudioDeviceReady() {
@@ -112,10 +119,18 @@ impl RaylibAudio {
     }
 
     /// Loads a new sound from file.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::LoadFailed`] if [`ffi::LoadSound`] returns a sound whose `buffer` is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
-    #[must_use]
     pub fn new_sound<'aud>(&'aud self, filename: &str) -> Result<Sound<'aud>, LoadSoundError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let s = unsafe { ffi::LoadSound(c_filename.as_ptr()) };
         if s.stream.buffer.is_null() {
             return Err(LoadSoundError::LoadFailed {
@@ -127,8 +142,11 @@ impl RaylibAudio {
     }
 
     /// Loads sound from wave data.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::LoadFromWaveFailed`] if [`ffi::LoadSoundFromWave`] returns a sound whose `buffer` is null.
     #[inline]
-    #[must_use]
     pub fn new_sound_from_wave<'aud>(
         &'aud self,
         wave: &Wave,
@@ -139,11 +157,20 @@ impl RaylibAudio {
         }
         Ok(Sound(s, self))
     }
+
     /// Loads wave data from file into RAM.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::LoadWaveFromFileFailed`] if [`ffi::LoadWave`] returns a sound whose `buffer` is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
-    #[must_use]
     pub fn new_wave<'aud>(&'aud self, filename: &str) -> Result<Wave<'aud>, LoadSoundError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let w = unsafe { ffi::LoadWave(c_filename.as_ptr()) };
         if w.data.is_null() {
             return Err(LoadSoundError::LoadWaveFromFileFailed {
@@ -154,28 +181,51 @@ impl RaylibAudio {
     }
 
     /// Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::Null`] if [`ffi::LoadWaveFromMemory`] returns a wave whose `data` is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filetype` contains an internal 0 byte or if `bytes` has a length greater than [`i32::MAX`].
     #[inline]
-    #[must_use]
     pub fn new_wave_from_memory<'aud>(
         &'aud self,
         filetype: &str,
         bytes: &[u8],
     ) -> Result<Wave<'aud>, LoadSoundError> {
-        let c_filetype = CString::new(filetype).unwrap();
+        let c_filetype =
+            CString::new(filetype).expect("filetype should not contain an internal 0 byte");
         let w = unsafe {
-            ffi::LoadWaveFromMemory(c_filetype.as_ptr(), bytes.as_ptr(), bytes.len() as i32)
+            ffi::LoadWaveFromMemory(
+                c_filetype.as_ptr(),
+                bytes.as_ptr(),
+                bytes
+                    .len()
+                    .try_into()
+                    .expect("bytes should not exceed i32::MAX elements"),
+            )
         };
         if w.data.is_null() {
             return Err(LoadSoundError::Null);
-        };
+        }
         Ok(Wave(w, self))
     }
 
     /// Loads music stream from file.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::LoadMusicFromFileFailed`] if [`ffi::LoadMusicStream`] returns a music whose stream buffer is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
-    #[must_use]
     pub fn new_music<'aud>(&'aud self, filename: &str) -> Result<Music<'aud>, LoadSoundError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let m = unsafe { ffi::LoadMusicStream(c_filename.as_ptr()) };
         if m.stream.buffer.is_null() {
             return Err(LoadSoundError::LoadMusicFromFileFailed {
@@ -186,32 +236,47 @@ impl RaylibAudio {
     }
 
     /// Load music stream from data
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::MusicNull`] if [`ffi::LoadMusicStreamFromMemory`] returns a music whose stream buffer is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filetype` contains an internal 0 byte or if `bytes` has a length greater than [`i32::MAX`].
     #[inline]
-    #[must_use]
     pub fn new_music_from_memory<'aud>(
         &'aud self,
         filetype: &str,
-        bytes: &Vec<u8>,
+        bytes: &[u8],
     ) -> Result<Music<'aud>, LoadSoundError> {
-        let c_filetype = CString::new(filetype).unwrap();
+        let c_filetype =
+            CString::new(filetype).expect("filetype should not contain an internal 0 byte");
         let w = unsafe {
-            ffi::LoadMusicStreamFromMemory(c_filetype.as_ptr(), bytes.as_ptr(), bytes.len() as i32)
+            ffi::LoadMusicStreamFromMemory(
+                c_filetype.as_ptr(),
+                bytes.as_ptr(),
+                bytes
+                    .len()
+                    .try_into()
+                    .expect("bytes should not exceed i32::MAX elements"),
+            )
         };
         if w.stream.buffer.is_null() {
             return Err(LoadSoundError::MusicNull);
-        };
+        }
         Ok(Music(w, self))
     }
 
     /// Initializes audio stream (to stream raw PCM data).
     #[inline]
     #[must_use]
-    pub fn new_audio_stream<'aud>(
-        &'aud self,
+    pub fn new_audio_stream(
+        &self,
         sample_rate: u32,
         sample_size: u32,
         channels: u32,
-    ) -> AudioStream<'aud> {
+    ) -> AudioStream<'_> {
         unsafe {
             AudioStream(
                 ffi::LoadAudioStream(sample_rate, sample_size, channels),
@@ -221,7 +286,7 @@ impl RaylibAudio {
     }
 }
 
-impl<'aud> Drop for RaylibAudio {
+impl Drop for RaylibAudio {
     #[inline]
     fn drop(&mut self) {
         unsafe { ffi::CloseAudioDevice() }
@@ -253,6 +318,12 @@ impl<'aud> Wave<'aud> {
     pub const fn channels(&self) -> u32 {
         self.0.channels
     }
+
+    /// Convert the type to its raw [`ffi`] equivalent.
+    ///
+    /// # Safety
+    ///
+    /// The resource must be unloaded manually to prevent leaking memory.
     #[inline]
     #[must_use]
     pub unsafe fn inner(self) -> ffi::Wave {
@@ -269,22 +340,37 @@ impl<'aud> Wave<'aud> {
     }
 
     /// Export wave file. Extension must be .wav or .raw
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`ExportWaveError::ExportFailed`] if [`ffi::ExportWave`] returns `false`.
+    ///
+    /// This method returns [`ExportWaveError::QoaBadSamples`] if the reason [`ffi::ExportWave`] returned false is because
+    /// the file is in '.qoa' format and a sample size other than 16.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename`, when converted to a lossy string with [`Path::to_string_lossy`], contains an internal 0 byte.
     #[inline]
-    #[must_use]
     pub fn export(&self, filename: impl AsRef<Path>) -> Result<(), ExportWaveError> {
-        let c_filename = CString::new(filename.as_ref().to_string_lossy().as_bytes()).unwrap();
+        let c_filename = CString::new(filename.as_ref().to_string_lossy().as_bytes())
+            .expect("lossy filename should not contain an internal 0 byte");
         let success = unsafe { ffi::ExportWave(self.0, c_filename.as_ptr()) };
         if success {
             Ok(())
         } else {
-            // const WAV: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b".wav\0") };
-            const QOA: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b".qoa\0") };
-            // const RAW: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b".raw\0") };
+            // const WAV: &CStr = c".wav";
+            const QOA: &CStr = c".qoa";
+            // const RAW: &CStr = c".raw";
             let is_qoa = unsafe { ffi::IsFileExtension(c_filename.as_ptr(), QOA.as_ptr()) };
             if is_qoa {
-                let samples = self.0.sampleSize as i32;
+                let samples = self
+                    .0
+                    .sampleSize
+                    .try_into()
+                    .expect("sample size should not exceed i32::MAX");
                 if samples != 16 {
-                    return Err(ExportWaveError::QoaBadSamples(self.0.sampleSize as i32));
+                    return Err(ExportWaveError::QoaBadSamples(samples));
                 }
             }
             Err(ExportWaveError::ExportFailed)
@@ -294,32 +380,34 @@ impl<'aud> Wave<'aud> {
     /*/// Export wave sample data to code (.h)
     #[inline]
     pub fn export_wave_as_code(&self, filename: &str) -> bool {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename = CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe { ffi::ExportWaveAsCode(self.0, c_filename.as_ptr()) }
     }*/
 
     /// Copies a wave to a new wave.
     #[inline]
     #[must_use]
-    pub(crate) fn copy(&self) -> Wave {
+    pub(crate) fn copy(&self) -> Wave<'aud> {
         unsafe { Wave(ffi::WaveCopy(self.0), self.1) }
     }
 
     /// Converts wave data to desired format.
     #[inline]
     pub fn format(&mut self, sample_rate: i32, sample_size: i32, channels: i32) {
-        unsafe { ffi::WaveFormat(&mut self.0, sample_rate, sample_size, channels) }
+        unsafe { ffi::WaveFormat(&raw mut self.0, sample_rate, sample_size, channels) }
     }
 
     /// Crops a wave to defined sample range.
     #[inline]
     pub fn crop(&mut self, init_sample: i32, final_sample: i32) {
-        unsafe { ffi::WaveCrop(&mut self.0, init_sample, final_sample) }
+        unsafe { ffi::WaveCrop(&raw mut self.0, init_sample, final_sample) }
     }
 
     /// Load samples data from wave as a floats array
+    ///
     /// NOTE 1: Returned sample values are normalized to range [-1..1]
-    /// NOTE 2: Sample data allocated should be freed with UnloadWaveSamples()
+    ///
+    /// NOTE 2: Sample data allocated should be freed with [`ffi::UnloadWaveSamples()`]
     #[inline]
     #[must_use]
     pub fn load_samples(&self) -> WaveSamples {
@@ -330,19 +418,19 @@ impl<'aud> Wave<'aud> {
     }
 }
 
-impl<'aud> AsRef<ffi::AudioStream> for Sound<'aud> {
+impl AsRef<ffi::AudioStream> for Sound<'_> {
     fn as_ref(&self) -> &ffi::AudioStream {
         &self.0.stream
     }
 }
 
-impl<'aud> AsMut<ffi::AudioStream> for Sound<'aud> {
+impl AsMut<ffi::AudioStream> for Sound<'_> {
     fn as_mut(&mut self) -> &mut ffi::AudioStream {
         &mut self.0.stream
     }
 }
 
-impl<'aud> Sound<'aud> {
+impl Sound<'_> {
     /// Checks if a sound is valid (data loaded and buffers initialized)
     #[inline]
     #[must_use]
@@ -356,6 +444,12 @@ impl<'aud> Sound<'aud> {
     pub const fn frame_count(&self) -> u32 {
         self.0.frameCount
     }
+
+    /// Convert the type to its raw [`ffi`] equivalent.
+    ///
+    /// # Safety
+    ///
+    /// The resource must be unloaded manually to prevent leaking memory.
     #[inline]
     #[must_use]
     pub unsafe fn inner(self) -> ffi::Sound {
@@ -427,7 +521,7 @@ impl<'aud> Sound<'aud> {
     // }}
 }
 
-impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
+impl SoundAlias<'_, '_> {
     /// Checks if a sound is valid (data loaded and buffers initialized)
     #[inline]
     #[must_use]
@@ -441,6 +535,12 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
     pub const fn frame_count(&self) -> u32 {
         self.0.frameCount
     }
+
+    /// Convert the type to its raw [`ffi`] equivalent.
+    ///
+    /// # Safety
+    ///
+    /// The resource must be unloaded manually to prevent leaking memory.
     #[must_use]
     pub unsafe fn inner(self) -> ffi::Sound {
         let inner = self.0;
@@ -504,7 +604,7 @@ impl Drop for SoundAlias<'_, '_> {
     }
 }
 
-impl<'aud> Music<'aud> {
+impl Music<'_> {
     /// Starts music playing.
     #[inline]
     pub fn play_stream(&self) {
@@ -588,7 +688,7 @@ impl<'aud> Music<'aud> {
     }
 }
 
-impl<'aud> AudioStream<'aud> {
+impl AudioStream<'_> {
     /// Checks if an audio stream is valid (buffers initialized)
     #[inline]
     #[must_use]
@@ -614,6 +714,11 @@ impl<'aud> AudioStream<'aud> {
         self.0.channels
     }
 
+    /// Convert the type to its raw [`ffi`] equivalent.
+    ///
+    /// # Safety
+    ///
+    /// The resource must be unloaded manually to prevent leaking memory.
     #[must_use]
     pub unsafe fn inner(self) -> ffi::AudioStream {
         let inner = self.0;
@@ -622,13 +727,19 @@ impl<'aud> AudioStream<'aud> {
     }
 
     /// Updates audio stream buffers with data.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `data` is more than [`i32::MAX`] total bytes.
     #[inline]
     pub fn update<T: AudioSample>(&mut self, data: &[T]) {
         unsafe {
             ffi::UpdateAudioStream(
                 self.0,
-                data.as_ptr() as *const std::os::raw::c_void,
-                (data.len() * std::mem::size_of::<T>()) as i32,
+                data.as_ptr().cast::<std::os::raw::c_void>(),
+                std::mem::size_of_val(data)
+                    .try_into()
+                    .expect("data should not exceed i32::MAX elements"),
             );
         }
     }
@@ -695,7 +806,7 @@ impl<'aud> AudioStream<'aud> {
         unsafe { ffi::IsAudioStreamProcessed(self.0) }
     }
 
-    /// Set pan for audio stream (0.5 is centered)
+    /// Set pan for audio stream (`0.5` is centered)
     #[inline]
     pub fn set_pan(&self, pan: f32) {
         unsafe {
@@ -707,8 +818,11 @@ impl<'aud> AudioStream<'aud> {
 impl<'bind> Sound<'bind> {
     /// Clone sound from existing sound data, clone does not own wave data
     // NOTE: Wave data must be unallocated manually and will be shared across all clones
-    #[must_use]
-    pub fn alias<'snd>(&'snd self) -> Result<SoundAlias<'snd, 'bind>, LoadSoundError> {
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadSoundError::LoadFromWaveFailed`] if [`ffi::LoadSoundAlias`] returns a sound alias whose stream buffer is null.
+    pub fn alias(&self) -> Result<SoundAlias<'_, 'bind>, LoadSoundError> {
         let s = unsafe { ffi::LoadSoundAlias(self.0) };
         if s.stream.buffer.is_null() {
             return Err(LoadSoundError::LoadFromWaveFailed);

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -326,7 +326,7 @@ impl<'aud> Wave<'aud> {
     /// The resource must be unloaded manually to prevent leaking memory.
     #[inline]
     #[must_use]
-    pub unsafe fn inner(self) -> ffi::Wave {
+    pub const unsafe fn inner(self) -> ffi::Wave {
         let inner = self.0;
         std::mem::forget(self);
         inner
@@ -458,7 +458,7 @@ impl Sound<'_> {
     /// The resource must be unloaded manually to prevent leaking memory.
     #[inline]
     #[must_use]
-    pub unsafe fn inner(self) -> ffi::Sound {
+    pub const unsafe fn inner(self) -> ffi::Sound {
         let inner = self.0;
         std::mem::forget(self);
         inner
@@ -548,7 +548,7 @@ impl SoundAlias<'_, '_> {
     ///
     /// The resource must be unloaded manually to prevent leaking memory.
     #[must_use]
-    pub unsafe fn inner(self) -> ffi::Sound {
+    pub const unsafe fn inner(self) -> ffi::Sound {
         let inner = self.0;
         std::mem::forget(self);
         inner
@@ -726,7 +726,7 @@ impl AudioStream<'_> {
     ///
     /// The resource must be unloaded manually to prevent leaking memory.
     #[must_use]
-    pub unsafe fn inner(self) -> ffi::AudioStream {
+    pub const unsafe fn inner(self) -> ffi::AudioStream {
         let inner = self.0;
         std::mem::forget(self);
         inner

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -388,7 +388,7 @@ impl<'aud> Wave<'aud> {
     /// Copies a wave to a new wave.
     #[inline]
     #[must_use]
-    pub(crate) fn copy(&self) -> Wave<'aud> {
+    pub fn copy(&self) -> Wave<'aud> {
         unsafe { Wave(ffi::WaveCopy(self.0), self.1) }
     }
 

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -1,14 +1,14 @@
 //! Contains code related to audio. [`RaylibAudio`] plays sounds and music.
 
 use crate::{
-    error::{AudioInitError, LoadSoundError},
+    error::{AudioInitError, ExportWaveError, LoadSoundError},
     ffi,
 };
-use std::ffi::{CStr, CString};
-use std::marker::PhantomData;
-use std::path::Path;
-
-use super::error::ExportWaveError;
+use std::{
+    ffi::{CStr, CString},
+    marker::PhantomData,
+    path::Path,
+};
 
 make_thin_wrapper_lifetime!(
     /// Wave, audio wave data
@@ -26,6 +26,7 @@ make_thin_wrapper_lifetime!(
     (ffi::UnloadSound),
     true
 );
+
 make_thin_wrapper_lifetime!(
     /// Music, audio stream, anything longer than ~10 seconds should be streamed
     Music,
@@ -33,6 +34,7 @@ make_thin_wrapper_lifetime!(
     RaylibAudio,
     ffi::UnloadMusicStream
 );
+
 make_thin_wrapper_lifetime!(
     /// AudioStream, custom audio stream
     AudioStream,
@@ -301,18 +303,21 @@ impl<'aud> Wave<'aud> {
     pub const fn frame_count(&self) -> u32 {
         self.0.frameCount
     }
+
     /// Frequency (samples per second)
     #[inline]
     #[must_use]
     pub const fn sample_rate(&self) -> u32 {
         self.0.sampleRate
     }
+
     /// Bit depth (bits per sample): 8, 16, 32 (24 not supported)
     #[inline]
     #[must_use]
     pub const fn sample_size(&self) -> u32 {
         self.0.sampleSize
     }
+
     /// Number of channels (1-mono, 2-stereo, ...)
     #[inline]
     #[must_use]
@@ -324,7 +329,9 @@ impl<'aud> Wave<'aud> {
     ///
     /// # Safety
     ///
-    /// The resource must be unloaded manually to prevent leaking memory.
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
     pub const unsafe fn inner(self) -> ffi::Wave {
@@ -388,7 +395,7 @@ impl<'aud> Wave<'aud> {
     /// Copies a wave to a new wave.
     #[inline]
     #[must_use]
-    pub fn copy(&self) -> Wave<'aud> {
+    pub(crate) fn copy(&self) -> Wave<'aud> {
         unsafe { Wave(ffi::WaveCopy(self.0), self.1) }
     }
 
@@ -426,12 +433,14 @@ impl<'aud> Wave<'aud> {
 }
 
 impl AsRef<ffi::AudioStream> for Sound<'_> {
+    #[inline]
     fn as_ref(&self) -> &ffi::AudioStream {
         &self.0.stream
     }
 }
 
 impl AsMut<ffi::AudioStream> for Sound<'_> {
+    #[inline]
     fn as_mut(&mut self) -> &mut ffi::AudioStream {
         &mut self.0.stream
     }
@@ -442,6 +451,7 @@ impl Sound<'_> {
     #[inline]
     #[must_use]
     pub fn is_sound_valid(&self) -> bool {
+        // SAFETY: IsSoundValid has no preconditions and is trivially safe
         unsafe { ffi::IsSoundValid(self.0) }
     }
 
@@ -456,7 +466,9 @@ impl Sound<'_> {
     ///
     /// # Safety
     ///
-    /// The resource must be unloaded manually to prevent leaking memory.
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
     pub const unsafe fn inner(self) -> ffi::Sound {
@@ -547,7 +559,10 @@ impl SoundAlias<'_, '_> {
     ///
     /// # Safety
     ///
-    /// The resource must be unloaded manually to prevent leaking memory.
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
+    #[inline]
     #[must_use]
     pub const unsafe fn inner(self) -> ffi::Sound {
         let inner = self.0;
@@ -598,7 +613,7 @@ impl SoundAlias<'_, '_> {
         unsafe { ffi::SetSoundPitch(self.0, pitch) }
     }
 
-    /// Set pan for a sound (0.5 is center)
+    /// Set pan for a sound (`0.5` is center)
     #[inline]
     pub fn set_pan(&self, pan: f32) {
         unsafe { ffi::SetSoundPan(self.0, pan) }
@@ -691,6 +706,7 @@ impl Music<'_> {
     #[inline]
     #[must_use]
     pub fn is_music_valid(&self) -> bool {
+        // SAFETY: IsMusicValid has no preconditions and is trivially safe
         unsafe { ffi::IsMusicValid(self.0) }
     }
 }
@@ -700,20 +716,24 @@ impl AudioStream<'_> {
     #[inline]
     #[must_use]
     pub fn is_audio_stream_valid(&self) -> bool {
+        // SAFETY: IsMusicValid has no preconditions and is trivially safe
         unsafe { ffi::IsAudioStreamValid(self.0) }
     }
+
     /// Frequency (samples per second)
     #[inline]
     #[must_use]
     pub const fn sample_rate(&self) -> u32 {
         self.0.sampleRate
     }
+
     /// Bit depth (bits per sample): 8, 16, 32 (24 not supported)
     #[inline]
     #[must_use]
     pub const fn sample_size(&self) -> u32 {
         self.0.sampleSize
     }
+
     /// Number of channels (1-mono, 2-stereo, ...)
     #[inline]
     #[must_use]
@@ -725,7 +745,9 @@ impl AudioStream<'_> {
     ///
     /// # Safety
     ///
-    /// The resource must be unloaded manually to prevent leaking memory.
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[must_use]
     pub const unsafe fn inner(self) -> ffi::AudioStream {
         let inner = self.0;
@@ -824,7 +846,8 @@ impl AudioStream<'_> {
 
 impl<'bind> Sound<'bind> {
     /// Clone sound from existing sound data, clone does not own wave data
-    // NOTE: Wave data must be unallocated manually and will be shared across all clones
+    ///
+    /// NOTE: Wave data must be unallocated manually and will be shared across all clones
     ///
     /// # Errors
     ///

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -78,14 +78,14 @@ impl RaylibAudio {
     /// or [`AudioInitError::InitFailed`] if the audio device fails to be initialized after calling.
     #[inline]
     pub fn init_audio_device() -> Result<RaylibAudio, AudioInitError> {
+        if unsafe { ffi::IsAudioDeviceReady() } {
+            return Err(AudioInitError::DoubleInit);
+        }
         unsafe {
-            if ffi::IsAudioDeviceReady() {
-                return Err(AudioInitError::DoubleInit);
-            }
             ffi::InitAudioDevice();
-            if !ffi::IsAudioDeviceReady() {
-                return Err(AudioInitError::InitFailed);
-            }
+        }
+        if !unsafe { ffi::IsAudioDeviceReady() } {
+            return Err(AudioInitError::InitFailed);
         }
         Ok(RaylibAudio(PhantomData))
     }
@@ -408,12 +408,18 @@ impl<'aud> Wave<'aud> {
     /// NOTE 1: Returned sample values are normalized to range [-1..1]
     ///
     /// NOTE 2: Sample data allocated should be freed with [`ffi::UnloadWaveSamples()`]
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `self.frameCount` is negative.
     #[inline]
     #[must_use]
     pub fn load_samples(&self) -> WaveSamples {
         WaveSamples(
             unsafe { ffi::LoadWaveSamples(self.0) },
-            self.frameCount as usize,
+            self.frameCount
+                .try_into()
+                .expect("frameCount not be negative"),
         )
     }
 }

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -41,6 +41,7 @@ make_thin_wrapper_lifetime!(
     ffi::UnloadAudioStream
 );
 
+/// Sample buffer for a [`Wave`].
 pub struct WaveSamples(*mut f32, usize);
 
 impl AsRef<[f32]> for WaveSamples {
@@ -837,4 +838,7 @@ impl<'bind> Sound<'bind> {
     }
 }
 
+/// Weak clone of a [`Sound`].
+///
+/// See [`Sound::alias`]
 pub struct SoundAlias<'snd, 'bind>(ffi::Sound, PhantomData<&'snd Sound<'bind>>);

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -4,13 +4,13 @@ use std::{
     ptr::null,
 };
 
-use crate::{ffi, RaylibHandle};
+use crate::{RaylibHandle, ffi};
 
 #[derive(Debug, Clone)]
 pub struct AutomationEventIter<'a> {
     iter: std::slice::Iter<'a, ffi::AutomationEvent>,
 }
-impl<'a> AutomationEventIter<'a> {
+impl AutomationEventIter<'_> {
     #[must_use]
     unsafe fn new(events: *mut ffi::AutomationEvent, count: u32) -> Self {
         // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
@@ -27,7 +27,7 @@ impl<'a> AutomationEventIter<'a> {
         AutomationEvent(*e)
     }
 }
-impl<'a> Iterator for AutomationEventIter<'a> {
+impl Iterator for AutomationEventIter<'_> {
     type Item = AutomationEvent;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -52,7 +52,7 @@ impl<'a> Iterator for AutomationEventIter<'a> {
         self.iter.nth(n).map(Self::func)
     }
 }
-impl<'a> DoubleEndedIterator for AutomationEventIter<'a> {
+impl DoubleEndedIterator for AutomationEventIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(Self::func)
     }
@@ -61,7 +61,7 @@ impl<'a> DoubleEndedIterator for AutomationEventIter<'a> {
         self.iter.nth_back(n).map(Self::func)
     }
 }
-impl<'a> ExactSizeIterator for AutomationEventIter<'a> {
+impl ExactSizeIterator for AutomationEventIter<'_> {
     #[inline]
     fn len(&self) -> usize {
         self.iter.len()
@@ -99,14 +99,29 @@ impl AutomationEventList {
     }
     /// An iterator over the events held in this list.
     #[must_use]
-    pub fn iter<'a>(&'a self) -> AutomationEventIter<'a> {
+    pub fn iter(&self) -> AutomationEventIter<'_> {
         unsafe { AutomationEventIter::new(self.0.events, self.count()) }
     }
 
     /// Export automation events list as text file
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `file_name` contains an internal 0 byte.
     pub fn export(&self, file_name: impl AsRef<Path>) -> bool {
-        let c_str = CString::new(file_name.as_ref().to_string_lossy().as_bytes()).unwrap();
+        let c_str = CString::new(file_name.as_ref().to_string_lossy().as_bytes())
+            .expect("lossy filename should not contain an internal 0 byte");
         unsafe { ffi::ExportAutomationEventList(self.0, c_str.as_ptr()) }
+    }
+}
+
+impl<'a> IntoIterator for &'a AutomationEventList {
+    type Item = <AutomationEventIter<'a> as Iterator>::Item;
+    type IntoIter = AutomationEventIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 
@@ -124,7 +139,7 @@ impl AutomationEvent {
     pub const fn frame(&self) -> u32 {
         self.0.frame
     }
-    /// Event type (AutomationEventType)
+    /// Event type ([`AutomationEventType`])
     #[inline]
     #[must_use]
     pub const fn get_type(&self) -> u32 {
@@ -151,12 +166,17 @@ fn unload_automation_event(_s: ffi::AutomationEvent) {
 }
 
 impl RaylibHandle {
-    /// Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
+    /// Load automation events list from file, NULL for empty list, capacity = `MAX_AUTOMATION_EVENTS` (16,384 by default)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `file_name` contains an internal 0 byte.
     #[must_use]
     pub fn load_automation_event_list(&self, file_name: Option<PathBuf>) -> AutomationEventList {
         match file_name {
             Some(a) => {
-                let c_str = CString::new(a.to_string_lossy().as_bytes()).unwrap();
+                let c_str = CString::new(a.to_string_lossy().as_bytes())
+                    .expect("lossy filename should not contain an internal 0 byte");
                 AutomationEventList(unsafe { ffi::LoadAutomationEventList(c_str.as_ptr()) })
             }
             None => AutomationEventList(unsafe { ffi::LoadAutomationEventList(null()) }),
@@ -166,7 +186,7 @@ impl RaylibHandle {
     #[inline]
     pub fn set_automation_event_list(&self, l: &mut AutomationEventList) {
         unsafe {
-            ffi::SetAutomationEventList(&mut l.0 as *mut ffi::AutomationEventList);
+            ffi::SetAutomationEventList(&raw mut l.0);
         }
     }
     /// Set automation event internal base frame to start recording
@@ -174,7 +194,7 @@ impl RaylibHandle {
     pub fn set_automation_event_base_frame(&self, b: i32) {
         unsafe { ffi::SetAutomationEventBaseFrame(b) };
     }
-    /// Start recording automation events (AutomationEventList must be set)
+    /// Start recording automation events ([`AutomationEventList`] must be set)
     #[inline]
     pub fn start_automation_event_recording(&self) {
         unsafe { ffi::StartAutomationEventRecording() };

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -79,6 +79,7 @@ impl ExactSizeIterator for AutomationEventIter<'_> {
 }
 
 make_thin_wrapper!(
+    /// An iterable collection of [`AutomationEvent`]s.
     AutomationEventList,
     ffi::AutomationEventList,
     ffi::UnloadAutomationEventList,
@@ -151,6 +152,7 @@ impl<'a> IntoIterator for &'a AutomationEventList {
 }
 
 make_thin_wrapper!(
+    /// Automation event
     AutomationEvent,
     ffi::AutomationEvent,
     unload_automation_event,

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -1,3 +1,5 @@
+//! Raylib event automation
+
 use std::{
     ffi::CString,
     path::{Path, PathBuf},

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -140,7 +140,7 @@ impl AutomationEventList {
 }
 
 impl<'a> IntoIterator for &'a AutomationEventList {
-    type Item = <AutomationEventIter<'a> as Iterator>::Item;
+    type Item = <Self::IntoIter as Iterator>::Item;
     type IntoIter = AutomationEventIter<'a>;
 
     #[inline]

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -1,18 +1,18 @@
 //! Raylib event automation
 
+use crate::{RaylibHandle, ffi};
 use std::{
     ffi::CString,
     path::{Path, PathBuf},
     ptr::null,
 };
 
-use crate::{RaylibHandle, ffi};
-
 /// Iterator over [`AutomationEvent`]s. Returned by [`AutomationEventList::iter`].
 #[derive(Debug, Clone)]
 pub struct AutomationEventIter<'a> {
     iter: std::slice::Iter<'a, ffi::AutomationEvent>,
 }
+
 impl AutomationEventIter<'_> {
     #[must_use]
     unsafe fn new(events: *mut ffi::AutomationEvent, count: u32) -> Self {
@@ -39,9 +39,11 @@ impl AutomationEventIter<'_> {
         AutomationEvent(*e)
     }
 }
+
 impl Iterator for AutomationEventIter<'_> {
     type Item = AutomationEvent;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(Self::func)
     }
@@ -56,23 +58,29 @@ impl Iterator for AutomationEventIter<'_> {
         self.len()
     }
 
+    #[inline]
     fn last(self) -> Option<Self::Item> {
         self.iter.last().map(Self::func)
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.iter.nth(n).map(Self::func)
     }
 }
+
 impl DoubleEndedIterator for AutomationEventIter<'_> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(Self::func)
     }
 
+    #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         self.iter.nth_back(n).map(Self::func)
     }
 }
+
 impl ExactSizeIterator for AutomationEventIter<'_> {
     #[inline]
     fn len(&self) -> usize {
@@ -133,9 +141,12 @@ impl AutomationEventList {
 
     /// Export automation events list as text file
     ///
+    /// Returns `true` on success
+    ///
     /// # Panics
     ///
     /// This method will panic if `file_name` contains an internal 0 byte.
+    #[must_use = "return indicates success or failure of the operation"]
     pub fn export(&self, file_name: impl AsRef<Path>) -> bool {
         let c_str = CString::new(file_name.as_ref().to_string_lossy().as_bytes())
             .expect("lossy filename should not contain an internal 0 byte");
@@ -168,12 +179,14 @@ impl AutomationEvent {
     pub const fn frame(&self) -> u32 {
         self.0.frame
     }
+
     /// Event type ([`AutomationEventType`])
     #[inline]
     #[must_use]
     pub const fn get_type(&self) -> u32 {
         self.0.type_
     }
+
     /// Event parameters (if required)
     #[inline]
     #[must_use]
@@ -190,6 +203,7 @@ impl AutomationEvent {
     }
 }
 
+#[inline(always)] // This is fine because the method is empty
 const fn unload_automation_event(_s: ffi::AutomationEvent) {
     // As far as I can tell, this is actually unloaded when UnloadAnimationEventList is called.
 }
@@ -202,15 +216,14 @@ impl RaylibHandle {
     /// This method will panic if `file_name` contains an internal 0 byte.
     #[must_use]
     pub fn load_automation_event_list(&self, file_name: Option<PathBuf>) -> AutomationEventList {
-        match file_name {
-            Some(a) => {
-                let c_str = CString::new(a.to_string_lossy().as_bytes())
-                    .expect("lossy filename should not contain an internal 0 byte");
-                AutomationEventList(unsafe { ffi::LoadAutomationEventList(c_str.as_ptr()) })
-            }
-            None => AutomationEventList(unsafe { ffi::LoadAutomationEventList(null()) }),
-        }
+        let c_file_name = file_name.map(|a| {
+            CString::new(a.to_string_lossy().as_bytes())
+                .expect("lossy filename should not contain an internal 0 byte")
+        });
+        let c_str = c_file_name.as_ref().map_or_else(null, |s| s.as_ptr());
+        AutomationEventList(unsafe { ffi::LoadAutomationEventList(c_str) })
     }
+
     /// Set automation event list to record to
     #[inline]
     pub fn set_automation_event_list(&self, l: &mut AutomationEventList) {
@@ -218,16 +231,19 @@ impl RaylibHandle {
             ffi::SetAutomationEventList(&raw mut l.0);
         }
     }
+
     /// Set automation event internal base frame to start recording
     #[inline]
     pub fn set_automation_event_base_frame(&self, b: i32) {
         unsafe { ffi::SetAutomationEventBaseFrame(b) };
     }
+
     /// Start recording automation events ([`AutomationEventList`] must be set)
     #[inline]
     pub fn start_automation_event_recording(&self) {
         unsafe { ffi::StartAutomationEventRecording() };
     }
+
     /// Stop recording automation events
     #[inline]
     pub fn stop_automation_event_recording(&self) {

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -19,10 +19,19 @@ impl AutomationEventIter<'_> {
             events.is_aligned(),
             "automation event array must be aligned"
         );
-        let iter = unsafe { std::slice::from_raw_parts(events, count as usize) }.iter();
+        let iter = unsafe {
+            std::slice::from_raw_parts(
+                events,
+                count
+                    .try_into()
+                    .expect("slice should not exceed usize::MAX elements"),
+            )
+        }
+        .iter();
         Self { iter }
     }
-    fn func(e: &ffi::AutomationEvent) -> AutomationEvent {
+
+    const fn func(e: &ffi::AutomationEvent) -> AutomationEvent {
         // This relies on the fact that `ffi::AutomationEvent` is Copy `unload_automation_event` doesn't actually do anything.
         AutomationEvent(*e)
     }
@@ -82,21 +91,36 @@ impl AutomationEventList {
     pub const fn count(&self) -> u32 {
         self.0.count
     }
+
     /// The amount of automation events that can be held in this list.
     #[inline]
     #[must_use]
     pub const fn capacity(&self) -> u32 {
         self.0.capacity
     }
+
     /// The events held in this list.
+    ///
     /// NOTE: This will copy the values into a vector.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `self` contains more than [`usize::MAX`] events.
     #[must_use]
     pub fn events(&self) -> Vec<AutomationEvent> {
-        unsafe { std::slice::from_raw_parts(self.0.events, self.count() as usize) }
-            .iter()
-            .map(|f| AutomationEvent(*f))
-            .collect()
+        unsafe {
+            std::slice::from_raw_parts(
+                self.0.events,
+                self.count()
+                    .try_into()
+                    .expect("slice should not exceed usize::MAX elements"),
+            )
+        }
+        .iter()
+        .map(|f| AutomationEvent(*f))
+        .collect()
     }
+
     /// An iterator over the events held in this list.
     #[must_use]
     pub fn iter(&self) -> AutomationEventIter<'_> {
@@ -161,7 +185,7 @@ impl AutomationEvent {
     }
 }
 
-fn unload_automation_event(_s: ffi::AutomationEvent) {
+const fn unload_automation_event(_s: ffi::AutomationEvent) {
     // As far as I can tell, this is actually unloaded when UnloadAnimationEventList is called.
 }
 

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::{RaylibHandle, ffi};
 
+/// Iterator over [`AutomationEvent`]s. Returned by [`AutomationEventList::iter`].
 #[derive(Debug, Clone)]
 pub struct AutomationEventIter<'a> {
     iter: std::slice::Iter<'a, ffi::AutomationEvent>,

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -242,12 +242,14 @@ extern "C" fn custom_audio_stream_callback(a: *mut c_void, b: u32) {
     let a = unsafe { std::slice::from_raw_parts(a.cast::<u8>(), b as usize) };
     audio_stream(a);
 }
+
+/// Error caused by attempting to reassign a Raylib callback after it has been set.
 #[derive(Debug)]
 pub struct SetCallbackError(&'static str);
 
 impl std::fmt::Display for SetCallbackError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("There is a {} callback already set.", self.0))
+        write!(f, "there is a {} callback already set", self.0)
     }
 }
 
@@ -445,6 +447,10 @@ where
 /// # Errors
 ///
 /// This function returns [`SetCallbackError`] if a custom `audio_stream` callback is already set.
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "changing this could be a breaking change"
+)]
 pub fn set_audio_stream_callback(
     stream: AudioStream,
     cb: RustAudioStreamCallback,
@@ -530,6 +536,10 @@ impl RaylibHandle {
     ///
     /// This function returns [`SetCallbackError`] if a custom `audio_stream` callback is already set.
     #[deprecated = "Decoupled from RaylibHandle. Use [`set_audio_stream_callback`](core::callbacks::set_audio_stream_callback) instead."]
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "function is deprecated and therefore should not have changes to the interface"
+    )]
     pub fn set_audio_stream_callback(
         &mut self,
         stream: AudioStream,

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -29,8 +29,9 @@ unsafe extern "C" {
 
 mod sealed {
     use super::{
-        RustAudioStreamCallback, RustLoadFileDataCallback, RustLoadFileTextCallback,
-        RustSaveFileDataCallback, RustSaveFileTextCallback, RustTraceLogCallback,
+        AtomicFn, AtomicUsize, RustAudioStreamCallback, RustLoadFileDataCallback,
+        RustLoadFileTextCallback, RustSaveFileDataCallback, RustSaveFileTextCallback,
+        RustTraceLogCallback,
     };
     use std::num::NonZeroUsize;
 
@@ -57,6 +58,7 @@ mod sealed {
                 assert!(std::mem::size_of::<$Callback>() == std::mem::size_of::<NonZeroUsize>());
                 assert!(std::mem::align_of::<$Callback>() == std::mem::align_of::<NonZeroUsize>());
                 assert!(std::mem::size_of::<Option<$Callback>>() == std::mem::size_of::<$Callback>());
+                assert!(std::mem::size_of::<AtomicFn<$Callback>>() == std::mem::size_of::<AtomicUsize>());
             };
 
             unsafe impl AtomicFnExt for $Callback {

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -1,19 +1,22 @@
 #![allow(non_camel_case_types)]
 
-use crate::{RaylibHandle, audio::AudioStream, ffi};
-pub use raylib_sys::TraceLogLevel;
+mod stream_processor_with_user_data_wrapper;
+
+use crate::{
+    RaylibHandle,
+    audio::{AudioStream, Music},
+    ffi::{self, TraceLogLevel},
+};
 use std::{
     borrow::Cow,
     convert::TryInto,
     ffi::{CStr, CString, c_char, c_int, c_void},
-    mem::{size_of, transmute},
+    marker::PhantomData,
     pin::Pin,
     ptr::null_mut,
     slice::from_raw_parts_mut,
     sync::atomic::{AtomicUsize, Ordering},
 };
-mod stream_processor_with_user_data_wrapper;
-use super::audio::Music;
 use stream_processor_with_user_data_wrapper::{
     AudioCallbackWithUserData, attach_audio_stream_processor_with_user_data,
     detach_audio_stream_processor_with_user_data,
@@ -24,6 +27,100 @@ unsafe extern "C" {
     fn SetTraceLogCallback(cb: Option<TraceLogCallback>);
 }
 
+mod sealed {
+    use super::{
+        RustAudioStreamCallback, RustLoadFileDataCallback, RustLoadFileTextCallback,
+        RustSaveFileDataCallback, RustSaveFileTextCallback, RustTraceLogCallback,
+    };
+    use std::num::NonZeroUsize;
+
+    /// # Safety
+    ///
+    /// `Self` and `NonZeroUsize` must be safe to convert between and call across threads.
+    pub unsafe trait AtomicFnExt: Sized + Send + Sync {
+        #[must_use]
+        fn into_nonzero(self) -> NonZeroUsize;
+
+        #[must_use]
+        fn from_nonzero(val: NonZeroUsize) -> Self;
+
+        #[must_use]
+        fn into_usize(val: Option<Self>) -> usize;
+
+        #[must_use]
+        fn from_usize(val: usize) -> Option<Self>;
+    }
+
+    macro_rules! impl_atomic_fn_ext {
+        ($(unsafe impl AtomicFnExt for $Callback:ident {})*) => {$(
+            const _: () = {
+                assert!(std::mem::size_of::<$Callback>() == std::mem::size_of::<NonZeroUsize>());
+                assert!(std::mem::align_of::<$Callback>() == std::mem::align_of::<NonZeroUsize>());
+                assert!(std::mem::size_of::<Option<$Callback>>() == std::mem::size_of::<$Callback>());
+            };
+
+            unsafe impl AtomicFnExt for $Callback {
+                #[inline(always)]
+                fn into_nonzero(self) -> NonZeroUsize {
+                    // SAFETY: Implementor must uphold trait safety contract
+                    unsafe { std::mem::transmute::<$Callback, NonZeroUsize>(self) }
+                }
+
+                #[inline(always)]
+                fn from_nonzero(val: NonZeroUsize) -> $Callback {
+                    // SAFETY: Implementor must uphold trait safety contract
+                    unsafe { std::mem::transmute::<NonZeroUsize, $Callback>(val) }
+                }
+
+                #[inline(always)]
+                fn into_usize(val: Option<$Callback>) -> usize {
+                    // SAFETY: Implementor must uphold trait safety contract
+                    unsafe { std::mem::transmute::<Option<$Callback>, usize>(val) }
+                }
+
+                #[inline(always)]
+                fn from_usize(val: usize) -> Option<$Callback> {
+                    // SAFETY: Implementor must uphold trait safety contract
+                    unsafe { std::mem::transmute::<usize, Option<$Callback>>(val) }
+                }
+            }
+        )*};
+    }
+
+    impl_atomic_fn_ext! {
+        unsafe impl AtomicFnExt for RustTraceLogCallback {}
+        unsafe impl AtomicFnExt for RustSaveFileDataCallback {}
+        unsafe impl AtomicFnExt for RustLoadFileDataCallback {}
+        unsafe impl AtomicFnExt for RustSaveFileTextCallback {}
+        unsafe impl AtomicFnExt for RustLoadFileTextCallback {}
+        unsafe impl AtomicFnExt for RustAudioStreamCallback {}
+    }
+}
+use sealed::AtomicFnExt;
+
+#[repr(transparent)]
+struct AtomicFn<F: AtomicFnExt>(AtomicUsize, PhantomData<F>);
+
+impl<F: AtomicFnExt> AtomicFn<F> {
+    /// Construct a null function pointer
+    #[inline]
+    pub const fn null() -> Self {
+        Self(AtomicUsize::new(0), PhantomData)
+    }
+
+    /// Stores a value into the atomic function pointer.
+    #[inline]
+    pub fn store(&self, val: Option<F>, order: Ordering) {
+        self.0.store(AtomicFnExt::into_usize(val), order);
+    }
+
+    /// Loads a value from the atomic function pointer.
+    #[inline]
+    pub fn load(&self, order: Ordering) -> Option<F> {
+        AtomicFnExt::from_usize(self.0.load(order))
+    }
+}
+
 type RustTraceLogCallback = fn(TraceLogLevel, &str);
 type RustSaveFileDataCallback = fn(&str, &[u8]) -> bool;
 type RustLoadFileDataCallback = fn(&str) -> Vec<u8>;
@@ -31,41 +128,37 @@ type RustSaveFileTextCallback = fn(&str, &str) -> bool;
 type RustLoadFileTextCallback = fn(&str) -> String;
 type RustAudioStreamCallback = fn(&[u8]);
 
-static TRACE_LOG_CALLBACK: AtomicUsize = AtomicUsize::new(0);
-static SAVE_FILE_DATA_CALLBACK: AtomicUsize = AtomicUsize::new(0);
-static LOAD_FILE_DATA_CALLBACK: AtomicUsize = AtomicUsize::new(0);
-static SAVE_FILE_TEXT_CALLBACK: AtomicUsize = AtomicUsize::new(0);
-static LOAD_FILE_TEXT_CALLBACK: AtomicUsize = AtomicUsize::new(0);
-static AUDIO_STREAM_CALLBACK: AtomicUsize = AtomicUsize::new(0);
+const _: () = {};
+
+static TRACE_LOG_CALLBACK: AtomicFn<RustTraceLogCallback> = AtomicFn::null();
+static SAVE_FILE_DATA_CALLBACK: AtomicFn<RustSaveFileDataCallback> = AtomicFn::null();
+static LOAD_FILE_DATA_CALLBACK: AtomicFn<RustLoadFileDataCallback> = AtomicFn::null();
+static SAVE_FILE_TEXT_CALLBACK: AtomicFn<RustSaveFileTextCallback> = AtomicFn::null();
+static LOAD_FILE_TEXT_CALLBACK: AtomicFn<RustLoadFileTextCallback> = AtomicFn::null();
+static AUDIO_STREAM_CALLBACK: AtomicFn<RustAudioStreamCallback> = AtomicFn::null();
 
 fn trace_log_callback() -> Option<RustTraceLogCallback> {
-    debug_assert!(size_of::<RustTraceLogCallback>() == size_of::<usize>());
-    unsafe { transmute(TRACE_LOG_CALLBACK.load(Ordering::Relaxed)) }
+    TRACE_LOG_CALLBACK.load(Ordering::Relaxed)
 }
 
 fn save_file_data_callback() -> Option<RustSaveFileDataCallback> {
-    debug_assert!(size_of::<RustSaveFileDataCallback>() == size_of::<usize>());
-    unsafe { transmute(SAVE_FILE_DATA_CALLBACK.load(Ordering::Relaxed)) }
+    SAVE_FILE_DATA_CALLBACK.load(Ordering::Relaxed)
 }
 
 fn load_file_data_callback() -> Option<RustLoadFileDataCallback> {
-    debug_assert!(size_of::<RustLoadFileDataCallback>() == size_of::<usize>());
-    unsafe { transmute(LOAD_FILE_DATA_CALLBACK.load(Ordering::Relaxed)) }
+    LOAD_FILE_DATA_CALLBACK.load(Ordering::Relaxed)
 }
 
 fn save_file_text_callback() -> Option<RustSaveFileTextCallback> {
-    debug_assert!(size_of::<RustSaveFileTextCallback>() == size_of::<usize>());
-    unsafe { transmute(SAVE_FILE_TEXT_CALLBACK.load(Ordering::Relaxed)) }
+    SAVE_FILE_TEXT_CALLBACK.load(Ordering::Relaxed)
 }
 
 fn load_file_text_callback() -> Option<RustLoadFileTextCallback> {
-    debug_assert!(size_of::<RustLoadFileTextCallback>() == size_of::<usize>());
-    unsafe { transmute(LOAD_FILE_TEXT_CALLBACK.load(Ordering::Relaxed)) }
+    LOAD_FILE_TEXT_CALLBACK.load(Ordering::Relaxed)
 }
 
 fn audio_stream_callback() -> Option<RustAudioStreamCallback> {
-    debug_assert!(size_of::<RustAudioStreamCallback>() == size_of::<usize>());
-    unsafe { transmute(AUDIO_STREAM_CALLBACK.load(Ordering::Relaxed)) }
+    AUDIO_STREAM_CALLBACK.load(Ordering::Relaxed)
 }
 
 /// # Safety
@@ -148,36 +241,44 @@ extern "C" fn custom_audio_stream_callback(a: *mut c_void, b: u32) {
     audio_stream(a);
 }
 #[derive(Debug)]
-pub struct SetLogError<'a>(&'a str);
+pub struct SetCallbackError(&'static str);
 
-impl std::fmt::Display for SetLogError<'_> {
+impl std::fmt::Display for SetCallbackError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("There is a {} callback already set.", self.0))
     }
 }
 
-impl std::error::Error for SetLogError<'_> {}
+impl std::error::Error for SetCallbackError {}
 
 macro_rules! safe_callback_set_func {
     ($cb:expr, $target_cb:expr, $rawsetter:expr, $ogfunc:expr, $ty:literal) => {
-        if $target_cb.load(Ordering::Acquire) == 0 {
-            $target_cb.store($cb as usize, Ordering::Release);
+        if $target_cb.load(Ordering::Acquire).is_none() {
+            $target_cb.store(Some($cb), Ordering::Release);
             unsafe { $rawsetter(Some($ogfunc)) };
             Ok(())
         } else {
-            Err(SetLogError($ty))
+            Err(SetCallbackError($ty))
         }
     };
 }
 
 /// Set custom trace log
-pub fn set_trace_log_callback<'a>(cb: fn(TraceLogLevel, &str)) -> Result<(), SetLogError<'a>> {
-    TRACE_LOG_CALLBACK.store(cb as usize, Ordering::Relaxed);
+///
+/// # Errors
+///
+/// This function does not error currently.
+pub fn set_trace_log_callback(cb: RustTraceLogCallback) -> Result<(), SetCallbackError> {
+    TRACE_LOG_CALLBACK.store(Some(cb), Ordering::Relaxed);
     unsafe { ffi::setLogCallbackWrapper() };
     Ok(())
 }
 /// Set custom file binary data saver
-pub fn set_save_file_data_callback<'a>(cb: fn(&str, &[u8]) -> bool) -> Result<(), SetLogError<'a>> {
+///
+/// # Errors
+///
+/// This function returns [`SetCallbackError`] if a custom `save_file_data` callback is already set.
+pub fn set_save_file_data_callback(cb: RustSaveFileDataCallback) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         SAVE_FILE_DATA_CALLBACK,
@@ -189,7 +290,11 @@ pub fn set_save_file_data_callback<'a>(cb: fn(&str, &[u8]) -> bool) -> Result<()
 /// Set custom file binary data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-pub fn set_load_file_data_callback<'b>(cb: fn(&str) -> Vec<u8>) -> Result<(), SetLogError<'b>> {
+///
+/// # Errors
+///
+/// This function returns [`SetCallbackError`] if a custom `load_file_data` callback is already set.
+pub fn set_load_file_data_callback(cb: RustLoadFileDataCallback) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         LOAD_FILE_DATA_CALLBACK,
@@ -199,7 +304,11 @@ pub fn set_load_file_data_callback<'b>(cb: fn(&str) -> Vec<u8>) -> Result<(), Se
     )
 }
 /// Set custom file text data saver
-pub fn set_save_file_text_callback<'a>(cb: fn(&str, &str) -> bool) -> Result<(), SetLogError<'a>> {
+///
+/// # Errors
+///
+/// This function returns [`SetCallbackError`] if a custom `save_file_text` callback is already set.
+pub fn set_save_file_text_callback(cb: RustSaveFileTextCallback) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         SAVE_FILE_TEXT_CALLBACK,
@@ -211,7 +320,11 @@ pub fn set_save_file_text_callback<'a>(cb: fn(&str, &str) -> bool) -> Result<(),
 /// Set custom file text data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-pub fn set_load_file_text_callback<'a>(cb: fn(&str) -> String) -> Result<(), SetLogError<'a>> {
+///
+/// # Errors
+///
+/// This function returns [`SetCallbackError`] if a custom `load_file_text` callback is already set.
+pub fn set_load_file_text_callback(cb: RustLoadFileTextCallback) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         LOAD_FILE_TEXT_CALLBACK,
@@ -240,7 +353,7 @@ impl<'a, F> AudioStreamProcessorCallback<'a, F>
 where
     F: FnMut(&mut [f32], u32),
 {
-    fn new(closure: &'a mut F, nb_channels_from_music: u32) -> Self {
+    const fn new(closure: &'a mut F, nb_channels_from_music: u32) -> Self {
         Self {
             rust_callback: closure,
             nb_channels: nb_channels_from_music,
@@ -248,7 +361,7 @@ where
         }
     }
 
-    fn get_as_user_data(&mut self) -> *mut ::std::os::raw::c_void {
+    const fn get_as_user_data(&mut self) -> *mut ::std::os::raw::c_void {
         std::ptr::from_mut(self).cast::<::std::os::raw::c_void>()
     }
 
@@ -259,6 +372,7 @@ where
         *mut ::std::os::raw::c_void,
         ::std::os::raw::c_uint,
     ) {
+        _ = self;
         Self::c_callback
     }
 
@@ -325,75 +439,106 @@ where
 }
 
 /// Audio thread callback to request new data
-pub fn set_audio_stream_callback(stream: AudioStream, cb: fn(&[u8])) -> Result<(), SetLogError> {
-    if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire) == 0 {
-        AUDIO_STREAM_CALLBACK.store(cb as _, Ordering::Release);
+///
+/// # Errors
+///
+/// This function returns [`SetCallbackError`] if a custom `audio_stream` callback is already set.
+pub fn set_audio_stream_callback(
+    stream: AudioStream,
+    cb: RustAudioStreamCallback,
+) -> Result<(), SetCallbackError> {
+    if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire).is_none() {
+        AUDIO_STREAM_CALLBACK.store(Some(cb), Ordering::Release);
         unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }
         Ok(())
     } else {
-        Err(SetLogError("audio stream"))
+        Err(SetCallbackError("audio stream"))
     }
 }
 
 impl RaylibHandle {
     /// Set custom trace log
-    #[deprecated = "Decoupled from RaylibHandle. Use [set_trace_log_callback](core::callbacks::set_trace_log_callback) instead."]
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`SetCallbackError`] if a custom `trace_log` callback is already set.
+    #[deprecated = "Decoupled from RaylibHandle. Use [`set_trace_log_callback`](core::callbacks::set_trace_log_callback) instead."]
     pub fn set_trace_log_callback(
         &mut self,
-        cb: fn(TraceLogLevel, &str),
-    ) -> Result<(), SetLogError> {
+        cb: RustTraceLogCallback,
+    ) -> Result<(), SetCallbackError> {
         set_trace_log_callback(cb)
     }
     /// Set custom file binary data saver
-    #[deprecated = "Decoupled from RaylibHandle. Use [set_save_file_data_callback](core::callbacks::set_save_file_data_callback) instead."]
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`SetCallbackError`] if a custom `save_file_data` callback is already set.
+    #[deprecated = "Decoupled from RaylibHandle. Use [`set_save_file_data_callback`](core::callbacks::set_save_file_data_callback) instead."]
     pub fn set_save_file_data_callback(
         &mut self,
-        cb: fn(&str, &[u8]) -> bool,
-    ) -> Result<(), SetLogError> {
+        cb: RustSaveFileDataCallback,
+    ) -> Result<(), SetCallbackError> {
         set_save_file_data_callback(cb)
     }
     /// Set custom file binary data loader
     ///
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-    #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_data_callback](core::callbacks::set_load_file_data_callback) instead."]
-    pub fn set_load_file_data_callback<'b>(
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`SetCallbackError`] if a custom `load_file_data` callback is already set.
+    #[deprecated = "Decoupled from RaylibHandle. Use [`set_load_file_data_callback`](core::callbacks::set_load_file_data_callback) instead."]
+    pub fn set_load_file_data_callback(
         &mut self,
-        cb: fn(&str) -> Vec<u8>,
-    ) -> Result<(), SetLogError> {
+        cb: RustLoadFileDataCallback,
+    ) -> Result<(), SetCallbackError> {
         set_load_file_data_callback(cb)
     }
     /// Set custom file text data saver
-    #[deprecated = "Decoupled from RaylibHandle. Use [set_save_file_text_callback](core::callbacks::set_save_file_text_callback) instead."]
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`SetCallbackError`] if a custom `save_file_text` callback is already set.
+    #[deprecated = "Decoupled from RaylibHandle. Use [`set_save_file_text_callback`](core::callbacks::set_save_file_text_callback) instead."]
     pub fn set_save_file_text_callback(
         &mut self,
-        cb: fn(&str, &str) -> bool,
-    ) -> Result<(), SetLogError> {
+        cb: RustSaveFileTextCallback,
+    ) -> Result<(), SetCallbackError> {
         set_save_file_text_callback(cb)
     }
     /// Set custom file text data loader
     ///
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-    #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_text_callback](core::callbacks::set_load_file_text_callback) instead."]
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`SetCallbackError`] if a custom `load_file_text` callback is already set.
+    #[deprecated = "Decoupled from RaylibHandle. Use [`set_load_file_text_callback`](core::callbacks::set_load_file_text_callback) instead."]
     pub fn set_load_file_text_callback(
         &mut self,
-        cb: fn(&str) -> String,
-    ) -> Result<(), SetLogError> {
+        cb: RustLoadFileTextCallback,
+    ) -> Result<(), SetCallbackError> {
         set_load_file_text_callback(cb)
     }
 
     /// Audio thread callback to request new data
-    #[deprecated = "Decoupled from RaylibHandle. Use [set_audio_stream_callback](core::callbacks::set_audio_stream_callback) instead."]
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`SetCallbackError`] if a custom `audio_stream` callback is already set.
+    #[deprecated = "Decoupled from RaylibHandle. Use [`set_audio_stream_callback`](core::callbacks::set_audio_stream_callback) instead."]
     pub fn set_audio_stream_callback(
         &mut self,
         stream: AudioStream,
-        cb: fn(&[u8]),
-    ) -> Result<(), SetLogError> {
-        if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire) == 0 {
-            AUDIO_STREAM_CALLBACK.store(cb as _, Ordering::Release);
+        cb: RustAudioStreamCallback,
+    ) -> Result<(), SetCallbackError> {
+        if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire).is_none() {
+            AUDIO_STREAM_CALLBACK.store(Some(cb), Ordering::Release);
             unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }
             Ok(())
         } else {
-            Err(SetLogError("audio stream"))
+            Err(SetCallbackError("audio stream"))
         }
     }
 }

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -1,4 +1,4 @@
-// #![allow(non_camel_case_types)]
+//! Wrappers for callbacks
 
 mod stream_processor_with_user_data_wrapper;
 
@@ -22,10 +22,10 @@ use stream_processor_with_user_data_wrapper::{
     detach_audio_stream_processor_with_user_data,
 };
 
-// type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
-// unsafe extern "C" {
-//     fn SetTraceLogCallback(cb: Option<TraceLogCallback>);
-// }
+type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
+unsafe extern "C" {
+    fn SetTraceLogCallback(cb: Option<TraceLogCallback>);
+}
 
 mod sealed {
     use super::{
@@ -37,7 +37,7 @@ mod sealed {
 
     /// # Safety
     ///
-    /// `Self` and `NonZeroUsize` must be safe to convert between and call across threads.
+    /// `Self` and `usize` must be safe to convert between and call across threads.
     pub unsafe trait AtomicFnExt: Sized + Send + Sync {
         #[must_use]
         fn into_usize(val: Option<Self>) -> usize;
@@ -55,6 +55,7 @@ mod sealed {
                 assert!(std::mem::size_of::<AtomicFn<$Callback>>() == std::mem::size_of::<AtomicUsize>());
             };
 
+            // SAFETY: Asserted size and align, and $Callback is safe to use across threads
             unsafe impl AtomicFnExt for $Callback {
                 #[inline(always)]
                 fn into_usize(val: Option<$Callback>) -> usize {

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use std::{
     borrow::Cow,
-    convert::TryInto,
     ffi::{CStr, CString, c_char, c_int, c_void},
     marker::PhantomData,
     pin::Pin,
@@ -155,6 +154,7 @@ pub unsafe extern "C" fn custom_trace_log_callback(level: TraceLogLevel, text: *
         let text = if text.is_null() {
             Cow::Borrowed("(MESSAGE WAS NULL)")
         } else {
+            // SAFETY: Caller must uphold safety contract
             unsafe { CStr::from_ptr(text).to_string_lossy() }
         };
 
@@ -260,6 +260,7 @@ pub fn set_trace_log_callback(cb: RustTraceLogCallback) -> Result<(), SetCallbac
     unsafe { ffi::setLogCallbackWrapper() };
     Ok(())
 }
+
 /// Set custom file binary data saver
 ///
 /// # Errors
@@ -274,6 +275,7 @@ pub fn set_save_file_data_callback(cb: RustSaveFileDataCallback) -> Result<(), S
         "save file data"
     )
 }
+
 /// Set custom file binary data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
@@ -290,6 +292,7 @@ pub fn set_load_file_data_callback(cb: RustLoadFileDataCallback) -> Result<(), S
         "load file data"
     )
 }
+
 /// Set custom file text data saver
 ///
 /// # Errors
@@ -304,6 +307,7 @@ pub fn set_save_file_text_callback(cb: RustSaveFileTextCallback) -> Result<(), S
         "load file data"
     )
 }
+
 /// Set custom file text data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
@@ -432,7 +436,7 @@ where
 /// This function returns [`SetCallbackError`] if a custom `audio_stream` callback is already set.
 #[allow(
     clippy::needless_pass_by_value,
-    reason = "changing this could be a breaking change"
+    reason = "fixing this could be a breaking change"
 )]
 pub fn set_audio_stream_callback(
     stream: AudioStream,
@@ -460,6 +464,7 @@ impl RaylibHandle {
     ) -> Result<(), SetCallbackError> {
         set_trace_log_callback(cb)
     }
+
     /// Set custom file binary data saver
     ///
     /// # Errors
@@ -472,6 +477,7 @@ impl RaylibHandle {
     ) -> Result<(), SetCallbackError> {
         set_save_file_data_callback(cb)
     }
+
     /// Set custom file binary data loader
     ///
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
@@ -486,6 +492,7 @@ impl RaylibHandle {
     ) -> Result<(), SetCallbackError> {
         set_load_file_data_callback(cb)
     }
+
     /// Set custom file text data saver
     ///
     /// # Errors
@@ -498,6 +505,7 @@ impl RaylibHandle {
     ) -> Result<(), SetCallbackError> {
         set_save_file_text_callback(cb)
     }
+
     /// Set custom file text data loader
     ///
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -14,7 +14,10 @@ use std::{
 };
 mod stream_processor_with_user_data_wrapper;
 use super::audio::Music;
-use stream_processor_with_user_data_wrapper::*;
+use stream_processor_with_user_data_wrapper::{
+    AudioCallbackWithUserData, attach_audio_stream_processor_with_user_data,
+    detach_audio_stream_processor_with_user_data,
+};
 
 type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
 unsafe extern "C" {
@@ -65,6 +68,9 @@ fn audio_stream_callback() -> Option<RustAudioStreamCallback> {
     unsafe { transmute(AUDIO_STREAM_CALLBACK.load(Ordering::Relaxed)) }
 }
 
+/// # Safety
+///
+/// This method converts `text` to a [`CStr`] without checks. It is the caller's responsibility to ensure that `text` meets the safety requirements of [`CStr::from_ptr`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn custom_trace_log_callback(level: TraceLogLevel, text: *const c_char) {
     if let Some(trace_log) = trace_log_callback() {
@@ -74,7 +80,7 @@ pub unsafe extern "C" fn custom_trace_log_callback(level: TraceLogLevel, text: *
             unsafe { CStr::from_ptr(text).to_string_lossy() }
         };
 
-        trace_log(level, &text)
+        trace_log(level, &text);
     }
 }
 
@@ -85,9 +91,14 @@ extern "C" fn custom_save_file_data_callback(
 ) -> bool {
     let save_file_data = save_file_data_callback().expect("no callback");
     let path = unsafe { CStr::from_ptr(path) };
-    let buffer = unsafe { from_raw_parts_mut(buffer as *mut u8, size as usize) };
+    let buffer = unsafe {
+        from_raw_parts_mut(
+            buffer.cast::<u8>(),
+            size.try_into().expect("size should not be negative"),
+        )
+    };
 
-    save_file_data(path.to_str().expect("path is non utf-8"), buffer)
+    save_file_data(path.to_str().expect("path should be non utf-8"), buffer)
 }
 
 extern "C" fn custom_load_file_data_callback(path: *const c_char, size: *mut c_int) -> *mut u8 {
@@ -99,48 +110,53 @@ extern "C" fn custom_load_file_data_callback(path: *const c_char, size: *mut c_i
         *size = buffer.len().try_into().expect("out of range buffer size");
 
         // Copy everything to the raylib world
+        let buffer_ffi =
+            unsafe { ffi::MemAlloc((*size).try_into().expect("non representable buffer size")) }
+                .cast::<u8>();
         unsafe {
-            let buffer_ffi =
-                ffi::MemAlloc((*size).try_into().expect("non representable buffer size"))
-                    as *mut u8;
             buffer_ffi.copy_from_nonoverlapping(buffer.as_ptr(), buffer.len());
-
-            buffer_ffi
         }
+
+        buffer_ffi
     } else {
         null_mut()
     }
 }
 
 extern "C" fn custom_save_file_text_callback(a: *const c_char, b: *mut c_char) -> bool {
-    let save_file_text = save_file_text_callback().unwrap();
+    let save_file_text = save_file_text_callback().expect("callback should be initialized");
     let a = unsafe { CStr::from_ptr(a) };
     let b = unsafe { CStr::from_ptr(b) };
-    return save_file_text(a.to_str().unwrap(), b.to_str().unwrap());
+    save_file_text(
+        a.to_str().expect("string should be utf-8"),
+        b.to_str().expect("string should be utf-8"),
+    )
 }
 extern "C" fn custom_load_file_text_callback(a: *const c_char) -> *mut c_char {
-    let load_file_text = load_file_text_callback().unwrap();
+    let load_file_text = load_file_text_callback().expect("callback should be initialized");
     let a = unsafe { CStr::from_ptr(a) };
-    let st = load_file_text(a.to_str().unwrap());
-    let oh = Box::leak(Box::new(CString::new(st).unwrap()));
-    oh.as_ptr() as *mut c_char
+    let st = load_file_text(a.to_str().expect("string should be utf-8"));
+    let oh = Box::leak(Box::new(
+        CString::new(st).expect("string should not contain an internal 0 byte"),
+    ));
+    oh.as_ptr().cast_mut().cast::<c_char>()
 }
 
 extern "C" fn custom_audio_stream_callback(a: *mut c_void, b: u32) {
-    let audio_stream = audio_stream_callback().unwrap();
-    let a = unsafe { std::slice::from_raw_parts(a as *mut u8, b as usize) };
+    let audio_stream = audio_stream_callback().expect("callback should be initialized");
+    let a = unsafe { std::slice::from_raw_parts(a.cast::<u8>(), b as usize) };
     audio_stream(a);
 }
 #[derive(Debug)]
 pub struct SetLogError<'a>(&'a str);
 
-impl<'a> std::fmt::Display for SetLogError<'a> {
+impl std::fmt::Display for SetLogError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("There is a {} callback already set.", self.0))
     }
 }
 
-impl<'a> std::error::Error for SetLogError<'a> {}
+impl std::error::Error for SetLogError<'_> {}
 
 macro_rules! safe_callback_set_func {
     ($cb:expr, $target_cb:expr, $rawsetter:expr, $ogfunc:expr, $ty:literal) => {
@@ -208,12 +224,12 @@ pub fn set_load_file_text_callback<'a>(cb: fn(&str) -> String) -> Result<(), Set
 // region: -- AudioStreamProcessorCallback --
 
 /// This struct encapsulates a rust callback
-/// and guarantees the lifetime to be long enough ('a)
-/// (once `get_as_user_data` is called, it the struct
-/// should not be moved again! -> use Pin<..>)
+/// and guarantees the lifetime to be long enough (`'a`)
+/// (once [`Self::get_as_user_data`] is called, it the struct
+/// should not be moved again! -> use [`Pin<..>`])
 pub struct AudioStreamProcessorCallback<'a, F>
 where
-    F: FnMut(&mut [f32], u32) -> (),
+    F: FnMut(&mut [f32], u32),
 {
     rust_callback: &'a mut F,
     nb_channels: u32,
@@ -222,7 +238,7 @@ where
 
 impl<'a, F> AudioStreamProcessorCallback<'a, F>
 where
-    F: FnMut(&mut [f32], u32) -> (),
+    F: FnMut(&mut [f32], u32),
 {
     fn new(closure: &'a mut F, nb_channels_from_music: u32) -> Self {
         Self {
@@ -233,7 +249,7 @@ where
     }
 
     fn get_as_user_data(&mut self) -> *mut ::std::os::raw::c_void {
-        return self as *mut Self as *mut ::std::os::raw::c_void;
+        std::ptr::from_mut(self).cast::<::std::os::raw::c_void>()
     }
 
     fn get_c_callback(
@@ -242,7 +258,7 @@ where
         *mut ::std::os::raw::c_void,
         *mut ::std::os::raw::c_void,
         ::std::os::raw::c_uint,
-    ) -> () {
+    ) {
         Self::c_callback
     }
 
@@ -250,24 +266,23 @@ where
         user_data: *mut ::std::os::raw::c_void,
         data_ptr: *mut ::std::os::raw::c_void,
         frame_count: ::std::os::raw::c_uint,
-    ) -> () {
-        unsafe {
-            let stream_processor_callback: &mut Self = user_data.cast::<Self>().as_mut().unwrap();
-            let f32_ptr = data_ptr as *mut f32;
-            let data = {
-                std::slice::from_raw_parts_mut(
-                    f32_ptr,
-                    frame_count as usize * stream_processor_callback.nb_channels as usize,
-                )
-            };
-            (stream_processor_callback.rust_callback)(data, stream_processor_callback.nb_channels);
-        }
+    ) {
+        let stream_processor_callback =
+            unsafe { user_data.cast::<Self>().as_mut() }.expect("user_data should not be null");
+        let f32_ptr = data_ptr.cast();
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(
+                f32_ptr,
+                frame_count as usize * stream_processor_callback.nb_channels as usize,
+            )
+        };
+        (stream_processor_callback.rust_callback)(data, stream_processor_callback.nb_channels);
     }
 }
 
 impl<'a, F> Drop for AudioStreamProcessorCallback<'a, F>
 where
-    F: FnMut(&mut [f32], u32) -> (),
+    F: FnMut(&mut [f32], u32) + 'a,
 {
     fn drop(&mut self) {
         if let Some(index) = self.callback_index {
@@ -278,22 +293,33 @@ where
 
 // endregion: -- AudioStreamProcessorCallback --
 
+/// # Panics
+///
+/// This method will panic if `music`'s stream buffer is null.
 pub fn attach_audio_stream_processor_to_music<'a, F>(
     music: &'a Music<'a>,
     processor: &'a mut F,
 ) -> Pin<Box<AudioStreamProcessorCallback<'a, F>>>
 where
-    F: FnMut(&mut [f32], u32) -> () + Send + 'static, // static because the function is executed in another thread
+    F: FnMut(&mut [f32], u32) + Send + 'static, // static because the function is executed in another thread
 {
+    assert!(
+        !music.stream.buffer.is_null(),
+        "music stream buffer should not be null"
+    );
     let mut stream_processor_callback =
         Box::new(AudioStreamProcessorCallback::<'a, F>::new(processor, 2));
-    stream_processor_callback.callback_index = Some(attach_audio_stream_processor_with_user_data(
-        music.stream,
-        AudioCallbackWithUserData::new(
-            stream_processor_callback.get_as_user_data(), // pass the address of the stream_processor_callback as void*
-            stream_processor_callback.get_c_callback(),
-        ),
-    ));
+    // SAFETY: Checked `music.stream.buffer` and it is not null.
+    // TODO: How can we ensure `music`'s stream does not have any copies
+    stream_processor_callback.callback_index = Some(unsafe {
+        attach_audio_stream_processor_with_user_data(
+            music.stream,
+            AudioCallbackWithUserData::new(
+                stream_processor_callback.get_as_user_data(), // pass the address of the stream_processor_callback as void*
+                stream_processor_callback.get_c_callback(),
+            ),
+        )
+    });
     assert!(stream_processor_callback.callback_index.is_some());
     Box::into_pin(stream_processor_callback)
 }

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+// #![allow(non_camel_case_types)]
 
 mod stream_processor_with_user_data_wrapper;
 
@@ -22,10 +22,10 @@ use stream_processor_with_user_data_wrapper::{
     detach_audio_stream_processor_with_user_data,
 };
 
-type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
-unsafe extern "C" {
-    fn SetTraceLogCallback(cb: Option<TraceLogCallback>);
-}
+// type TraceLogCallback = unsafe extern "C" fn(*mut i8, *const i8, ...);
+// unsafe extern "C" {
+//     fn SetTraceLogCallback(cb: Option<TraceLogCallback>);
+// }
 
 mod sealed {
     use super::{
@@ -39,12 +39,6 @@ mod sealed {
     ///
     /// `Self` and `NonZeroUsize` must be safe to convert between and call across threads.
     pub unsafe trait AtomicFnExt: Sized + Send + Sync {
-        #[must_use]
-        fn into_nonzero(self) -> NonZeroUsize;
-
-        #[must_use]
-        fn from_nonzero(val: NonZeroUsize) -> Self;
-
         #[must_use]
         fn into_usize(val: Option<Self>) -> usize;
 
@@ -62,18 +56,6 @@ mod sealed {
             };
 
             unsafe impl AtomicFnExt for $Callback {
-                #[inline(always)]
-                fn into_nonzero(self) -> NonZeroUsize {
-                    // SAFETY: Implementor must uphold trait safety contract
-                    unsafe { std::mem::transmute::<$Callback, NonZeroUsize>(self) }
-                }
-
-                #[inline(always)]
-                fn from_nonzero(val: NonZeroUsize) -> $Callback {
-                    // SAFETY: Implementor must uphold trait safety contract
-                    unsafe { std::mem::transmute::<NonZeroUsize, $Callback>(val) }
-                }
-
                 #[inline(always)]
                 fn into_usize(val: Option<$Callback>) -> usize {
                     // SAFETY: Implementor must uphold trait safety contract

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -68,12 +68,11 @@ macro_rules! generate_functions {
 
           /// Function to set our context
           /// and returns the slot used to store the context.
-          #[allow(unpredictable_function_pointer_comparisons)]
           fn set_context(audio_callback: AudioCallbackWithUserData) -> usize {
               $(
                   {
                       let mut guard = [< CLOSURE_ $n >].lock().unwrap();
-                      if (*guard).callback == None {
+                      if (*guard).callback.is_none() {
                         *guard = audio_callback;
                         return $n;
                       }
@@ -83,12 +82,11 @@ macro_rules! generate_functions {
           }
 
           /// Function to clear our context given the slot of the context.
-          #[allow(unpredictable_function_pointer_comparisons)]
           fn clear_context(index: usize) {
               $(
                   if index == $n {
                       let mut guard = [< CLOSURE_ $n >].lock().unwrap();
-                      if (*guard).callback == None {
+                      if (*guard).callback.is_none() {
                           panic!(
                               "No callbacks registered under this number ({}).",
                               index

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -1,5 +1,5 @@
+use crate::ffi;
 use paste::paste;
-use raylib_sys::{AttachAudioStreamProcessor, AudioStream};
 use seq_macro::seq;
 use std::sync::{LazyLock, Mutex};
 
@@ -139,13 +139,23 @@ seq!(I in 1..30 {
 // endregion: -- raw callbacks and linkage
 
 /// Here, we c
-pub fn attach_audio_stream_processor_with_user_data(
-    stream: AudioStream,
+///
+/// # Safety
+///
+/// This method calls [`ffi::AttachAudioStreamProcessor`], which performs the following unsafe operations:
+/// - `RL_CALLOC`s an [`ffi::rAudioProcessor`] and immediately dereferences the result without checks.
+/// - Dereferences `stream.buffer` without checks.
+///
+/// There must be enough memory for Rayib to safely allocate 1 [`ffi::rAudioProcessor`] without `RL_CALLOC` returning null.
+/// `stream.buffer` must be non-null, aligned, and safe dereference for writing. The caller must uphold Rust's aliasing rules.
+pub unsafe fn attach_audio_stream_processor_with_user_data(
+    stream: ffi::AudioStream,
     callback: AudioCallbackWithUserData,
 ) -> usize {
     let idx = set_context(callback);
+    // SAFETY: Caller must uphold safety contract
     unsafe {
-        AttachAudioStreamProcessor(stream, Some(get_callback(idx)));
+        ffi::AttachAudioStreamProcessor(stream, Some(get_callback(idx)));
     }
     idx
 }

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -15,7 +15,7 @@ type RawAudioCallbackWithUserData = extern "C" fn(
 ) -> ();
 
 /// This is a tuple of `user_data` which represents
-/// our context (see RawAudioCallbackWithUserData)
+/// our context (see [`RawAudioCallbackWithUserData`])
 /// and the callback we wish to pass to our raylib
 /// abstraction layer (wrapping the real raylib
 /// callback to plug in our context).
@@ -32,7 +32,7 @@ impl AudioCallbackWithUserData {
         raw_callback: RawAudioCallbackWithUserData,
     ) -> Self {
         AudioCallbackWithUserData {
-            user_data: user_data,
+            user_data,
             callback: Some(raw_callback),
         }
     }

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -96,7 +96,7 @@ impl From<&mut Camera3D> for *mut ffi::Camera3D {
 impl Camera3D {
     #[must_use]
     #[inline]
-    pub fn camera_type(&self) -> ffi::CameraProjection {
+    pub const fn camera_type(&self) -> ffi::CameraProjection {
         self.projection
     }
 
@@ -104,7 +104,12 @@ impl Camera3D {
     /// fovy is in degrees
     #[must_use]
     #[inline]
-    pub fn perspective(position: Vector3, target: Vector3, up: Vector3, fovy: f32) -> Camera3D {
+    pub const fn perspective(
+        position: Vector3,
+        target: Vector3,
+        up: Vector3,
+        fovy: f32,
+    ) -> Camera3D {
         Camera3D {
             position,
             target,
@@ -118,7 +123,12 @@ impl Camera3D {
     /// fovy is in degrees
     #[must_use]
     #[inline]
-    pub fn orthographic(position: Vector3, target: Vector3, up: Vector3, fovy: f32) -> Camera3D {
+    pub const fn orthographic(
+        position: Vector3,
+        target: Vector3,
+        up: Vector3,
+        fovy: f32,
+    ) -> Camera3D {
         let mut c = Self::perspective(position, target, up, fovy);
         c.projection = ffi::CameraProjection::CAMERA_ORTHOGRAPHIC;
         c

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -1,14 +1,12 @@
 //! Utility code for using Raylib [`Camera3D`] and [`Camera2D`]
-use raylib_sys::CameraMode;
-use std::mem::transmute;
 
-use crate::ffi::{self, CameraProjection};
-use crate::math::{Vector2, Vector3};
 use crate::MintVec3;
+use crate::ffi;
+use crate::math::{Vector2, Vector3};
 
 use super::math::Matrix;
 
-/// Camera2D, defines position/orientation in 2d space
+/// [`Camera2D`], defines position/orientation in 2d space
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Camera2D {
@@ -23,7 +21,7 @@ pub struct Camera2D {
 }
 impl Camera2D {
     #[must_use]
-    #[inline(always)]
+    #[inline]
     #[allow(dead_code)]
     fn get_camera_matrix_2d(camera: impl Into<ffi::Camera2D>) -> Matrix {
         unsafe { ffi::GetCameraMatrix2D(camera.into()).into() }
@@ -36,15 +34,15 @@ impl From<ffi::Camera2D> for Camera2D {
     }
 }
 
-impl Into<ffi::Camera2D> for Camera2D {
-    fn into(self) -> ffi::Camera2D {
-        unsafe { std::mem::transmute(self) }
+impl From<Camera2D> for ffi::Camera2D {
+    fn from(v: Camera2D) -> Self {
+        unsafe { std::mem::transmute(v) }
     }
 }
 
-impl Into<ffi::Camera2D> for &Camera2D {
-    fn into(self) -> ffi::Camera2D {
-        unsafe { std::mem::transmute(*self) }
+impl From<&Camera2D> for ffi::Camera2D {
+    fn from(v: &Camera2D) -> Self {
+        unsafe { std::mem::transmute(*v) }
     }
 }
 
@@ -60,10 +58,10 @@ pub struct Camera3D {
     pub up: Vector3,
     /// Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic
     pub fovy: f32,
-    /// Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
-    pub projection: CameraProjection,
+    /// Camera projection: [`ffi::CameraProjection::CAMERA_PERSPECTIVE`] or [`ffi::CameraProjection::CAMERA_ORTHOGRAPHIC`]
+    pub projection: ffi::CameraProjection,
 }
-/// Camera type fallback, defaults to Camera3D
+/// [`Camera`] type fallback, defaults to [`Camera3D`]
 pub type Camera = Camera3D;
 
 impl From<ffi::Camera3D> for Camera3D {
@@ -72,98 +70,98 @@ impl From<ffi::Camera3D> for Camera3D {
     }
 }
 
-impl Into<ffi::Camera3D> for Camera3D {
-    fn into(self) -> ffi::Camera3D {
-        unsafe { std::mem::transmute(self) }
+impl From<Camera3D> for ffi::Camera3D {
+    fn from(v: Camera3D) -> Self {
+        unsafe { std::mem::transmute(v) }
     }
 }
 
-impl Into<ffi::Camera3D> for &Camera3D {
-    fn into(self) -> ffi::Camera3D {
-        unsafe { std::mem::transmute(*self) }
+impl From<&Camera3D> for ffi::Camera3D {
+    fn from(v: &Camera3D) -> Self {
+        unsafe { std::mem::transmute(*v) }
     }
 }
 
-impl Into<ffi::Camera3D> for &mut Camera3D {
-    fn into(self) -> ffi::Camera3D {
-        unsafe { std::mem::transmute(*self) }
+impl From<&mut Camera3D> for ffi::Camera3D {
+    fn from(v: &mut Camera3D) -> Self {
+        unsafe { std::mem::transmute(*v) }
     }
 }
 impl From<&mut Camera3D> for *mut ffi::Camera3D {
     fn from(val: &mut Camera3D) -> Self {
-        unsafe { std::mem::transmute(val) }
+        std::ptr::from_mut(val).cast()
     }
 }
 
 impl Camera3D {
     #[must_use]
-    #[inline(always)]
-    pub fn camera_type(&self) -> CameraProjection {
-        unsafe { transmute(self.projection as u32) }
+    #[inline]
+    pub fn camera_type(&self) -> ffi::CameraProjection {
+        self.projection
     }
 
-    #[must_use]
-    #[inline(always)]
     /// Create a perspective camera.
     /// fovy is in degrees
+    #[must_use]
+    #[inline]
     pub fn perspective(position: Vector3, target: Vector3, up: Vector3, fovy: f32) -> Camera3D {
         Camera3D {
             position,
             target,
             up,
             fovy,
-            projection: CameraProjection::CAMERA_PERSPECTIVE,
+            projection: ffi::CameraProjection::CAMERA_PERSPECTIVE,
         }
     }
 
-    #[must_use]
-    #[inline(always)]
     /// Create a orthographic camera.
     /// fovy is in degrees
+    #[must_use]
+    #[inline]
     pub fn orthographic(position: Vector3, target: Vector3, up: Vector3, fovy: f32) -> Camera3D {
         let mut c = Self::perspective(position, target, up, fovy);
-        c.projection = CameraProjection::CAMERA_ORTHOGRAPHIC;
+        c.projection = ffi::CameraProjection::CAMERA_ORTHOGRAPHIC;
         c
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn forward(&self) -> Vector3 {
-        unsafe { ffi::GetCameraForward(self as *const _ as *mut _).into() }
+        unsafe { ffi::GetCameraForward(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn up(&self) -> Vector3 {
-        unsafe { ffi::GetCameraUp(self as *const _ as *mut _).into() }
+        unsafe { ffi::GetCameraUp(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn move_forward(&mut self, distance: f32, in_world_plane: bool) {
         unsafe { ffi::CameraMoveForward(self.into(), distance, in_world_plane) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn move_up(&mut self, distance: f32) {
         unsafe { ffi::CameraMoveUp(self.into(), distance) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn move_right(&mut self, distance: f32, in_world_plane: bool) {
         unsafe { ffi::CameraMoveRight(self.into(), distance, in_world_plane) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn move_to_target(&mut self, delta: f32) {
         unsafe { ffi::CameraMoveToTarget(self.into(), delta) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn yaw(&mut self, angle: f32, rotate_around_target: bool) {
         unsafe { ffi::CameraYaw(self.into(), angle, rotate_around_target) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn pitch(
         &mut self,
         angle: f32,
@@ -178,31 +176,34 @@ impl Camera3D {
                 lock_view,
                 rotate_around_target,
                 rotate_up,
-            )
+            );
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn roll(&mut self, angle: f32) {
         unsafe { ffi::CameraRoll(self.into(), angle) }
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn view_matrix(&self) -> Matrix {
-        unsafe { ffi::GetCameraViewMatrix(self as *const _ as *mut _).into() }
+        unsafe { ffi::GetCameraViewMatrix(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn projection_matrix(&self, aspect: f32) -> Matrix {
-        unsafe { ffi::GetCameraProjectionMatrix(self as *const _ as *mut _, aspect).into() }
+        unsafe {
+            ffi::GetCameraProjectionMatrix(std::ptr::from_ref(self).cast_mut().cast(), aspect)
+                .into()
+        }
     }
     /// Updates camera position for selected mode.
-    #[inline(always)]
-    pub fn update_camera(&mut self, mode: CameraMode) {
+    #[inline]
+    pub fn update_camera(&mut self, mode: ffi::CameraMode) {
         unsafe { ffi::UpdateCamera(self.into(), mode as i32) }
     }
-    #[inline(always)]
+    #[inline]
     pub fn update_camera_pro(
         &mut self,
         movement: impl Into<MintVec3>,

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -1,6 +1,5 @@
 //! Utility code for using Raylib [`Camera3D`] and [`Camera2D`]
 
-use crate::MintVec3;
 use crate::ffi;
 use crate::math::{Vector2, Vector3};
 
@@ -94,6 +93,7 @@ impl From<&mut Camera3D> for *mut ffi::Camera3D {
 }
 
 impl Camera3D {
+    /// The projection this camera uses.
     #[must_use]
     #[inline]
     pub const fn camera_type(&self) -> ffi::CameraProjection {
@@ -101,7 +101,7 @@ impl Camera3D {
     }
 
     /// Create a perspective camera.
-    /// fovy is in degrees
+    /// `fovy` is in degrees
     #[must_use]
     #[inline]
     pub const fn perspective(
@@ -120,7 +120,7 @@ impl Camera3D {
     }
 
     /// Create a orthographic camera.
-    /// fovy is in degrees
+    /// `fovy` is in degrees
     #[must_use]
     #[inline]
     pub const fn orthographic(
@@ -134,43 +134,69 @@ impl Camera3D {
         c
     }
 
+    /// Returns the cameras forward vector (normalized)
     #[must_use]
     #[inline]
     pub fn forward(&self) -> Vector3 {
         unsafe { ffi::GetCameraForward(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
+    /// Returns the cameras up vector (normalized)
+    ///
+    /// Note: The up vector might not be perpendicular to the forward vector
     #[must_use]
     #[inline]
     pub fn up(&self) -> Vector3 {
         unsafe { ffi::GetCameraUp(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
+    /// Returns the cameras right vector (normalized)
+    #[must_use]
+    #[inline]
+    pub fn right(&self) -> Vector3 {
+        unsafe { ffi::GetCameraRight(std::ptr::from_ref(self).cast_mut().cast()).into() }
+    }
+
+    /// Moves the camera in its forward direction
     #[inline]
     pub fn move_forward(&mut self, distance: f32, in_world_plane: bool) {
         unsafe { ffi::CameraMoveForward(self.into(), distance, in_world_plane) }
     }
 
+    /// Moves the camera in its up direction
     #[inline]
     pub fn move_up(&mut self, distance: f32) {
         unsafe { ffi::CameraMoveUp(self.into(), distance) }
     }
 
+    /// Moves the camera target in its current right direction
     #[inline]
     pub fn move_right(&mut self, distance: f32, in_world_plane: bool) {
         unsafe { ffi::CameraMoveRight(self.into(), distance, in_world_plane) }
     }
 
+    /// Moves the camera position closer/farther to/from the camera target
     #[inline]
     pub fn move_to_target(&mut self, delta: f32) {
         unsafe { ffi::CameraMoveToTarget(self.into(), delta) }
     }
 
+    /// Rotates the camera around its up vector
+    /// Yaw is "looking left and right"
+    /// If `rotateAroundTarget` is false, the camera rotates around its position
+    ///
+    /// Note: `angle` must be provided in radians
     #[inline]
     pub fn yaw(&mut self, angle: f32, rotate_around_target: bool) {
         unsafe { ffi::CameraYaw(self.into(), angle, rotate_around_target) }
     }
 
+    /// Rotates the camera around its right vector, pitch is "looking up and down"
+    ///  - `lockView` prevents camera overrotation (aka "somersaults")
+    ///  - `rotateAroundTarget` defines if rotation is around target or around its position
+    ///  - `rotateUp` rotates the up direction as well (typically only usefull in [`CAMERA_FREE`](crate::consts::CameraMode::CAMERA_FREE))
+    ///
+    /// NOTE: `angle` must be provided in radians
     #[inline]
     pub fn pitch(
         &mut self,
@@ -190,16 +216,23 @@ impl Camera3D {
         }
     }
 
+    /// Rotates the camera around its forward vector
+    /// Roll is "turning your head sideways to the left or right"
+    ///
+    /// Note: `angle` must be provided in radians
     #[inline]
     pub fn roll(&mut self, angle: f32) {
         unsafe { ffi::CameraRoll(self.into(), angle) }
     }
 
+    /// Returns the camera view matrix
     #[must_use]
     #[inline]
     pub fn view_matrix(&self) -> Matrix {
         unsafe { ffi::GetCameraViewMatrix(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
+
+    /// Returns the camera projection matrix
     #[must_use]
     #[inline]
     pub fn projection_matrix(&self, aspect: f32) -> Matrix {
@@ -208,16 +241,19 @@ impl Camera3D {
                 .into()
         }
     }
+
     /// Updates camera position for selected mode.
     #[inline]
     pub fn update_camera(&mut self, mode: ffi::CameraMode) {
         unsafe { ffi::UpdateCamera(self.into(), mode as i32) }
     }
+
+    /// Update camera movement, movement/rotation values should be provided by user
     #[inline]
     pub fn update_camera_pro(
         &mut self,
-        movement: impl Into<MintVec3>,
-        rotation: impl Into<MintVec3>,
+        movement: impl Into<ffi::Vector3>,
+        rotation: impl Into<ffi::Vector3>,
         zoom: f32,
     ) {
         unsafe { ffi::UpdateCameraPro(self.into(), movement.into(), rotation.into(), zoom) }

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -19,10 +19,10 @@ pub struct Camera2D {
     pub zoom: f32,
 }
 impl Camera2D {
+    /// Get camera 2d transform matrix
     #[must_use]
     #[inline]
-    #[allow(dead_code)]
-    fn get_camera_matrix_2d(camera: impl Into<ffi::Camera2D>) -> Matrix {
+    pub fn get_camera_matrix_2d(camera: impl Into<ffi::Camera2D>) -> Matrix {
         unsafe { ffi::GetCameraMatrix2D(camera.into()).into() }
     }
 }

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -1,9 +1,9 @@
 //! Utility code for using Raylib [`Camera3D`] and [`Camera2D`]
 
-use crate::ffi;
-use crate::math::{Vector2, Vector3};
-
-use super::math::Matrix;
+use crate::{
+    ffi,
+    math::{Matrix, Vector2, Vector3},
+};
 
 /// [`Camera2D`], defines position/orientation in 2d space
 #[repr(C)]
@@ -18,29 +18,49 @@ pub struct Camera2D {
     /// Camera zoom (scaling), should be 1.0 by default
     pub zoom: f32,
 }
+
+assert_layout_compat!(
+    Camera2D {
+        offset,
+        target,
+        rotation,
+        zoom,
+    },
+    ffi::Camera2D {
+        offset,
+        target,
+        rotation,
+        zoom,
+    },
+);
+
 impl Camera2D {
     /// Get camera 2d transform matrix
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn get_camera_matrix_2d(camera: impl Into<ffi::Camera2D>) -> Matrix {
+        // SAFETY: GetCameraMatrix2D is a pure math function with no preconditions and is trivially safe
         unsafe { ffi::GetCameraMatrix2D(camera.into()).into() }
     }
 }
 
 impl From<ffi::Camera2D> for Camera2D {
     fn from(v: ffi::Camera2D) -> Self {
+        // SAFETY: Camera2D is repr(C) and has the same layout as ffi::Camera2D
         unsafe { std::mem::transmute(v) }
     }
 }
 
 impl From<Camera2D> for ffi::Camera2D {
     fn from(v: Camera2D) -> Self {
+        // SAFETY: Camera2D is repr(C) and has the same layout as ffi::Camera2D
         unsafe { std::mem::transmute(v) }
     }
 }
 
 impl From<&Camera2D> for ffi::Camera2D {
     fn from(v: &Camera2D) -> Self {
+        // SAFETY: Camera2D is repr(C) and has the same layout as ffi::Camera2D
         unsafe { std::mem::transmute(*v) }
     }
 }
@@ -60,50 +80,79 @@ pub struct Camera3D {
     /// Camera projection: [`ffi::CameraProjection::CAMERA_PERSPECTIVE`] or [`ffi::CameraProjection::CAMERA_ORTHOGRAPHIC`]
     pub projection: ffi::CameraProjection,
 }
+
 /// [`Camera`] type fallback, defaults to [`Camera3D`]
 pub type Camera = Camera3D;
 
+assert_layout_compat!(
+    Camera3D {
+        position,
+        target,
+        up,
+        fovy,
+        projection,
+    },
+    ffi::Camera3D {
+        position,
+        target,
+        up,
+        fovy,
+        projection,
+    },
+);
+
 impl From<ffi::Camera3D> for Camera3D {
+    #[inline]
     fn from(v: ffi::Camera3D) -> Camera3D {
+        // SAFETY: Camera3D is repr(C) and has the same layout as ffi::Camera3D
         unsafe { std::mem::transmute(v) }
     }
 }
 
 impl From<Camera3D> for ffi::Camera3D {
+    #[inline]
     fn from(v: Camera3D) -> Self {
+        // SAFETY: Camera3D is repr(C) and has the same layout as ffi::Camera3D
         unsafe { std::mem::transmute(v) }
     }
 }
 
 impl From<&Camera3D> for ffi::Camera3D {
+    #[inline]
     fn from(v: &Camera3D) -> Self {
+        // SAFETY: Camera3D is repr(C) and has the same layout as ffi::Camera3D
         unsafe { std::mem::transmute(*v) }
     }
 }
 
-impl From<&mut Camera3D> for ffi::Camera3D {
-    fn from(v: &mut Camera3D) -> Self {
-        unsafe { std::mem::transmute(*v) }
-    }
-}
+// impl From<&mut Camera3D> for ffi::Camera3D {
+//     #[inline]
+//     fn from(v: &mut Camera3D) -> Self {
+//         // SAFETY: Camera3D is repr(C) and has the same layout as ffi::Camera3D
+//         unsafe { std::mem::transmute(*v) }
+//     }
+// }
+
 impl From<&mut Camera3D> for *mut ffi::Camera3D {
+    #[inline]
     fn from(val: &mut Camera3D) -> Self {
+        // SAFETY: Camera3D is repr(C) and has the same layout as ffi::Camera3D
         std::ptr::from_mut(val).cast()
     }
 }
 
 impl Camera3D {
     /// The projection this camera uses.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const fn camera_type(&self) -> ffi::CameraProjection {
         self.projection
     }
 
     /// Create a perspective camera.
     /// `fovy` is in degrees
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const fn perspective(
         position: Vector3,
         target: Vector3,
@@ -121,8 +170,8 @@ impl Camera3D {
 
     /// Create a orthographic camera.
     /// `fovy` is in degrees
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const fn orthographic(
         position: Vector3,
         target: Vector3,
@@ -135,49 +184,56 @@ impl Camera3D {
     }
 
     /// Returns the cameras forward vector (normalized)
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn forward(&self) -> Vector3 {
+        // SAFETY: GetCameraForward is a pure math function with no preconditions and is trivially safe
         unsafe { ffi::GetCameraForward(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
     /// Returns the cameras up vector (normalized)
     ///
     /// Note: The up vector might not be perpendicular to the forward vector
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn up(&self) -> Vector3 {
+        // SAFETY: GetCameraUp is a pure math function with no preconditions and is trivially safe
         unsafe { ffi::GetCameraUp(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
     /// Returns the cameras right vector (normalized)
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn right(&self) -> Vector3 {
+        // SAFETY: GetCameraRight is a pure math function with no preconditions and is trivially safe
         unsafe { ffi::GetCameraRight(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
     /// Moves the camera in its forward direction
     #[inline]
     pub fn move_forward(&mut self, distance: f32, in_world_plane: bool) {
+        // SAFETY: CameraMoveForward is a math function with no preconditions and is trivially safe
         unsafe { ffi::CameraMoveForward(self.into(), distance, in_world_plane) }
     }
 
     /// Moves the camera in its up direction
     #[inline]
     pub fn move_up(&mut self, distance: f32) {
+        // SAFETY: CameraMoveUp is a math function with no preconditions and is trivially safe
         unsafe { ffi::CameraMoveUp(self.into(), distance) }
     }
 
     /// Moves the camera target in its current right direction
     #[inline]
     pub fn move_right(&mut self, distance: f32, in_world_plane: bool) {
+        // SAFETY: CameraMoveRight is a math function with no preconditions and is trivially safe
         unsafe { ffi::CameraMoveRight(self.into(), distance, in_world_plane) }
     }
 
     /// Moves the camera position closer/farther to/from the camera target
     #[inline]
     pub fn move_to_target(&mut self, delta: f32) {
+        // SAFETY: CameraMoveToTarget is a math function with no preconditions and is trivially safe
         unsafe { ffi::CameraMoveToTarget(self.into(), delta) }
     }
 
@@ -188,6 +244,7 @@ impl Camera3D {
     /// Note: `angle` must be provided in radians
     #[inline]
     pub fn yaw(&mut self, angle: f32, rotate_around_target: bool) {
+        // SAFETY: CameraYaw is a math function with no preconditions and is trivially safe
         unsafe { ffi::CameraYaw(self.into(), angle, rotate_around_target) }
     }
 
@@ -205,6 +262,7 @@ impl Camera3D {
         rotate_around_target: bool,
         rotate_up: bool,
     ) {
+        // SAFETY: CameraPitch is a math function with no preconditions and is trivially safe
         unsafe {
             ffi::CameraPitch(
                 self.into(),
@@ -222,20 +280,27 @@ impl Camera3D {
     /// Note: `angle` must be provided in radians
     #[inline]
     pub fn roll(&mut self, angle: f32) {
+        // SAFETY: CameraRoll is a math function with no preconditions and is trivially safe
         unsafe { ffi::CameraRoll(self.into(), angle) }
     }
 
     /// Returns the camera view matrix
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn view_matrix(&self) -> Matrix {
+        // SAFETY: GetCameraViewMatrix is a pure math function with no preconditions and is trivially safe.
+        // Casting `self` to mut is ok here because `GetCameraViewMatrix` doesn't actually mutate `self`,
+        // and appears to take a mutable pointer by mistake.
         unsafe { ffi::GetCameraViewMatrix(std::ptr::from_ref(self).cast_mut().cast()).into() }
     }
 
     /// Returns the camera projection matrix
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn projection_matrix(&self, aspect: f32) -> Matrix {
+        // SAFETY: GetCameraProjectionMatrix is a pure math function with no preconditions and is trivially safe.
+        // Casting `self` to mut is ok here because `GetCameraProjectionMatrix` doesn't actually mutate `self`,
+        // and appears to take a mutable pointer by mistake.
         unsafe {
             ffi::GetCameraProjectionMatrix(std::ptr::from_ref(self).cast_mut().cast(), aspect)
                 .into()
@@ -243,19 +308,29 @@ impl Camera3D {
     }
 
     /// Updates camera position for selected mode.
+    ///
+    /// # Safety
+    ///
+    /// This method accesses static memory without locking. The caller must ensure proper synchronization with Raylib.
     #[inline]
-    pub fn update_camera(&mut self, mode: ffi::CameraMode) {
+    pub unsafe fn update_camera(&mut self, mode: ffi::CameraMode) {
+        // SAFETY: Caller must uphold safety contract
         unsafe { ffi::UpdateCamera(self.into(), mode as i32) }
     }
 
     /// Update camera movement, movement/rotation values should be provided by user
+    ///
+    /// # Safety
+    ///
+    /// This method accesses static memory without locking. The caller must ensure proper synchronization with Raylib.
     #[inline]
-    pub fn update_camera_pro(
+    pub unsafe fn update_camera_pro(
         &mut self,
         movement: impl Into<ffi::Vector3>,
         rotation: impl Into<ffi::Vector3>,
         zoom: f32,
     ) {
+        // SAFETY: Caller must uphold safety contract
         unsafe { ffi::UpdateCameraPro(self.into(), movement.into(), rotation.into(), zoom) }
     }
 }

--- a/raylib/src/core/collision.rs
+++ b/raylib/src/core/collision.rs
@@ -42,14 +42,21 @@ pub fn check_collision_point_circle(
 }
 
 /// Check if point is within a polygon described by array of vertices
+///
+/// # Panics
+///
+/// This function will panic if `points` has a length greater than [`i32::MAX`] elements.
 #[inline]
 #[must_use]
 pub fn check_collision_point_poly(point: impl Into<ffi::Vector2>, points: &[Vector2]) -> bool {
     unsafe {
         ffi::CheckCollisionPointPoly(
             point.into(),
-            std::mem::transmute(points.as_ptr()),
-            points.len() as i32,
+            points.as_ptr().cast(),
+            points
+                .len()
+                .try_into()
+                .expect("points should not exceed i32::MAX elements"),
         )
     }
 }
@@ -95,14 +102,10 @@ pub fn check_collision_lines(
             end_pos1.into(),
             start_pos2.into(),
             end_pos2.into(),
-            &mut out,
+            &raw mut out,
         )
     };
-    if collision {
-        return Some(out.into());
-    } else {
-        return None;
-    }
+    collision.then(|| out.into())
 }
 
 /// Detects collision between two spheres.

--- a/raylib/src/core/collision.rs
+++ b/raylib/src/core/collision.rs
@@ -14,6 +14,7 @@ pub fn check_collision_circle_line(
     p1: impl Into<ffi::Vector2>,
     p2: impl Into<ffi::Vector2>,
 ) -> bool {
+    // SAFETY: CheckCollisionCircleLine is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::CheckCollisionCircleLine(center.into(), radius, p1.into(), p2.into()) }
 }
 
@@ -27,6 +28,7 @@ pub fn check_collision_circles(
     center2: impl Into<ffi::Vector2>,
     radius2: f32,
 ) -> bool {
+    // SAFETY: CheckCollisionCircles is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::CheckCollisionCircles(center1.into(), radius1, center2.into(), radius2) }
 }
 
@@ -38,6 +40,7 @@ pub fn check_collision_point_circle(
     center: impl Into<ffi::Vector2>,
     radius: f32,
 ) -> bool {
+    // SAFETY: CheckCollisionPointCircle is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::CheckCollisionPointCircle(point.into(), center.into(), radius) }
 }
 
@@ -49,6 +52,8 @@ pub fn check_collision_point_circle(
 #[inline]
 #[must_use]
 pub fn check_collision_point_poly(point: impl Into<ffi::Vector2>, points: &[Vector2]) -> bool {
+    // SAFETY: `points` is guaranteed to be safe to dereference because it is a reference, and `pointCount` is guaranteed
+    // to accurately describe the number of valid elements in the array because it is the length of the slice.
     unsafe {
         ffi::CheckCollisionPointPoly(
             point.into(),
@@ -70,6 +75,7 @@ pub fn check_collision_point_line(
     p2: impl Into<ffi::Vector2>,
     threshold: i32,
 ) -> bool {
+    // SAFETY: CheckCollisionPointLine is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::CheckCollisionPointLine(point.into(), p1.into(), p2.into(), threshold) }
 }
 
@@ -82,6 +88,7 @@ pub fn check_collision_point_triangle(
     p2: impl Into<ffi::Vector2>,
     p3: impl Into<ffi::Vector2>,
 ) -> bool {
+    // SAFETY: CheckCollisionPointTriangle is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::CheckCollisionPointTriangle(point.into(), p1.into(), p2.into(), p3.into()) }
 }
 
@@ -96,6 +103,8 @@ pub fn check_collision_lines(
 ) -> Option<Vector2> {
     let mut out = ffi::Vector2 { x: 0.0, y: 0.0 };
 
+    // SAFETY: `out` is guaranteed to be safe to dereference and write to because it is a mutable reference
+    // to a valid local variable.
     let collision = unsafe {
         ffi::CheckCollisionLines(
             start_pos1.into(),
@@ -117,6 +126,7 @@ pub fn check_collision_spheres(
     center_b: impl Into<ffi::Vector3>,
     radius_b: f32,
 ) -> bool {
+    // SAFETY: CheckCollisionSpheres is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::CheckCollisionSpheres(center_a.into(), radius_a, center_b.into(), radius_b) }
 }
 
@@ -128,21 +138,60 @@ pub fn get_ray_collision_sphere(
     sphere_position: impl Into<ffi::Vector3>,
     sphere_radius: f32,
 ) -> RayCollision {
+    // SAFETY: GetRayCollisionSphere is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::GetRayCollisionSphere(ray.into(), sphere_position.into(), sphere_radius).into() }
 }
 
-/// Gets collision info between ray and model.
+/// Gets collision info between ray and mesh.
+///
+/// # Safety
+///
+/// If `mesh.vertices` is null, this function does nothing dangerous and returns [`RayCollision::default()`].
+///
+/// If `mesh.vertices` is *not* null, it must point to valid, initialized data that is safe to dereference
+/// for reading when cast to [`*const ffi::Vector3`](ffi::Vector3).
+///
+/// If `mesh.indices` is null, `mesh.vertices` must point to an array of at least `mesh.triangles` valid,
+/// initialized [`ffi::Vector3`] **triplets** (`[ffi::Vector3; mesh.triangles * 3]`).
+///
+/// If `mesh.indices` is *not* null, `mesh.indices` must point to valid, initialized data that is safe to
+/// dereference for reading at least `mesh.triangles` **triplets** (`[u16; mesh.triangles * 3]`).
+/// In this case, every element in `mesh.indices` must be a valid index that is in-bounds of `mesh.vertices`.
+/// `mesh.vertices` is not required to have `mesh.triangles` elements, it is only required to have at least as
+/// many elements as 1 + the greatest index present in `mesh.indices`.
 #[inline]
 #[must_use]
-pub fn get_ray_collision_model(
+pub unsafe fn get_ray_collision_mesh(
+    ray: impl Into<ffi::Ray>,
+    mesh: &Mesh,
+    transform: &Matrix,
+) -> RayCollision {
+    // SAFETY: Caller must uphold safety contract
+    unsafe { ffi::GetRayCollisionMesh(ray.into(), mesh.0, transform.into()).into() }
+}
+
+/// Gets collision info between ray and model.
+///
+/// # Safety
+///
+/// See [`get_ray_collision_mesh`]
+#[inline]
+#[must_use]
+#[deprecated = "renamed to `get_ray_collision_mesh` to reflect the name of the Raylib function it calls"]
+pub unsafe fn get_ray_collision_model(
     ray: impl Into<ffi::Ray>,
     model: &Mesh,
     transform: &Matrix,
 ) -> RayCollision {
-    unsafe { ffi::GetRayCollisionMesh(ray.into(), model.0, transform.into()).into() }
+    // SAFETY: Caller must uphold safety contract
+    unsafe { get_ray_collision_mesh(ray, model, transform) }
 }
 
-/// Gets collision info between ray and triangle.
+/// Get collision info between ray and triangle
+///
+/// NOTE: The points are expected to be in counter-clockwise winding
+///
+/// NOTE: Based on https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
 #[inline]
 #[must_use]
 pub fn get_ray_collision_triangle(
@@ -151,10 +200,13 @@ pub fn get_ray_collision_triangle(
     p2: impl Into<ffi::Vector3>,
     p3: impl Into<ffi::Vector3>,
 ) -> RayCollision {
+    // SAFETY: GetRayCollisionTriangle is a pure math function with no preconditions and is trivially safe
     unsafe { ffi::GetRayCollisionTriangle(ray.into(), p1.into(), p2.into(), p3.into()).into() }
 }
 
 /// Gets collision info between ray and model.
+///
+/// NOTE: The points are expected to be in counter-clockwise winding
 #[inline]
 #[must_use]
 pub fn get_ray_collision_quad(
@@ -164,6 +216,7 @@ pub fn get_ray_collision_quad(
     p3: impl Into<ffi::Vector3>,
     p4: impl Into<ffi::Vector3>,
 ) -> RayCollision {
+    // SAFETY: GetRayCollisionQuad is a pure math function with no preconditions and is trivially safe
     unsafe {
         ffi::GetRayCollisionQuad(ray.into(), p1.into(), p2.into(), p3.into(), p4.into()).into()
     }

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -6,20 +6,32 @@ use std::{
 };
 
 /// Compress data (DEFLATE algorithm)
-/// ```rust
+///
+/// # Example
+/// ```
 /// use raylib::prelude::*;
 /// let data = compress_data(b"11111").unwrap();
 /// let expected: &[u8] = &[1, 5, 0, 250, 255, 49, 49, 49, 49, 49];
 /// assert_eq!(data.as_ref(), expected);
 /// ```
+///
+/// # Errors
+///
+/// This function returns [`CompressionError::CompressionFailed`] if the pointer returned by [`ffi::CompressData`] is null.
+///
+/// # Panics
+///
+/// This function will panic if `data` has a length greater than [`i32::MAX`] bytes.
 pub fn compress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     let mut out_length = MaybeUninit::uninit();
     // CompressData doesn't actually modify the data, but the header is wrong
     let buffer = {
         unsafe {
             ffi::CompressData(
-                data.as_ptr() as *mut _,
-                data.len() as i32,
+                data.as_ptr().cast_mut(),
+                data.len()
+                    .try_into()
+                    .expect("data should not exceed i32::MAX bytes"),
                 out_length.as_mut_ptr(),
             )
         }
@@ -32,13 +44,23 @@ pub fn compress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
 }
 
 /// Decompress data (DEFLATE algorithm)
-/// ```rust
+///
+/// # Example
+/// ```
 /// use raylib::prelude::*;
 /// let input: &[u8] = &[1, 5, 0, 250, 255, 49, 49, 49, 49, 49];
 /// let expected: &[u8] = b"11111";
 /// let data = decompress_data(input).unwrap();
 /// assert_eq!(data.as_ref(), expected);
 /// ```
+///
+/// # Errors
+///
+/// This function returns [`CompressionError::CompressionFailed`] if the pointer returned by [`ffi::CompressData`] is null.
+///
+/// # Panics
+///
+/// This function will panic if `data` has a length greater than [`i32::MAX`] bytes.
 pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     #[cfg(debug_assertions)]
     println!("{:?}", data.len());
@@ -48,8 +70,10 @@ pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     let buffer = {
         unsafe {
             ffi::DecompressData(
-                data.as_ptr() as *mut _,
-                data.len() as i32,
+                data.as_ptr().cast_mut(),
+                data.len()
+                    .try_into()
+                    .expect("data should not exceed i32::MAX bytes"),
                 out_length.as_mut_ptr(),
             )
         }
@@ -61,31 +85,65 @@ pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
         .ok_or(CompressionError::CompressionFailed)
 }
 
-#[cfg(unix)]
 fn path_to_bytes<P: AsRef<Path>>(path: P) -> Vec<u8> {
-    use std::os::unix::ffi::OsStrExt;
-    path.as_ref().as_os_str().as_bytes().to_vec()
-}
-
-#[cfg(not(unix))]
-fn path_to_bytes<P: AsRef<Path>>(path: P) -> Vec<u8> {
-    path.as_ref().to_string_lossy().to_string().into_bytes()
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_ref().as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        path.as_ref().to_string_lossy().to_string().into_bytes()
+    }
 }
 
 /// Export data to code (.h), returns true on success
+///
+/// # Panics
+///
+/// This function will panic if `file_name` contains an internal 0 byte or if `data` has a length greater than [`i32::MAX`].
+#[must_use = "return indicates success or failure of the operation"]
 pub fn export_data_as_code(data: &[u8], file_name: impl AsRef<Path>) -> bool {
-    let c_str = CString::new(path_to_bytes(file_name)).unwrap();
+    let c_str = CString::new(path_to_bytes(file_name))
+        .expect("file_name should not have an internal 0 byte");
 
-    unsafe { ffi::ExportDataAsCode(data.as_ptr(), data.len() as i32, c_str.as_ptr()) }
+    unsafe {
+        ffi::ExportDataAsCode(
+            data.as_ptr(),
+            data.len()
+                .try_into()
+                .expect("data should not exceed i32::MAX bytes"),
+            c_str.as_ptr(),
+        )
+    }
 }
 
 /// Encode data to Base64 string
+///
+/// # Panics
+///
+/// This function will panic if `data` has a length greater than [`i32::MAX`] or if [`ffi::EncodeDataBase64`] gives a negative output size.
+#[must_use]
 pub fn encode_data_base64(data: &[u8]) -> Vec<c_char> {
     let mut output_size = 0;
-    let bytes =
-        unsafe { ffi::EncodeDataBase64(data.as_ptr(), data.len() as i32, &mut output_size) };
+    let bytes = unsafe {
+        ffi::EncodeDataBase64(
+            data.as_ptr(),
+            data.len()
+                .try_into()
+                .expect("data should not exceed i32::MAX bytes"),
+            &raw mut output_size,
+        )
+    };
 
-    let s = unsafe { std::slice::from_raw_parts(bytes, output_size as usize) };
+    let s = unsafe {
+        std::slice::from_raw_parts(
+            bytes,
+            output_size
+                .try_into()
+                .expect("output_size should not be negative"),
+        )
+    };
     if s.contains(&0) {
         // Work around a bug in Rust's from_raw_parts function
         let mut keep = true;
@@ -106,12 +164,24 @@ pub fn encode_data_base64(data: &[u8]) -> Vec<c_char> {
 }
 
 /// Decode Base64 data
+///
+/// # Panics
+///
+/// This function will panic if [`ffi::DecodeDataBase64`] gives a negative output size.
+#[must_use]
 pub fn decode_data_base64(data: &[u8]) -> Vec<u8> {
     let mut output_size = 0;
 
-    let bytes = unsafe { ffi::DecodeDataBase64(data.as_ptr(), &mut output_size) };
+    let bytes = unsafe { ffi::DecodeDataBase64(data.as_ptr(), &raw mut output_size) };
 
-    let s = unsafe { std::slice::from_raw_parts(bytes, output_size as usize) };
+    let s = unsafe {
+        std::slice::from_raw_parts(
+            bytes,
+            output_size
+                .try_into()
+                .expect("output_size should not be negative"),
+        )
+    };
     if s.contains(&0) {
         // Work around a bug in Rust's from_raw_parts function
         let mut keep = true;

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -1,3 +1,5 @@
+//! Memory compression/decompression
+
 use crate::{databuf::DataBuf, error::CompressionError, ffi};
 use std::{
     ffi::{CString, c_char},

--- a/raylib/src/core/databuf.rs
+++ b/raylib/src/core/databuf.rs
@@ -604,7 +604,8 @@ mod tests {
         }
 
         let mut times_dropped = 0;
-        let buf = DataBuf::alloc_from(DropTest(|| times_dropped += 1)).unwrap();
+        let buf = DataBuf::alloc_from(DropTest(|| times_dropped += 1))
+            .expect("should be able to allocate enough memory to store a closure");
         drop(buf);
         assert_eq!(
             times_dropped, 1,
@@ -618,7 +619,7 @@ mod tests {
         const EXPECT: [i32; 5] = [64, 264, -57, 653, -153];
         let bytes @ 1.. = (std::mem::size_of::<i32>() * EXPECT.len())
             .try_into()
-            .unwrap()
+            .expect("EXPECT should have a quantity of elements that can be expressed in a u32")
         else {
             unreachable!()
         };
@@ -640,7 +641,7 @@ mod tests {
         const EXPECT: ExpectTy = [6, -453, 364, 45632, -1233];
         let bytes @ 1.. = (std::mem::size_of::<i32>() * EXPECT.len())
             .try_into()
-            .unwrap()
+            .expect("EXPECT should have a quantity of elements that can be expressed in a u32")
         else {
             unreachable!()
         };
@@ -653,7 +654,12 @@ mod tests {
         };
         // SAFETY: `ptr` is unique, non-dangling, valid, and allocated by Raylib
         let buf = unsafe {
-            DataBuf::slice_from_raw(ptr, MaybeUninit::new(EXPECT.len().try_into().unwrap()))
+            DataBuf::slice_from_raw(
+                ptr,
+                MaybeUninit::new(EXPECT.len().try_into().expect(
+                    "EXPECT should have a quantity of elements that can be expressed in an i32",
+                )),
+            )
         }
         .expect("ptr should be convertible to DataBuf");
         assert_eq!(&*buf, &EXPECT);

--- a/raylib/src/core/databuf.rs
+++ b/raylib/src/core/databuf.rs
@@ -3,7 +3,6 @@
 //!
 //! See [`DataBuf`]
 
-#![warn(clippy::style, clippy::pedantic)]
 #![allow(
     clippy::missing_errors_doc,
     reason = "errors are documented at their defintion, not by the functions that use them"
@@ -471,9 +470,8 @@ impl<T> DataBuf<[T]> {
                     "`count` should fit within usize"
                 );
             }
-            #[allow(clippy::cast_sign_loss, reason = "intentional")]
-            // SAFETY: Just checked that count is non-zero and positive.
-            let len = unsafe { NonZeroUsize::new_unchecked(count as usize) };
+            // SAFETY: Just checked that count is non-zero.
+            let len = unsafe { NonZeroUsize::new_unchecked(count.cast_unsigned() as usize) };
             // SAFETY: Caller must uphold `DataBuf` and `slice` safety contracts
             Some(unsafe { Self::slice_from_nonnull(buf, len) })
         } else {

--- a/raylib/src/core/databuf.rs
+++ b/raylib/src/core/databuf.rs
@@ -50,12 +50,6 @@ fn allocation_array_size<T>(count: usize) -> Result<NonZeroU32, AllocationError>
     allocation_layout_size(Layout::array::<T>(count).map_err(|_| AllocationError::IntoUIntFailed)?)
 }
 
-/// Calculate the number of bytes needed to allocate a copy of `val`
-#[inline]
-fn allocation_val_size<T: ?Sized>(val: &T) -> Result<NonZeroU32, AllocationError> {
-    allocation_layout_size(Layout::for_value(val))
-}
-
 mod rl_managed {
     use super::ffi;
     use std::{mem::MaybeUninit, num::NonZeroU32, ptr::NonNull};

--- a/raylib/src/core/databuf.rs
+++ b/raylib/src/core/databuf.rs
@@ -3,7 +3,7 @@
 //!
 //! See [`DataBuf`]
 
-#![warn(clippy::style, clippy::pedantic, clippy::perf)]
+#![warn(clippy::style, clippy::pedantic)]
 #![allow(
     clippy::missing_errors_doc,
     reason = "errors are documented at their defintion, not by the functions that use them"

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -22,6 +22,7 @@ impl RaylibHandle {
 
         RaylibDrawHandle(self)
     }
+
     /// Setup canvas (framebuffer) to start drawing.
     // Every FnMut is a FnOnce, but not every FnOnce is a FnMut. The closure may possibly execute multiple times throughout the program, but not multiple times in a single call to this method.
     // Taking a FnOnce instead of a FnMut when the function only needs to be called once in this method makes the method slightly more versatile/less needlessly restrictive for no actual cost.
@@ -316,8 +317,8 @@ where
     /// Prefer using the closure version, [`RaylibMode3DExt::draw_mode3D`].
     /// This version returns a handle that calls [`ffi::EndMode3D`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[allow(non_snake_case, reason = "consistent style")]
-    #[must_use]
     #[inline]
+    #[must_use]
     fn begin_mode3D(&mut self, camera: impl Into<ffi::Camera3D>) -> RaylibMode3D<'_, Self> {
         unsafe {
             ffi::BeginMode3D(camera.into());
@@ -383,8 +384,8 @@ where
     ///
     /// Prefer using the closure version, [`RaylibShaderModeExt::draw_shader_mode`].
     /// This version returns a handle that calls [`ffi::EndShaderMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
-    #[must_use]
     #[inline]
+    #[must_use]
     fn begin_shader_mode<'a, 'b>(
         &'a mut self,
         shader: &'b mut Shader,
@@ -507,8 +508,8 @@ where
     ///
     /// Prefer using the closure version, [`RaylibScissorModeExt::draw_scissor_mode`].
     /// This version returns a handle that calls [`ffi::EndScissorMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
-    #[must_use]
     #[inline]
+    #[must_use]
     fn begin_scissor_mode(
         &mut self,
         x: i32,
@@ -693,6 +694,7 @@ pub unsafe trait RaylibDraw {
             ffi::DrawCircle(center_x, center_y, radius, color.into());
         }
     }
+
     /// Draw a piece of a circle
     #[inline]
     fn draw_circle_sector(
@@ -1012,6 +1014,7 @@ pub unsafe trait RaylibDraw {
             ffi::DrawRectangleLinesEx(rec.into(), line_thick, color.into());
         }
     }
+
     /// Draws rectangle with rounded edges.
     #[inline]
     fn draw_rectangle_rounded(
@@ -1060,6 +1063,7 @@ pub unsafe trait RaylibDraw {
             );
         }
     }
+
     /// Draws a triangle.
     #[inline]
     fn draw_triangle(
@@ -1316,6 +1320,7 @@ pub unsafe trait RaylibDraw {
             );
         }
     }
+
     /// Draws text using `font` and additional parameters.
     #[inline]
     fn draw_text_ex(
@@ -1424,6 +1429,7 @@ pub unsafe trait RaylibDraw {
             );
         }
     }
+
     /// Draw spline: Linear, minimum 2 points
     #[inline]
     fn draw_spline_linear(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
@@ -1439,6 +1445,7 @@ pub unsafe trait RaylibDraw {
             );
         }
     }
+
     /// Draw spline: B-Spline, minimum 4 points
     #[inline]
     fn draw_spline_basis(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
@@ -1454,6 +1461,7 @@ pub unsafe trait RaylibDraw {
             );
         }
     }
+
     /// Draw spline: Catmull-Rom, minimum 4 points
     #[inline]
     fn draw_spline_catmull_rom(

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -1,5 +1,5 @@
 //! Contains code related to drawing. Types that can be set as a surface to draw will implement the [`RaylibDraw`] trait
-
+//!
 use crate::{
     core::{RaylibHandle, RaylibThread, texture::Texture2D, vr::VrStereoConfig},
     ffi,
@@ -25,7 +25,7 @@ impl RaylibHandle {
         // denies `Send`/`Sync` proves we are on the thread that initialized Raylib.
         unsafe {
             ffi::BeginDrawing();
-        };
+        }
 
         RaylibDrawHandle(self, PhantomData)
     }
@@ -39,7 +39,7 @@ impl RaylibHandle {
         // denies `Send`/`Sync` proves we are on the thread that initialized Raylib.
         unsafe {
             ffi::BeginDrawing();
-        };
+        }
         func(RaylibDrawHandle(self, PhantomData));
         // Uncomment the following if RaylibDrawHandle has been changed to no longer call EndDrawing() in its drop implementation:
         // unsafe {
@@ -177,7 +177,9 @@ pub unsafe trait RaylibTextureModeExt {
         framebuffer: &'b mut ffi::RenderTexture2D,
     ) -> RaylibTextureMode<'a, 'b, Self> {
         // SAFETY: Implementor must uphold the trait safety contract.
-        unsafe { ffi::BeginTextureMode(*framebuffer) }
+        unsafe {
+            ffi::BeginTextureMode(*framebuffer);
+        }
         RaylibTextureMode(self, PhantomData, PhantomData)
     }
 
@@ -189,7 +191,9 @@ pub unsafe trait RaylibTextureModeExt {
         func: impl FnOnce(RaylibTextureMode<'a, 'b, Self>),
     ) {
         // SAFETY: Implementor must uphold the trait safety contract.
-        unsafe { ffi::BeginTextureMode(*framebuffer) }
+        unsafe {
+            ffi::BeginTextureMode(*framebuffer);
+        }
         func(RaylibTextureMode(self, PhantomData, PhantomData));
         // Uncomment the following if RaylibTextureMode has been changed to no longer call EndTextureMode() in its drop implementation:
         // unsafe { ffi::EndTextureMode(); }
@@ -265,8 +269,10 @@ pub trait RaylibVRModeExt: RaylibDraw {
         _: &RaylibThread,
         vr_config: &'b mut VrStereoConfig,
     ) -> RaylibVRMode<'a, 'b, Self> {
-        // SAFETY: Implementors of RaylibDraw are required to ensure draw functions are safe to call for the duration of their lifetime.
-        unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginVrStereoMode(*vr_config.as_ref());
+        }
         RaylibVRMode(self, PhantomData, PhantomData)
     }
 
@@ -276,8 +282,10 @@ pub trait RaylibVRModeExt: RaylibDraw {
         vr_config: &'b mut VrStereoConfig,
         func: impl FnOnce(RaylibVRMode<'a, 'b, Self>),
     ) {
-        // SAFETY: Implementors of RaylibDraw are required to ensure draw functions are safe to call for the duration of their lifetime.
-        unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginVrStereoMode(*vr_config.as_ref());
+        }
         func(RaylibVRMode(self, PhantomData, PhantomData));
         // Uncomment the following if RaylibVRMode has been changed to no longer call EndTextureMode() in its drop implementation:
         // unsafe { ffi::EndVrStereoMode(); }
@@ -285,6 +293,9 @@ pub trait RaylibVRModeExt: RaylibDraw {
 }
 
 impl<D: ?Sized + RaylibDraw> RaylibVRModeExt for D {}
+
+// SAFETY: RaylibVRModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibVRMode does not perform any operation that would change this.
 unsafe impl<'a, T: ?Sized + RaylibVRModeExt + 'a> RaylibDraw for RaylibVRMode<'a, '_, T> {}
 
 // 2D Mode
@@ -296,15 +307,19 @@ unsafe impl<'a, T: ?Sized + RaylibVRModeExt + 'a> RaylibDraw for RaylibVRMode<'a
 /// # Guarantees
 ///
 /// [`RaylibMode2D`] guarantees [`ffi::BeginMode2D`] has been called this frame without the corresponding [`ffi::EndMode2D`] having been called yet.
-pub struct RaylibMode2D<'a, T: 'a>(&'a mut T);
+pub struct RaylibMode2D<'a, T: ?Sized + RaylibMode2DExt + 'a>(&'a mut T);
 
-impl<'a, T: 'a> Drop for RaylibMode2D<'a, T> {
+impl<'a, T: ?Sized + RaylibMode2DExt + 'a> Drop for RaylibMode2D<'a, T> {
+    #[inline]
     fn drop(&mut self) {
-        unsafe { ffi::EndMode2D() }
+        // SAFETY: RaylibMode2D guarantees BeginMode2D has been called this frame without the corresponding EndMode2D having been called yet.
+        unsafe {
+            ffi::EndMode2D();
+        }
     }
 }
 
-impl<'a, T: 'a> Deref for RaylibMode2D<'a, T>
+impl<'a, T: ?Sized + RaylibMode2DExt + 'a> Deref for RaylibMode2D<'a, T>
 where
     T: Deref<Target = RaylibHandle>,
 {
@@ -316,7 +331,7 @@ where
     }
 }
 
-impl<'a, T: 'a> DerefMut for RaylibMode2D<'a, T>
+impl<'a, T: ?Sized + RaylibMode2DExt + 'a> DerefMut for RaylibMode2D<'a, T>
 where
     T: DerefMut<Target = RaylibHandle>,
 {
@@ -327,10 +342,7 @@ where
 }
 
 /// Ability to begin drawing in 2D.
-pub trait RaylibMode2DExt
-where
-    Self: Sized,
-{
+pub trait RaylibMode2DExt: RaylibDraw {
     /// Begin 2D mode with custom camera (2D).
     ///
     /// Prefer using the closure version, [`RaylibMode2DExt::draw_mode2D`].
@@ -339,6 +351,7 @@ where
     #[inline]
     #[must_use]
     fn begin_mode2D(&mut self, camera: impl Into<ffi::Camera2D>) -> RaylibMode2D<'_, Self> {
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
         unsafe {
             ffi::BeginMode2D(camera.into());
         }
@@ -352,6 +365,7 @@ where
         camera: impl Into<ffi::Camera2D>,
         func: impl FnOnce(RaylibMode2D<'a, Self>),
     ) {
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
         unsafe {
             ffi::BeginMode2D(camera.into());
         }
@@ -363,21 +377,34 @@ where
     }
 }
 
-impl<D: RaylibDraw> RaylibMode2DExt for D {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibMode2D<'a, T> {}
+impl<D: ?Sized + RaylibDraw> RaylibMode2DExt for D {}
+
+// SAFETY: RaylibMode2DExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibMode2D does not perform any operation that would change this.
+unsafe impl<'a, T: ?Sized + RaylibMode2DExt + 'a> RaylibDraw for RaylibMode2D<'a, T> {}
 
 // 3D Mode
 
 /// Handle returned by [`begin_mode3D`](RaylibMode3DExt::begin_mode3D) to provide access to 3D drawing functions.
 ///
 /// Calls [`ffi::EndMode3D`] when dropped.
-pub struct RaylibMode3D<'a, T: 'a>(&'a mut T);
-impl<'a, T: 'a> Drop for RaylibMode3D<'a, T> {
+///
+/// # Guarantees
+///
+/// [`RaylibMode3D`] guarantees [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
+pub struct RaylibMode3D<'a, T: ?Sized + RaylibMode3DExt + 'a>(&'a mut T);
+
+impl<'a, T: ?Sized + RaylibMode3DExt + 'a> Drop for RaylibMode3D<'a, T> {
+    #[inline]
     fn drop(&mut self) {
-        unsafe { ffi::EndMode3D() }
+        // SAFETY: RaylibMode3D guarantees BeginMode3D has been called this frame without the corresponding EndMode3D having been called yet.
+        unsafe {
+            ffi::EndMode3D();
+        }
     }
 }
-impl<'a, T: 'a> Deref for RaylibMode3D<'a, T>
+
+impl<'a, T: ?Sized + RaylibMode3DExt + 'a> Deref for RaylibMode3D<'a, T>
 where
     T: Deref<Target = RaylibHandle>,
 {
@@ -388,7 +415,8 @@ where
         self.0
     }
 }
-impl<'a, T: 'a> DerefMut for RaylibMode3D<'a, T>
+
+impl<'a, T: ?Sized + RaylibMode3DExt + 'a> DerefMut for RaylibMode3D<'a, T>
 where
     T: DerefMut<Target = RaylibHandle>,
 {
@@ -399,10 +427,7 @@ where
 }
 
 /// Ability to begin drawing in 3D.
-pub trait RaylibMode3DExt
-where
-    Self: Sized,
-{
+pub trait RaylibMode3DExt: RaylibDraw {
     /// Begin 3D mode with custom camera (3D).
     ///
     /// Prefer using the closure version, [`RaylibMode3DExt::draw_mode3D`].
@@ -411,6 +436,7 @@ where
     #[inline]
     #[must_use]
     fn begin_mode3D(&mut self, camera: impl Into<ffi::Camera3D>) -> RaylibMode3D<'_, Self> {
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
         unsafe {
             ffi::BeginMode3D(camera.into());
         }
@@ -424,6 +450,7 @@ where
         camera: impl Into<ffi::Camera3D>,
         func: impl FnOnce(RaylibMode3D<'a, Self>),
     ) {
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
         unsafe {
             ffi::BeginMode3D(camera.into());
         }
@@ -435,23 +462,42 @@ where
     }
 }
 
-impl<D: RaylibDraw> RaylibMode3DExt for D {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibMode3D<'a, T> {}
-unsafe impl<'a, T: 'a> RaylibDraw3D for RaylibMode3D<'a, T> {}
+impl<D: ?Sized + RaylibDraw> RaylibMode3DExt for D {}
+
+// SAFETY: RaylibMode3DExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibMode3D does not perform any operation that would change this.
+unsafe impl<'a, T: ?Sized + RaylibMode3DExt + 'a> RaylibDraw for RaylibMode3D<'a, T> {}
+
+// SAFETY: RaylibMode3DExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibMode3D does not perform any operation that would change this.
+// Additionally, RaylibMode3D inherently guarantees 3D draw functions are safe to call in particular.
+unsafe impl<'a, T: ?Sized + RaylibMode3DExt + 'a> RaylibDraw3D for RaylibMode3D<'a, T> {}
 
 // shader Mode
 
 /// Handle returned by [`begin_shader_mode`](RaylibShaderModeExt::begin_shader_mode) to provide access to drawing functions.
 ///
 /// Calls [`ffi::EndShaderMode`] when dropped.
-pub struct RaylibShaderMode<'a, 'b, T: 'a>(&'a mut T, PhantomData<&'b mut Shader>);
+///
+/// # Guarantees
+///
+/// [`RaylibShaderMode`] guarantees [`ffi::BeginShaderMode`] has been called this frame without the corresponding [`ffi::EndShaderMode`] having been called yet.
+pub struct RaylibShaderMode<'a, 'b, T: ?Sized + RaylibShaderModeExt + 'a>(
+    &'a mut T,
+    PhantomData<&'b mut Shader>,
+);
 
-impl<'a, T: 'a> Drop for RaylibShaderMode<'a, '_, T> {
+impl<'a, T: ?Sized + RaylibShaderModeExt + 'a> Drop for RaylibShaderMode<'a, '_, T> {
+    #[inline]
     fn drop(&mut self) {
-        unsafe { ffi::EndShaderMode() }
+        // SAFETY: RaylibShaderMode guarantees BeginShaderMode has been called this frame without the corresponding EndShaderMode having been called yet.
+        unsafe {
+            ffi::EndShaderMode();
+        }
     }
 }
-impl<'a, T: 'a> Deref for RaylibShaderMode<'a, '_, T>
+
+impl<'a, T: ?Sized + RaylibShaderModeExt + 'a> Deref for RaylibShaderMode<'a, '_, T>
 where
     T: Deref<Target = RaylibHandle>,
 {
@@ -462,7 +508,8 @@ where
         self.0
     }
 }
-impl<'a, T: 'a> DerefMut for RaylibShaderMode<'a, '_, T>
+
+impl<'a, T: ?Sized + RaylibShaderModeExt + 'a> DerefMut for RaylibShaderMode<'a, '_, T>
 where
     T: DerefMut<Target = RaylibHandle>,
 {
@@ -473,10 +520,7 @@ where
 }
 
 /// Ability to begin drawing with a shader applied.
-pub trait RaylibShaderModeExt
-where
-    Self: Sized,
-{
+pub trait RaylibShaderModeExt: RaylibDraw {
     /// Begin custom shader drawing.
     ///
     /// Prefer using the closure version, [`RaylibShaderModeExt::draw_shader_mode`].
@@ -487,7 +531,10 @@ where
         &'a mut self,
         shader: &'b mut Shader,
     ) -> RaylibShaderMode<'a, 'b, Self> {
-        unsafe { ffi::BeginShaderMode(*shader.as_ref()) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginShaderMode(*shader.as_ref());
+        }
         RaylibShaderMode(self, PhantomData)
     }
 
@@ -497,29 +544,52 @@ where
         shader: &'b mut Shader,
         func: impl FnOnce(RaylibShaderMode<'a, 'b, Self>),
     ) {
-        unsafe { ffi::BeginShaderMode(*shader.as_ref()) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginShaderMode(*shader.as_ref());
+        }
         func(RaylibShaderMode(self, PhantomData));
         // Uncomment the following if RaylibShaderMode has been changed to no longer call EndShaderMode() in its drop implementation:
         // unsafe { ffi::EndShaderMode(); }
     }
 }
 
-impl<D: RaylibDraw> RaylibShaderModeExt for D {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibShaderMode<'a, '_, T> {}
-unsafe impl<'a, T: 'a> RaylibDraw3D for RaylibShaderMode<'a, '_, T> {}
+impl<D: ?Sized + RaylibDraw> RaylibShaderModeExt for D {}
+
+// SAFETY: RaylibShaderModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibShaderMode does not perform any operation that would change this.
+unsafe impl<'a, T: ?Sized + RaylibShaderModeExt + 'a> RaylibDraw for RaylibShaderMode<'a, '_, T> {}
+
+// SAFETY: RaylibShaderModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibShaderMode does not perform any operation that would change this.
+// Implementing RaylibDraw3D guarantees 3D draw functions are also safe to call.
+unsafe impl<'a, T: ?Sized + RaylibShaderModeExt + RaylibDraw3D + 'a> RaylibDraw3D
+    for RaylibShaderMode<'a, '_, T>
+{
+}
 
 // Blend Mode
 
 /// Handle returned by [`begin_blend_mode`](RaylibBlendModeExt::begin_blend_mode) to provide access to drawing functions.
 ///
 /// Calls [`ffi::EndBlendMode`] when dropped.
-pub struct RaylibBlendMode<'a, T: 'a>(&'a mut T);
-impl<'a, T: 'a> Drop for RaylibBlendMode<'a, T> {
+///
+/// # Guarantees
+///
+/// [`RaylibBlendMode`] guarantees [`ffi::BeginBlendMode`] has been called this frame without the corresponding [`ffi::EndBlendMode`] having been called yet.
+pub struct RaylibBlendMode<'a, T: ?Sized + RaylibBlendModeExt + 'a>(&'a mut T);
+
+impl<'a, T: ?Sized + RaylibBlendModeExt + 'a> Drop for RaylibBlendMode<'a, T> {
+    #[inline]
     fn drop(&mut self) {
-        unsafe { ffi::EndBlendMode() }
+        // SAFETY: RaylibBlendMode guarantees BeginBlendMode has been called this frame without the corresponding EndBlendMode having been called yet.
+        unsafe {
+            ffi::EndBlendMode();
+        }
     }
 }
-impl<'a, T: 'a> Deref for RaylibBlendMode<'a, T>
+
+impl<'a, T: ?Sized + RaylibBlendModeExt + 'a> Deref for RaylibBlendMode<'a, T>
 where
     T: Deref<Target = RaylibHandle>,
 {
@@ -530,7 +600,8 @@ where
         self.0
     }
 }
-impl<'a, T: 'a> DerefMut for RaylibBlendMode<'a, T>
+
+impl<'a, T: ?Sized + RaylibBlendModeExt + 'a> DerefMut for RaylibBlendMode<'a, T>
 where
     T: DerefMut<Target = RaylibHandle>,
 {
@@ -541,10 +612,7 @@ where
 }
 
 /// Ability to begin drawing with a blend mode applied.
-pub trait RaylibBlendModeExt
-where
-    Self: Sized,
-{
+pub trait RaylibBlendModeExt: RaylibDraw {
     /// Begin blending mode (alpha, additive, multiplied, subtract, custom).
     ///
     /// Prefer using the closure version, [`RaylibBlendModeExt::draw_blend_mode`].
@@ -555,7 +623,10 @@ where
         &mut self,
         blend_mode: crate::consts::BlendMode,
     ) -> RaylibBlendMode<'_, Self> {
-        unsafe { ffi::BeginBlendMode(blend_mode as i32) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginBlendMode(blend_mode as i32);
+        }
         RaylibBlendMode(self)
     }
 
@@ -565,29 +636,52 @@ where
         blend_mode: crate::consts::BlendMode,
         func: impl FnOnce(RaylibBlendMode<'a, Self>),
     ) {
-        unsafe { ffi::BeginBlendMode(blend_mode as i32) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginBlendMode(blend_mode as i32);
+        }
         func(RaylibBlendMode(self));
         // Uncomment the following if RaylibBlendMode has been changed to no longer call EndBlendMode() in its drop implementation:
         // unsafe { ffi::EndBlendMode(); }
     }
 }
 
-impl<D: RaylibDraw> RaylibBlendModeExt for D {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibBlendMode<'a, T> {}
-unsafe impl<'a, T: 'a> RaylibDraw3D for RaylibBlendMode<'a, T> {}
+impl<D: ?Sized + RaylibDraw> RaylibBlendModeExt for D {}
+
+// SAFETY: RaylibBlendModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibBlendMode does not perform any operation that would change this.
+unsafe impl<'a, T: ?Sized + RaylibBlendModeExt + 'a> RaylibDraw for RaylibBlendMode<'a, T> {}
+
+// SAFETY: RaylibBlendModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibBlendMode does not perform any operation that would change this.
+// Implementing RaylibDraw3D guarantees 3D draw functions are also safe to call.
+unsafe impl<'a, T: ?Sized + RaylibBlendModeExt + RaylibDraw3D + 'a> RaylibDraw3D
+    for RaylibBlendMode<'a, T>
+{
+}
 
 // Scissor Mode stuff
 
 /// Handle returned by [`begin_scissor_mode`](RaylibScissorModeExt::begin_scissor_mode) to provide access to drawing functions.
 ///
 /// Calls [`ffi::EndScissorMode`] when dropped.
-pub struct RaylibScissorMode<'a, T: 'a>(&'a mut T);
-impl<'a, T: 'a> Drop for RaylibScissorMode<'a, T> {
+///
+/// # Guarantees
+///
+/// [`RaylibScissorMode`] guarantees [`ffi::BeginScissorMode`] has been called this frame without the corresponding [`ffi::EndScissorMode`] having been called yet.
+pub struct RaylibScissorMode<'a, T: ?Sized + RaylibScissorModeExt + 'a>(&'a mut T);
+
+impl<'a, T: ?Sized + RaylibScissorModeExt + 'a> Drop for RaylibScissorMode<'a, T> {
+    #[inline]
     fn drop(&mut self) {
-        unsafe { ffi::EndScissorMode() }
+        // SAFETY: RaylibScissorMode guarantees BeginScissorMode has been called this frame without the corresponding EndScissorMode having been called yet.
+        unsafe {
+            ffi::EndScissorMode();
+        }
     }
 }
-impl<'a, T: 'a> Deref for RaylibScissorMode<'a, T>
+
+impl<'a, T: ?Sized + RaylibScissorModeExt + 'a> Deref for RaylibScissorMode<'a, T>
 where
     T: Deref<Target = RaylibHandle>,
 {
@@ -598,7 +692,8 @@ where
         self.0
     }
 }
-impl<'a, T: 'a> DerefMut for RaylibScissorMode<'a, T>
+
+impl<'a, T: ?Sized + RaylibScissorModeExt + 'a> DerefMut for RaylibScissorMode<'a, T>
 where
     T: DerefMut<Target = RaylibHandle>,
 {
@@ -609,10 +704,7 @@ where
 }
 
 /// Ability to begin drawing in scissor mode.
-pub trait RaylibScissorModeExt
-where
-    Self: Sized,
-{
+pub trait RaylibScissorModeExt: RaylibDraw {
     /// Begin scissor mode (define screen area for following drawing).
     ///
     /// Prefer using the closure version, [`RaylibScissorModeExt::draw_scissor_mode`].
@@ -626,7 +718,10 @@ where
         width: i32,
         height: i32,
     ) -> RaylibScissorMode<'_, Self> {
-        unsafe { ffi::BeginScissorMode(x, y, width, height) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginScissorMode(x, y, width, height);
+        }
         RaylibScissorMode(self)
     }
 
@@ -639,16 +734,29 @@ where
         height: i32,
         func: impl FnOnce(RaylibScissorMode<'a, Self>),
     ) {
-        unsafe { ffi::BeginScissorMode(x, y, width, height) }
+        // SAFETY: Implementors of RaylibDraw guarantee that draw functions are safe to call for the duration of their lifetime.
+        unsafe {
+            ffi::BeginScissorMode(x, y, width, height);
+        }
         func(RaylibScissorMode(self));
         // Uncomment the following if RaylibScissorMode has been changed to no longer call EndScissorMode() in its drop implementation:
         // unsafe { ffi::EndScissorMode(); }
     }
 }
 
-impl<D: RaylibDraw> RaylibScissorModeExt for D {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibScissorMode<'a, T> {}
-unsafe impl<'a, T: 'a + RaylibDraw3D> RaylibDraw3D for RaylibScissorMode<'a, T> {}
+impl<D: ?Sized + RaylibDraw> RaylibScissorModeExt for D {}
+
+// SAFETY: RaylibScissorModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibScissorMode does not perform any operation that would change this.
+unsafe impl<'a, T: ?Sized + RaylibScissorModeExt + 'a> RaylibDraw for RaylibScissorMode<'a, T> {}
+
+// SAFETY: RaylibScissorModeExt implies RaylibDraw, which guarantees draw functions are safe to call for
+// the duration of its lifetime. RaylibScissorMode does not perform any operation that would change this.
+// Implementing RaylibDraw3D guarantees 3D draw functions are also safe to call.
+unsafe impl<'a, T: ?Sized + RaylibScissorModeExt + RaylibDraw3D + 'a> RaylibDraw3D
+    for RaylibScissorMode<'a, T>
+{
+}
 
 // Actual drawing functions
 
@@ -698,7 +806,9 @@ pub unsafe trait RaylibDraw {
         source: impl Into<ffi::Rectangle>,
     ) {
         // SAFETY: Implementor must uphold trait safety contract.
-        unsafe { ffi::SetShapesTexture(*texture.as_ref(), source.into()) }
+        unsafe {
+            ffi::SetShapesTexture(*texture.as_ref(), source.into());
+        }
     }
 
     // // Draw gui widget
@@ -1890,7 +2000,7 @@ pub unsafe trait RaylibDraw {
 /// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
 /// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
 /// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
-pub unsafe trait RaylibDraw3D {
+pub unsafe trait RaylibDraw3D: RaylibDraw {
     /// Draw a point in 3D space, actually a small line
     #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
@@ -2487,5 +2597,43 @@ pub unsafe trait RaylibDraw3D {
                 tint.into(),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use std::mem::ManuallyDrop;
+
+    impl RaylibHandle {
+        fn rl_handle_reachable(&mut self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn test0() {
+        let mut rl: ManuallyDrop<RaylibHandle> = ManuallyDrop::new(RaylibHandle(()));
+
+        let mut d: ManuallyDrop<RaylibDrawHandle> =
+            ManuallyDrop::new(RaylibDrawHandle(&mut rl, PhantomData));
+
+        let mut d: ManuallyDrop<RaylibMode2D<_>> = ManuallyDrop::new(RaylibMode2D(&mut *d));
+
+        let mut d: ManuallyDrop<RaylibShaderMode<_>> =
+            ManuallyDrop::new(RaylibShaderMode(&mut *d, PhantomData));
+
+        let mut d: ManuallyDrop<RaylibScissorMode<_>> =
+            ManuallyDrop::new(RaylibScissorMode(&mut *d));
+
+        let mut d: ManuallyDrop<RaylibBlendMode<_>> = ManuallyDrop::new(RaylibBlendMode(&mut *d));
+
+        let mut d: ManuallyDrop<RaylibMode3D<_>> = ManuallyDrop::new(RaylibMode3D(&mut *d));
+
+        assert!(
+            d.rl_handle_reachable(),
+            "drawing should not deny access to RaylibHandle"
+        );
     }
 }

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -249,7 +249,7 @@ where
     ///
     /// Prefer using the closure version, [`RaylibMode2DExt::draw_mode2D`].
     /// This version returns a handle that calls [`ffi::EndMode2D`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     #[must_use]
     fn begin_mode2D(&mut self, camera: impl Into<ffi::Camera2D>) -> RaylibMode2D<'_, Self> {
@@ -260,7 +260,7 @@ where
     }
 
     /// Begin 2D mode with custom camera (2D).
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     fn draw_mode2D<'a>(
         &'a mut self,
         camera: impl Into<ffi::Camera2D>,
@@ -315,7 +315,7 @@ where
     ///
     /// Prefer using the closure version, [`RaylibMode3DExt::draw_mode3D`].
     /// This version returns a handle that calls [`ffi::EndMode3D`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[must_use]
     #[inline]
     fn begin_mode3D(&mut self, camera: impl Into<ffi::Camera3D>) -> RaylibMode3D<'_, Self> {
@@ -326,7 +326,7 @@ where
     }
 
     /// Begin 3D mode with custom camera (3D).
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     fn draw_mode3D<'a>(
         &'a mut self,
         camera: impl Into<ffi::Camera3D>,
@@ -825,7 +825,7 @@ pub unsafe trait RaylibDraw {
     }
 
     /// Draw ring
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
     #[inline]
     fn draw_ring(
         &mut self,
@@ -851,7 +851,7 @@ pub unsafe trait RaylibDraw {
     }
 
     /// Draw ring lines
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
     #[inline]
     fn draw_ring_lines(
         &mut self,
@@ -1341,7 +1341,7 @@ pub unsafe trait RaylibDraw {
     }
 
     /// Draw text using Font and pro parameters (rotation)
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
     #[inline]
     fn draw_text_pro(
         &mut self,
@@ -1704,7 +1704,7 @@ pub unsafe trait RaylibDraw {
 /// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
 pub unsafe trait RaylibDraw3D {
     /// Draw a point in 3D space, actually a small line
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     fn draw_point3D(&mut self, position: impl Into<ffi::Vector3>, color: impl Into<ffi::Color>) {
         unsafe {
@@ -1713,7 +1713,7 @@ pub unsafe trait RaylibDraw3D {
     }
 
     /// Draw a color-filled triangle (vertex in counter-clockwise order!)
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     fn draw_triangle3D(
         &mut self,
@@ -1728,7 +1728,7 @@ pub unsafe trait RaylibDraw3D {
     }
 
     /// Draw a triangle strip defined by points
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     fn draw_triangle_strip3D(&mut self, points: &[Vector3], color: impl Into<ffi::Color>) {
         unsafe {
@@ -1744,7 +1744,7 @@ pub unsafe trait RaylibDraw3D {
     }
 
     /// Draws a line in 3D world space.
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     fn draw_line3D(
         &mut self,
@@ -1758,7 +1758,7 @@ pub unsafe trait RaylibDraw3D {
     }
 
     /// Draws a circle in 3D world space.
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     fn draw_circle3D(
         &mut self,
@@ -2202,7 +2202,7 @@ pub unsafe trait RaylibDraw3D {
     }
 
     /// Draw a billboard texture defined by source and rotation
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
     #[inline]
     fn draw_billboard_pro(
         &mut self,

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -1,7 +1,6 @@
 //! Contains code related to drawing. Types that can be set as a surface to draw will implement the [`RaylibDraw`] trait
 
 use crate::{
-    MintVec2, MintVec3,
     core::{RaylibHandle, RaylibThread, texture::Texture2D, vr::VrStereoConfig},
     ffi,
     math::{Matrix, Rectangle, Vector2, Vector3},
@@ -12,10 +11,10 @@ use std::{convert::AsRef, ffi::CString, marker::PhantomData};
 
 /// Seems like all draw commands must be issued from the main thread
 impl RaylibHandle {
-    #[inline]
-    #[must_use]
     /// Setup canvas (framebuffer) to start drawing.
     /// Prefer using the closure version, [`RaylibHandle::draw`]. This version returns a handle that calls [`ffi::EndDrawing`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    #[inline]
+    #[must_use]
     pub fn begin_drawing<'a>(&'a mut self, _: &RaylibThread) -> RaylibDrawHandle<'a> {
         unsafe {
             ffi::BeginDrawing();
@@ -38,6 +37,9 @@ impl RaylibHandle {
     }
 }
 
+/// Handle returned by [`begin_drawing`](RaylibHandle::begin_drawing) to provide access to drawing functions.
+///
+/// Calls [`ffi::EndDrawing`] when dropped.
 pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle);
 
 impl RaylibDrawHandle<'_> {
@@ -64,20 +66,25 @@ impl Drop for RaylibDrawHandle<'_> {
 impl std::ops::Deref for RaylibDrawHandle<'_> {
     type Target = RaylibHandle;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 
 impl std::ops::DerefMut for RaylibDrawHandle<'_> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut RaylibHandle {
         self.0
     }
 }
-impl RaylibDraw for RaylibDrawHandle<'_> {}
+unsafe impl RaylibDraw for RaylibDrawHandle<'_> {}
 
 // Texture2D Stuff
 
+/// Handle returned by [`begin_texture_mode`](RaylibTextureModeExt::begin_texture_mode) to provide access to drawing functions.
+///
+/// Calls [`ffi::EndTextureMode`] when dropped.
 // The texture does not need to be held exclusively for the duration of the *previous* draw mode, nor does the *previous* draw mode need to outlive the texture reference.
 // The texture exclusivity and previous draw mode only need to outlive the *current* draw mode. So they can (and should) have separate lifetimes.
 //
@@ -94,17 +101,20 @@ impl<'a, T: 'a> Drop for RaylibTextureMode<'a, '_, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibTextureMode<'a, '_, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibTextureMode<'a, '_, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
 }
 // framebuffer: &'a mut ffi::RenderTexture2D,
 
+/// Ability to begin drawing to a [`ffi::RenderTexture2D`].
 pub trait RaylibTextureModeExt
 where
     Self: Sized,
@@ -141,10 +151,13 @@ where
 // Only the DrawHandle and the RaylibHandle can start a texture
 impl RaylibTextureModeExt for RaylibDrawHandle<'_> {}
 impl RaylibTextureModeExt for RaylibHandle {}
-impl<'a, T: 'a> RaylibDraw for RaylibTextureMode<'a, '_, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibTextureMode<'a, '_, T> {}
 
 // VR Stuff
 
+/// Handle returned by [`begin_vr_stereo_mode`](RaylibVRModeExt::begin_vr_stereo_mode) to provide access to drawing functions.
+///
+/// Calls [`ffi::EndVrStereoMode`] when dropped.
 // Lifetime 'a is duplicatively stored in a PhantomData so that the borrow checker knows T is being held *exclusively* for the lifetime of the mode, without giving the false impression that it can actually be mutated by the library.
 pub struct RaylibVRMode<'a, 'b, T: 'a>(
     &'a T,
@@ -159,11 +172,13 @@ impl<'a, T: 'a> Drop for RaylibVRMode<'a, '_, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibVRMode<'a, '_, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 
+/// Ability to begin drawing in VR stereo mode.
 pub trait RaylibVRModeExt
 where
     Self: Sized,
@@ -197,10 +212,13 @@ where
 }
 
 impl<D: RaylibDraw> RaylibVRModeExt for D {}
-impl<'a, T: 'a> RaylibDraw for RaylibVRMode<'a, '_, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibVRMode<'a, '_, T> {}
 
 // 2D Mode
 
+/// Handle returned by [`begin_mode2D`](RaylibMode2DExt::begin_mode2D) to provide access to 2D drawing functions.
+///
+/// Calls [`ffi::EndMode2D`] when dropped.
 pub struct RaylibMode2D<'a, T: 'a>(&'a mut T);
 impl<'a, T: 'a> Drop for RaylibMode2D<'a, T> {
     fn drop(&mut self) {
@@ -210,16 +228,19 @@ impl<'a, T: 'a> Drop for RaylibMode2D<'a, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibMode2D<'a, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibMode2D<'a, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
 }
 
+/// Ability to begin drawing in 2D.
 pub trait RaylibMode2DExt
 where
     Self: Sized,
@@ -257,10 +278,13 @@ where
 }
 
 impl<D: RaylibDraw> RaylibMode2DExt for D {}
-impl<'a, T: 'a> RaylibDraw for RaylibMode2D<'a, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibMode2D<'a, T> {}
 
 // 3D Mode
 
+/// Handle returned by [`begin_mode3D`](RaylibMode3DExt::begin_mode3D) to provide access to 3D drawing functions.
+///
+/// Calls [`ffi::EndMode3D`] when dropped.
 pub struct RaylibMode3D<'a, T: 'a>(&'a mut T);
 impl<'a, T: 'a> Drop for RaylibMode3D<'a, T> {
     fn drop(&mut self) {
@@ -270,16 +294,19 @@ impl<'a, T: 'a> Drop for RaylibMode3D<'a, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibMode3D<'a, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibMode3D<'a, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
 }
 
+/// Ability to begin drawing in 3D.
 pub trait RaylibMode3DExt
 where
     Self: Sized,
@@ -317,11 +344,14 @@ where
 }
 
 impl<D: RaylibDraw> RaylibMode3DExt for D {}
-impl<'a, T: 'a> RaylibDraw for RaylibMode3D<'a, T> {}
-impl<'a, T: 'a> RaylibDraw3D for RaylibMode3D<'a, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibMode3D<'a, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw3D for RaylibMode3D<'a, T> {}
 
 // shader Mode
 
+/// Handle returned by [`begin_shader_mode`](RaylibShaderModeExt::begin_shader_mode) to provide access to drawing functions.
+///
+/// Calls [`ffi::EndShaderMode`] when dropped.
 pub struct RaylibShaderMode<'a, 'b, T: 'a>(&'a mut T, PhantomData<&'b mut Shader>);
 
 impl<'a, T: 'a> Drop for RaylibShaderMode<'a, '_, T> {
@@ -332,16 +362,19 @@ impl<'a, T: 'a> Drop for RaylibShaderMode<'a, '_, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibShaderMode<'a, '_, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibShaderMode<'a, '_, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
 }
 
+/// Ability to begin drawing with a shader applied.
 pub trait RaylibShaderModeExt
 where
     Self: Sized,
@@ -374,11 +407,14 @@ where
 }
 
 impl<D: RaylibDraw> RaylibShaderModeExt for D {}
-impl<'a, T: 'a> RaylibDraw for RaylibShaderMode<'a, '_, T> {}
-impl<'a, T: 'a> RaylibDraw3D for RaylibShaderMode<'a, '_, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibShaderMode<'a, '_, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw3D for RaylibShaderMode<'a, '_, T> {}
 
 // Blend Mode
 
+/// Handle returned by [`begin_blend_mode`](RaylibBlendModeExt::begin_blend_mode) to provide access to drawing functions.
+///
+/// Calls [`ffi::EndBlendMode`] when dropped.
 pub struct RaylibBlendMode<'a, T: 'a>(&'a mut T);
 impl<'a, T: 'a> Drop for RaylibBlendMode<'a, T> {
     fn drop(&mut self) {
@@ -388,16 +424,19 @@ impl<'a, T: 'a> Drop for RaylibBlendMode<'a, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibBlendMode<'a, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibBlendMode<'a, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
 }
 
+/// Ability to begin drawing with a blend mode applied.
 pub trait RaylibBlendModeExt
 where
     Self: Sized,
@@ -430,11 +469,14 @@ where
 }
 
 impl<D: RaylibDraw> RaylibBlendModeExt for D {}
-impl<'a, T: 'a> RaylibDraw for RaylibBlendMode<'a, T> {}
-impl<'a, T: 'a> RaylibDraw3D for RaylibBlendMode<'a, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibBlendMode<'a, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw3D for RaylibBlendMode<'a, T> {}
 
 // Scissor Mode stuff
 
+/// Handle returned by [`begin_scissor_mode`](RaylibScissorModeExt::begin_scissor_mode) to provide access to drawing functions.
+///
+/// Calls [`ffi::EndScissorMode`] when dropped.
 pub struct RaylibScissorMode<'a, T: 'a>(&'a mut T);
 impl<'a, T: 'a> Drop for RaylibScissorMode<'a, T> {
     fn drop(&mut self) {
@@ -444,16 +486,19 @@ impl<'a, T: 'a> Drop for RaylibScissorMode<'a, T> {
 impl<'a, T: 'a> std::ops::Deref for RaylibScissorMode<'a, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibScissorMode<'a, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
 }
 
+/// Ability to begin drawing in scissor mode.
 pub trait RaylibScissorModeExt
 where
     Self: Sized,
@@ -492,12 +537,24 @@ where
 }
 
 impl<D: RaylibDraw> RaylibScissorModeExt for D {}
-impl<'a, T: 'a> RaylibDraw for RaylibScissorMode<'a, T> {}
-impl<'a, T: 'a + RaylibDraw3D> RaylibDraw3D for RaylibScissorMode<'a, T> {}
+unsafe impl<'a, T: 'a> RaylibDraw for RaylibScissorMode<'a, T> {}
+unsafe impl<'a, T: 'a + RaylibDraw3D> RaylibDraw3D for RaylibScissorMode<'a, T> {}
 
 // Actual drawing functions
 
-pub trait RaylibDraw {
+/// Types through which it is safe to call standard Raylib drawing functions.
+///
+/// # Safety
+///
+/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+/// and expect for there to be a window and buffer to target--all without any checks.
+///
+/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+/// [`ffi::BeginDrawing`] or [`ffi::BeginTextureMode`] has been called this frame without the corresponding
+/// [`ffi::EndDrawing`]/[`ffi::EndTextureMode`] having been called yet.
+pub unsafe trait RaylibDraw {
     /// Sets background color (framebuffer clear `color.into()`).
     #[inline]
     fn clear_background(&mut self, color: impl Into<ffi::Color>) {
@@ -546,7 +603,7 @@ pub trait RaylibDraw {
 
     /// Draws a pixel (Vector version).
     #[inline]
-    fn draw_pixel_v(&mut self, position: impl Into<MintVec2>, color: impl Into<ffi::Color>) {
+    fn draw_pixel_v(&mut self, position: impl Into<ffi::Vector2>, color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawPixelV(position.into(), color.into());
         }
@@ -571,8 +628,8 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_line_v(
         &mut self,
-        start_pos: impl Into<MintVec2>,
-        end_pos: impl Into<MintVec2>,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -584,8 +641,8 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_line_ex(
         &mut self,
-        start_pos: impl Into<MintVec2>,
-        end_pos: impl Into<MintVec2>,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -598,8 +655,8 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_line_bezier(
         &mut self,
-        start_pos: impl Into<MintVec2>,
-        end_pos: impl Into<MintVec2>,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -640,7 +697,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_circle_sector(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         radius: f32,
         start_angle: f32,
         end_angle: f32,
@@ -663,7 +720,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_circle_sector_lines(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         radius: f32,
         start_angle: f32,
         end_angle: f32,
@@ -701,7 +758,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_circle_v(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         radius: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -728,7 +785,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_circle_lines_v(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         radius: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -772,7 +829,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_ring(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         inner_radius: f32,
         outer_radius: f32,
         start_angle: f32,
@@ -798,7 +855,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_ring_lines(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         inner_radius: f32,
         outer_radius: f32,
         start_angle: f32,
@@ -838,8 +895,8 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_rectangle_v(
         &mut self,
-        position: impl Into<MintVec2>,
-        size: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
+        size: impl Into<ffi::Vector2>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -860,7 +917,7 @@ pub trait RaylibDraw {
     fn draw_rectangle_pro(
         &mut self,
         rec: impl Into<ffi::Rectangle>,
-        origin: impl Into<MintVec2>,
+        origin: impl Into<ffi::Vector2>,
         rotation: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1007,9 +1064,9 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_triangle(
         &mut self,
-        v1: impl Into<MintVec2>,
-        v2: impl Into<MintVec2>,
-        v3: impl Into<MintVec2>,
+        v1: impl Into<ffi::Vector2>,
+        v2: impl Into<ffi::Vector2>,
+        v3: impl Into<ffi::Vector2>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1021,9 +1078,9 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_triangle_lines(
         &mut self,
-        v1: impl Into<MintVec2>,
-        v2: impl Into<MintVec2>,
-        v3: impl Into<MintVec2>,
+        v1: impl Into<ffi::Vector2>,
+        v2: impl Into<ffi::Vector2>,
+        v3: impl Into<ffi::Vector2>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1065,7 +1122,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_poly(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         sides: i32,
         radius: f32,
         rotation: f32,
@@ -1080,7 +1137,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_poly_lines(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         sides: i32,
         radius: f32,
         rotation: f32,
@@ -1110,7 +1167,7 @@ pub trait RaylibDraw {
     fn draw_texture_v(
         &mut self,
         texture: impl AsRef<ffi::Texture2D>,
-        position: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1123,7 +1180,7 @@ pub trait RaylibDraw {
     fn draw_texture_ex(
         &mut self,
         texture: impl AsRef<ffi::Texture2D>,
-        position: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
         rotation: f32,
         scale: f32,
         tint: impl Into<ffi::Color>,
@@ -1145,7 +1202,7 @@ pub trait RaylibDraw {
         &mut self,
         texture: impl AsRef<ffi::Texture2D>,
         source_rec: impl Into<ffi::Rectangle>,
-        position: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1165,7 +1222,7 @@ pub trait RaylibDraw {
         texture: impl AsRef<ffi::Texture2D>,
         source_rec: impl Into<ffi::Rectangle>,
         dest_rec: impl Into<ffi::Rectangle>,
-        origin: impl Into<MintVec2>,
+        origin: impl Into<ffi::Vector2>,
         rotation: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -1188,7 +1245,7 @@ pub trait RaylibDraw {
         texture: impl AsRef<ffi::Texture2D>,
         n_patch_info: impl Into<ffi::NPatchInfo>,
         dest_rec: impl Into<ffi::Rectangle>,
-        origin: impl Into<MintVec2>,
+        origin: impl Into<ffi::Vector2>,
         rotation: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -1236,7 +1293,7 @@ pub trait RaylibDraw {
         &mut self,
         font: impl AsRef<ffi::Font>,
         text: &str,
-        position: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
         font_size: f32,
         spacing: f32,
         tint: impl Into<ffi::Color>,
@@ -1265,7 +1322,7 @@ pub trait RaylibDraw {
         &mut self,
         font: impl AsRef<ffi::Font>,
         text: &str,
-        position: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
         font_size: f32,
         spacing: f32,
         tint: impl Into<ffi::Color>,
@@ -1290,8 +1347,8 @@ pub trait RaylibDraw {
         &mut self,
         font: impl AsRef<ffi::Font>,
         text: &str,
-        position: impl Into<MintVec2>,
-        origin: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
+        origin: impl Into<ffi::Vector2>,
         rotation: f32,
         font_size: f32,
         spacing: f32,
@@ -1318,7 +1375,7 @@ pub trait RaylibDraw {
         &mut self,
         font: impl AsRef<ffi::Font>,
         codepoint: i32,
-        position: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector2>,
         scale: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -1349,7 +1406,7 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_poly_lines_ex(
         &mut self,
-        center: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector2>,
         sides: i32,
         radius: f32,
         rotation: f32,
@@ -1464,8 +1521,8 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_spline_segment_linear(
         &mut self,
-        p1: impl Into<MintVec2>,
-        p2: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1476,10 +1533,10 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_spline_segment_basis(
         &mut self,
-        p1: impl Into<MintVec2>,
-        p2: impl Into<MintVec2>,
-        p3: impl Into<MintVec2>,
-        p4: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1499,10 +1556,10 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_spline_segment_catmull_rom(
         &mut self,
-        p1: impl Into<MintVec2>,
-        p2: impl Into<MintVec2>,
-        p3: impl Into<MintVec2>,
-        p4: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1522,9 +1579,9 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_spline_segment_bezier_quadratic(
         &mut self,
-        p1: impl Into<MintVec2>,
-        c2: impl Into<MintVec2>,
-        p3: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1543,10 +1600,10 @@ pub trait RaylibDraw {
     #[inline]
     fn draw_spline_segment_bezier_cubic(
         &mut self,
-        p1: impl Into<MintVec2>,
-        c2: impl Into<MintVec2>,
-        c3: impl Into<MintVec2>,
-        p4: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        c3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
         thick: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1567,8 +1624,8 @@ pub trait RaylibDraw {
     #[must_use]
     fn get_spline_point_linear(
         &mut self,
-        start_pos: impl Into<MintVec2>,
-        end_pos: impl Into<MintVec2>,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
         t: f32,
     ) -> Vector2 {
         unsafe { ffi::GetSplinePointLinear(start_pos.into(), end_pos.into(), t).into() }
@@ -1579,10 +1636,10 @@ pub trait RaylibDraw {
     #[must_use]
     fn get_spline_point_basis(
         &mut self,
-        p1: impl Into<MintVec2>,
-        p2: impl Into<MintVec2>,
-        p3: impl Into<MintVec2>,
-        p4: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
         t: f32,
     ) -> Vector2 {
         unsafe { ffi::GetSplinePointBasis(p1.into(), p2.into(), p3.into(), p4.into(), t).into() }
@@ -1593,10 +1650,10 @@ pub trait RaylibDraw {
     #[must_use]
     fn get_spline_point_catmull_rom(
         &mut self,
-        p1: impl Into<MintVec2>,
-        p2: impl Into<MintVec2>,
-        p3: impl Into<MintVec2>,
-        p4: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
         t: f32,
     ) -> Vector2 {
         unsafe {
@@ -1609,9 +1666,9 @@ pub trait RaylibDraw {
     #[must_use]
     fn get_spline_point_bezier_quad(
         &mut self,
-        p1: impl Into<MintVec2>,
-        c2: impl Into<MintVec2>,
-        p3: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
         t: f32,
     ) -> Vector2 {
         unsafe { ffi::GetSplinePointBezierQuad(p1.into(), c2.into(), p3.into(), t).into() }
@@ -1622,10 +1679,10 @@ pub trait RaylibDraw {
     #[must_use]
     fn get_spline_point_bezier_cubic(
         &mut self,
-        p1: impl Into<MintVec2>,
-        c2: impl Into<MintVec2>,
-        c3: impl Into<MintVec2>,
-        p4: impl Into<MintVec2>,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        c3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
         t: f32,
     ) -> Vector2 {
         unsafe {
@@ -1634,11 +1691,22 @@ pub trait RaylibDraw {
     }
 }
 
-pub trait RaylibDraw3D {
+/// Types through which it is safe to call 3D Raylib drawing functions.
+///
+/// # Safety
+///
+/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+/// and expect for there to be a window, buffer, & projection matrix to target--all without any checks.
+///
+/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+/// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
+pub unsafe trait RaylibDraw3D {
     /// Draw a point in 3D space, actually a small line
     #[allow(non_snake_case)]
     #[inline]
-    fn draw_point3D(&mut self, position: impl Into<MintVec3>, color: impl Into<ffi::Color>) {
+    fn draw_point3D(&mut self, position: impl Into<ffi::Vector3>, color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawPoint3D(position.into(), color.into());
         }
@@ -1649,9 +1717,9 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_triangle3D(
         &mut self,
-        v1: impl Into<MintVec3>,
-        v2: impl Into<MintVec3>,
-        v3: impl Into<MintVec3>,
+        v1: impl Into<ffi::Vector3>,
+        v2: impl Into<ffi::Vector3>,
+        v3: impl Into<ffi::Vector3>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1680,8 +1748,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_line3D(
         &mut self,
-        start_pos: impl Into<MintVec3>,
-        end_pos: impl Into<MintVec3>,
+        start_pos: impl Into<ffi::Vector3>,
+        end_pos: impl Into<ffi::Vector3>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1694,9 +1762,9 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_circle3D(
         &mut self,
-        center: impl Into<MintVec3>,
+        center: impl Into<ffi::Vector3>,
         radius: f32,
-        rotation_axis: impl Into<MintVec3>,
+        rotation_axis: impl Into<ffi::Vector3>,
         rotation_angle: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1715,7 +1783,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cube(
         &mut self,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         width: f32,
         height: f32,
         length: f32,
@@ -1730,8 +1798,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cube_v(
         &mut self,
-        position: impl Into<MintVec3>,
-        size: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector3>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1743,7 +1811,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cube_wires(
         &mut self,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         width: f32,
         height: f32,
         length: f32,
@@ -1758,8 +1826,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cube_wires_v(
         &mut self,
-        position: impl Into<MintVec3>,
-        size: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector3>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -1803,7 +1871,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_sphere(
         &mut self,
-        center_pos: impl Into<MintVec3>,
+        center_pos: impl Into<ffi::Vector3>,
         radius: f32,
         color: impl Into<ffi::Color>,
     ) {
@@ -1816,7 +1884,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_sphere_ex(
         &mut self,
-        center_pos: impl Into<MintVec3>,
+        center_pos: impl Into<ffi::Vector3>,
         radius: f32,
         rings: i32,
         slices: i32,
@@ -1831,7 +1899,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_sphere_wires(
         &mut self,
-        center_pos: impl Into<MintVec3>,
+        center_pos: impl Into<ffi::Vector3>,
         radius: f32,
         rings: i32,
         slices: i32,
@@ -1846,7 +1914,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cylinder(
         &mut self,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         radius_top: f32,
         radius_bottom: f32,
         height: f32,
@@ -1869,8 +1937,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cylinder_ex(
         &mut self,
-        start_position: impl Into<MintVec3>,
-        end_position: impl Into<MintVec3>,
+        start_position: impl Into<ffi::Vector3>,
+        end_position: impl Into<ffi::Vector3>,
         radius_start: f32,
         radius_end: f32,
         slices: i32,
@@ -1892,7 +1960,7 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cylinder_wires(
         &mut self,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         radius_top: f32,
         radius_bottom: f32,
         height: f32,
@@ -1915,8 +1983,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_cylinder_wires_ex(
         &mut self,
-        start_position: impl Into<MintVec3>,
-        end_position: impl Into<MintVec3>,
+        start_position: impl Into<ffi::Vector3>,
+        end_position: impl Into<ffi::Vector3>,
         radius_start: f32,
         radius_end: f32,
         slices: i32,
@@ -1938,8 +2006,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_capsule(
         &mut self,
-        start_pos: impl Into<MintVec3>,
-        end_pos: impl Into<MintVec3>,
+        start_pos: impl Into<ffi::Vector3>,
+        end_pos: impl Into<ffi::Vector3>,
         radius: f32,
         slices: i32,
         rings: i32,
@@ -1961,8 +2029,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_capsule_wires(
         &mut self,
-        start_pos: impl Into<MintVec3>,
-        end_pos: impl Into<MintVec3>,
+        start_pos: impl Into<ffi::Vector3>,
+        end_pos: impl Into<ffi::Vector3>,
         radius: f32,
         slices: i32,
         rings: i32,
@@ -1984,8 +2052,8 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_plane(
         &mut self,
-        center_pos: impl Into<MintVec3>,
-        size: impl Into<MintVec2>,
+        center_pos: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector2>,
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -2014,7 +2082,7 @@ pub trait RaylibDraw3D {
     fn draw_model(
         &mut self,
         model: impl AsRef<ffi::Model>,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         scale: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -2028,10 +2096,10 @@ pub trait RaylibDraw3D {
     fn draw_model_ex(
         &mut self,
         model: impl AsRef<ffi::Model>,
-        position: impl Into<MintVec3>,
-        rotation_axis: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
+        rotation_axis: impl Into<ffi::Vector3>,
         rotation_angle: f32,
-        scale: impl Into<MintVec3>,
+        scale: impl Into<ffi::Vector3>,
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -2051,7 +2119,7 @@ pub trait RaylibDraw3D {
     fn draw_model_wires(
         &mut self,
         model: impl AsRef<ffi::Model>,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         scale: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -2065,10 +2133,10 @@ pub trait RaylibDraw3D {
     fn draw_model_wires_ex(
         &mut self,
         model: impl AsRef<ffi::Model>,
-        position: impl Into<MintVec3>,
-        rotation_axis: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
+        rotation_axis: impl Into<ffi::Vector3>,
         rotation_angle: f32,
-        scale: impl Into<MintVec3>,
+        scale: impl Into<ffi::Vector3>,
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -2101,7 +2169,7 @@ pub trait RaylibDraw3D {
         &mut self,
         camera: impl Into<ffi::Camera3D>,
         texture: &Texture2D,
-        center: impl Into<MintVec3>,
+        center: impl Into<ffi::Vector3>,
         size: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -2117,8 +2185,8 @@ pub trait RaylibDraw3D {
         camera: impl Into<ffi::Camera3D>,
         texture: &Texture2D,
         source_rec: impl Into<ffi::Rectangle>,
-        center: impl Into<MintVec3>,
-        size: impl Into<MintVec2>,
+        center: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector2>,
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {
@@ -2141,10 +2209,10 @@ pub trait RaylibDraw3D {
         camera: impl Into<ffi::Camera>,
         texture: impl Into<ffi::Texture2D>,
         source: impl Into<ffi::Rectangle>,
-        position: impl Into<MintVec3>,
-        up: impl Into<MintVec3>,
-        size: impl Into<MintVec2>,
-        origin: impl Into<MintVec2>,
+        position: impl Into<ffi::Vector3>,
+        up: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector2>,
+        origin: impl Into<ffi::Vector2>,
         rotation: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -2168,7 +2236,7 @@ pub trait RaylibDraw3D {
     fn draw_model_points(
         &mut self,
         model: impl Into<ffi::Model>,
-        position: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
         scale: f32,
         tint: impl Into<ffi::Color>,
     ) {
@@ -2182,10 +2250,10 @@ pub trait RaylibDraw3D {
     fn draw_model_points_ex(
         &mut self,
         model: impl Into<ffi::Model>,
-        position: impl Into<MintVec3>,
-        rotation_axis: impl Into<MintVec3>,
+        position: impl Into<ffi::Vector3>,
+        rotation_axis: impl Into<ffi::Vector3>,
         angle: f32,
-        scale: impl Into<MintVec3>,
+        scale: impl Into<ffi::Vector3>,
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -7,7 +7,11 @@ use crate::{
     models::WeakMaterial,
     shaders::Shader,
 };
-use std::{convert::AsRef, ffi::CString, marker::PhantomData};
+use std::{
+    ffi::CString,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 /// Seems like all draw commands must be issued from the main thread
 impl RaylibHandle {
@@ -16,21 +20,27 @@ impl RaylibHandle {
     #[inline]
     #[must_use]
     pub fn begin_drawing<'a>(&'a mut self, _: &RaylibThread) -> RaylibDrawHandle<'a> {
+        // SAFETY: Borrowing RaylibHandle proves that Raylib, its window, and GL functions are successfully loaded and that none of them can be
+        // released for the lifetime of `'a`. Borrowing RaylibThread, which can only be constructed *by* initializing Raylib and explicitly
+        // denies `Send`/`Sync` proves we are on the thread that initialized Raylib.
         unsafe {
             ffi::BeginDrawing();
         };
 
-        RaylibDrawHandle(self)
+        RaylibDrawHandle(self, PhantomData)
     }
 
     /// Setup canvas (framebuffer) to start drawing.
     // Every FnMut is a FnOnce, but not every FnOnce is a FnMut. The closure may possibly execute multiple times throughout the program, but not multiple times in a single call to this method.
     // Taking a FnOnce instead of a FnMut when the function only needs to be called once in this method makes the method slightly more versatile/less needlessly restrictive for no actual cost.
     pub fn draw<'a>(&'a mut self, _: &RaylibThread, func: impl FnOnce(RaylibDrawHandle<'a>)) {
+        // SAFETY: Borrowing RaylibHandle proves that Raylib, its window, and GL functions are successfully loaded and that none of them can be
+        // released for the lifetime of `'a`. Borrowing RaylibThread, which can only be constructed *by* initializing Raylib and explicitly
+        // denies `Send`/`Sync` proves we are on the thread that initialized Raylib.
         unsafe {
             ffi::BeginDrawing();
         };
-        func(RaylibDrawHandle(self));
+        func(RaylibDrawHandle(self, PhantomData));
         // Uncomment the following if RaylibDrawHandle has been changed to no longer call EndDrawing() in its drop implementation:
         // unsafe {
         //     ffi::EndDrawing();
@@ -41,7 +51,13 @@ impl RaylibHandle {
 /// Handle returned by [`begin_drawing`](RaylibHandle::begin_drawing) to provide access to drawing functions.
 ///
 /// Calls [`ffi::EndDrawing`] when dropped.
-pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle);
+///
+/// # Guarantees
+///
+/// [`RaylibDrawHandle`] guarantees [`ffi::BeginDrawing`] has been called this frame without the corresponding [`ffi::EndDrawing`] having been called yet.
+/// Raylib, the window, and GL functions are guaranteed to have loaded successfully and will not be released for the duration of `'a`.
+/// [`RaylibDrawHandle`] cannot be shared across threads, guaranteeing borrowers are on the thread that initiated drawing this frame.
+pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle, PhantomData<*const ()>);
 
 impl RaylibDrawHandle<'_> {
     #[deprecated = "Calling begin_drawing within RaylibDrawHandle will result in a runtime error."]
@@ -49,6 +65,7 @@ impl RaylibDrawHandle<'_> {
     pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle<'_> {
         panic!("Nested begin_drawing call")
     }
+
     #[deprecated = "Calling draw within RaylibDrawHandle will result in a runtime error."]
     #[doc(hidden)]
     pub fn draw(&mut self, _: &RaylibThread, mut _func: impl FnMut(RaylibDrawHandle)) {
@@ -57,14 +74,16 @@ impl RaylibDrawHandle<'_> {
 }
 
 impl Drop for RaylibDrawHandle<'_> {
+    #[inline]
     fn drop(&mut self) {
+        // SAFETY: RaylibDrawHandle guarantees BeginDrawing has been called this frame without the corresponding EndDrawing having been called yet.
         unsafe {
             ffi::EndDrawing();
         }
     }
 }
 
-impl std::ops::Deref for RaylibDrawHandle<'_> {
+impl Deref for RaylibDrawHandle<'_> {
     type Target = RaylibHandle;
 
     #[inline]
@@ -73,12 +92,14 @@ impl std::ops::Deref for RaylibDrawHandle<'_> {
     }
 }
 
-impl std::ops::DerefMut for RaylibDrawHandle<'_> {
+impl DerefMut for RaylibDrawHandle<'_> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut RaylibHandle {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
+
+// SAFETY: See `RaylibDrawHandle` guarantees.
 unsafe impl RaylibDraw for RaylibDrawHandle<'_> {}
 
 // Texture2D Stuff
@@ -86,44 +107,68 @@ unsafe impl RaylibDraw for RaylibDrawHandle<'_> {}
 /// Handle returned by [`begin_texture_mode`](RaylibTextureModeExt::begin_texture_mode) to provide access to drawing functions.
 ///
 /// Calls [`ffi::EndTextureMode`] when dropped.
+///
+/// # Guarantees
+///
+/// [`RaylibTextureMode`] guarantees [`ffi::BeginTextureMode`] has been called this frame without the corresponding [`ffi::EndTextureMode`] having been called yet.
+/// Raylib, the window, and GL functions are guaranteed to have loaded successfully and will not be released for the duration of `'a`.
+/// [`RaylibTextureMode`] cannot be shared across threads, guaranteeing borrowers are on the thread that initiated drawing this frame.
 // The texture does not need to be held exclusively for the duration of the *previous* draw mode, nor does the *previous* draw mode need to outlive the texture reference.
 // The texture exclusivity and previous draw mode only need to outlive the *current* draw mode. So they can (and should) have separate lifetimes.
 //
 // Additionally: the texture is not actually *used* by this wrapper after construction, only the previous draw mode.
 // Some space can be saved by using a phantom instead of copying the actual reference.
 // The PhantomData will ensure that the borrow checker still analyzes as though the mutable texture reference was held, without physically storing it in the runtime memory.
-pub struct RaylibTextureMode<'a, 'b, T: 'a>(&'a mut T, PhantomData<&'b mut ffi::RenderTexture2D>);
+pub struct RaylibTextureMode<'a, 'b, T: ?Sized + RaylibTextureModeExt + 'a>(
+    &'a mut T,
+    PhantomData<&'b mut ffi::RenderTexture2D>,
+    PhantomData<*const ()>,
+);
 
-impl<'a, T: 'a> Drop for RaylibTextureMode<'a, '_, T> {
+impl<'a, T: ?Sized + RaylibTextureModeExt + 'a> Drop for RaylibTextureMode<'a, '_, T> {
+    #[inline]
     fn drop(&mut self) {
+        // SAFETY: RaylibTextureMode guarantees BeginTextureMode has been called this frame without the corresponding EndTextureMode having been called yet.
         unsafe { ffi::EndTextureMode() }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibTextureMode<'a, '_, T> {
-    type Target = T;
+
+impl<'a, T: ?Sized + RaylibTextureModeExt + 'a> Deref for RaylibTextureMode<'a, '_, T>
+where
+    T: Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
-impl<'a, T: 'a> std::ops::DerefMut for RaylibTextureMode<'a, '_, T> {
+
+impl<'a, T: ?Sized + RaylibTextureModeExt + 'a> DerefMut for RaylibTextureMode<'a, '_, T>
+where
+    T: DerefMut<Target = RaylibHandle>,
+{
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
 // framebuffer: &'a mut ffi::RenderTexture2D,
 
 /// Ability to begin drawing to a [`ffi::RenderTexture2D`].
-pub trait RaylibTextureModeExt
-where
-    Self: Sized,
-{
+///
+/// # Safety
+///
+/// Implementors must guarantee that borrowing `Self` proves that Raylib, its window, and GL functions are
+/// successfully loaded and that none of them will be released for the lifetime of the borrow.
+///
+/// It must also be guaranteed that [`ffi::BeginTextureMode`] is safe to call given the current render mode.
+pub unsafe trait RaylibTextureModeExt {
     /// Begin drawing to render texture.
     ///
     /// Prefer using the closure version, [`RaylibTextureModeExt::draw_texture_mode`].
-    /// This version returns a handle that calls [`ffi::EndTextureMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    /// This version returns a handle that calls [`ffi::EndTextureMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures (such as lifetime or performance reasons)
     #[inline]
     #[must_use]
     fn begin_texture_mode<'a, 'b>(
@@ -131,8 +176,9 @@ where
         _: &RaylibThread,
         framebuffer: &'b mut ffi::RenderTexture2D,
     ) -> RaylibTextureMode<'a, 'b, Self> {
+        // SAFETY: Implementor must uphold the trait safety contract.
         unsafe { ffi::BeginTextureMode(*framebuffer) }
-        RaylibTextureMode(self, PhantomData)
+        RaylibTextureMode(self, PhantomData, PhantomData)
     }
 
     /// Begin drawing to render texture.
@@ -142,36 +188,62 @@ where
         framebuffer: &'b mut ffi::RenderTexture2D,
         func: impl FnOnce(RaylibTextureMode<'a, 'b, Self>),
     ) {
+        // SAFETY: Implementor must uphold the trait safety contract.
         unsafe { ffi::BeginTextureMode(*framebuffer) }
-        func(RaylibTextureMode(self, PhantomData));
+        func(RaylibTextureMode(self, PhantomData, PhantomData));
         // Uncomment the following if RaylibTextureMode has been changed to no longer call EndTextureMode() in its drop implementation:
         // unsafe { ffi::EndTextureMode(); }
     }
 }
 
-// Only the DrawHandle and the RaylibHandle can start a texture
-impl RaylibTextureModeExt for RaylibDrawHandle<'_> {}
-impl RaylibTextureModeExt for RaylibHandle {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibTextureMode<'a, '_, T> {}
+// Only the `DrawHandle` and the `RaylibHandle` can start a texture
+
+// SAFETY: `RaylibHandle` inherently proves that Raylib, its window, and GL functions are
+// successfully loaded and that none of them will be released for its lifetime.
+// It is safe to initialize Raylib texture mode while drawing is not active so long as the
+// window and GL functions are ready.
+unsafe impl RaylibTextureModeExt for RaylibHandle {}
+
+// SAFETY: `RaylibDrawHandle` borrows `RaylibHandle`, proving that Raylib, its window, and GL
+// functions are successfully loaded and that none of them will be released for its lifetime.
+// It is safe to initialize Raylib texture mode while drawing is active when no additional
+// draw modes are active.
+unsafe impl RaylibTextureModeExt for RaylibDrawHandle<'_> {}
+
+// SAFETY: see `RaylibTextureMode` guarantees.
+unsafe impl<'a, T: ?Sized + RaylibTextureModeExt + 'a> RaylibDraw for RaylibTextureMode<'a, '_, T> {}
 
 // VR Stuff
 
 /// Handle returned by [`begin_vr_stereo_mode`](RaylibVRModeExt::begin_vr_stereo_mode) to provide access to drawing functions.
 ///
 /// Calls [`ffi::EndVrStereoMode`] when dropped.
+///
+/// # Guarantees
+///
+/// [`RaylibVRMode`] guarantees [`ffi::BeginVrStereoMode`] has been called this frame without the corresponding [`ffi::EndVrStereoMode`] having been called yet.
 // Lifetime 'a is duplicatively stored in a PhantomData so that the borrow checker knows T is being held *exclusively* for the lifetime of the mode, without giving the false impression that it can actually be mutated by the library.
-pub struct RaylibVRMode<'a, 'b, T: 'a>(
+pub struct RaylibVRMode<'a, 'b, T: ?Sized + RaylibVRModeExt + 'a>(
     &'a T,
     PhantomData<&'a mut T>,
     PhantomData<&'b mut VrStereoConfig>,
 );
-impl<'a, T: 'a> Drop for RaylibVRMode<'a, '_, T> {
+
+impl<'a, T: ?Sized + RaylibVRModeExt + 'a> Drop for RaylibVRMode<'a, '_, T> {
+    #[inline]
     fn drop(&mut self) {
-        unsafe { ffi::EndVrStereoMode() }
+        // SAFETY: RaylibVRMode guarantees BeginVrStereoMode has been called this frame without the corresponding EndVrStereoMode having been called yet.
+        unsafe {
+            ffi::EndVrStereoMode();
+        }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibVRMode<'a, '_, T> {
-    type Target = T;
+
+impl<'a, T: 'a> Deref for RaylibVRMode<'a, '_, T>
+where
+    T: ?Sized + RaylibVRModeExt + Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -180,13 +252,11 @@ impl<'a, T: 'a> std::ops::Deref for RaylibVRMode<'a, '_, T> {
 }
 
 /// Ability to begin drawing in VR stereo mode.
-pub trait RaylibVRModeExt
-where
-    Self: Sized,
-{
+pub trait RaylibVRModeExt: RaylibDraw {
     /// Begin stereo rendering (requires VR simulator).
     ///
     /// Prefer using the closure version, [`RaylibVRModeExt::draw_vr_stereo_mode`].
+    ///
     /// This version returns a handle that calls [`ffi::EndVrStereoMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[inline]
     #[must_use]
@@ -195,6 +265,7 @@ where
         _: &RaylibThread,
         vr_config: &'b mut VrStereoConfig,
     ) -> RaylibVRMode<'a, 'b, Self> {
+        // SAFETY: Implementors of RaylibDraw are required to ensure draw functions are safe to call for the duration of their lifetime.
         unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
         RaylibVRMode(self, PhantomData, PhantomData)
     }
@@ -205,6 +276,7 @@ where
         vr_config: &'b mut VrStereoConfig,
         func: impl FnOnce(RaylibVRMode<'a, 'b, Self>),
     ) {
+        // SAFETY: Implementors of RaylibDraw are required to ensure draw functions are safe to call for the duration of their lifetime.
         unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
         func(RaylibVRMode(self, PhantomData, PhantomData));
         // Uncomment the following if RaylibVRMode has been changed to no longer call EndTextureMode() in its drop implementation:
@@ -212,31 +284,44 @@ where
     }
 }
 
-impl<D: RaylibDraw> RaylibVRModeExt for D {}
-unsafe impl<'a, T: 'a> RaylibDraw for RaylibVRMode<'a, '_, T> {}
+impl<D: ?Sized + RaylibDraw> RaylibVRModeExt for D {}
+unsafe impl<'a, T: ?Sized + RaylibVRModeExt + 'a> RaylibDraw for RaylibVRMode<'a, '_, T> {}
 
 // 2D Mode
 
 /// Handle returned by [`begin_mode2D`](RaylibMode2DExt::begin_mode2D) to provide access to 2D drawing functions.
 ///
 /// Calls [`ffi::EndMode2D`] when dropped.
+///
+/// # Guarantees
+///
+/// [`RaylibMode2D`] guarantees [`ffi::BeginMode2D`] has been called this frame without the corresponding [`ffi::EndMode2D`] having been called yet.
 pub struct RaylibMode2D<'a, T: 'a>(&'a mut T);
+
 impl<'a, T: 'a> Drop for RaylibMode2D<'a, T> {
     fn drop(&mut self) {
         unsafe { ffi::EndMode2D() }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibMode2D<'a, T> {
-    type Target = T;
+
+impl<'a, T: 'a> Deref for RaylibMode2D<'a, T>
+where
+    T: Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
-impl<'a, T: 'a> std::ops::DerefMut for RaylibMode2D<'a, T> {
+
+impl<'a, T: 'a> DerefMut for RaylibMode2D<'a, T>
+where
+    T: DerefMut<Target = RaylibHandle>,
+{
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
@@ -292,17 +377,23 @@ impl<'a, T: 'a> Drop for RaylibMode3D<'a, T> {
         unsafe { ffi::EndMode3D() }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibMode3D<'a, T> {
-    type Target = T;
+impl<'a, T: 'a> Deref for RaylibMode3D<'a, T>
+where
+    T: Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
-impl<'a, T: 'a> std::ops::DerefMut for RaylibMode3D<'a, T> {
+impl<'a, T: 'a> DerefMut for RaylibMode3D<'a, T>
+where
+    T: DerefMut<Target = RaylibHandle>,
+{
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
@@ -360,17 +451,23 @@ impl<'a, T: 'a> Drop for RaylibShaderMode<'a, '_, T> {
         unsafe { ffi::EndShaderMode() }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibShaderMode<'a, '_, T> {
-    type Target = T;
+impl<'a, T: 'a> Deref for RaylibShaderMode<'a, '_, T>
+where
+    T: Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
-impl<'a, T: 'a> std::ops::DerefMut for RaylibShaderMode<'a, '_, T> {
+impl<'a, T: 'a> DerefMut for RaylibShaderMode<'a, '_, T>
+where
+    T: DerefMut<Target = RaylibHandle>,
+{
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
@@ -422,17 +519,23 @@ impl<'a, T: 'a> Drop for RaylibBlendMode<'a, T> {
         unsafe { ffi::EndBlendMode() }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibBlendMode<'a, T> {
-    type Target = T;
+impl<'a, T: 'a> Deref for RaylibBlendMode<'a, T>
+where
+    T: Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
-impl<'a, T: 'a> std::ops::DerefMut for RaylibBlendMode<'a, T> {
+impl<'a, T: 'a> DerefMut for RaylibBlendMode<'a, T>
+where
+    T: DerefMut<Target = RaylibHandle>,
+{
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
@@ -484,17 +587,23 @@ impl<'a, T: 'a> Drop for RaylibScissorMode<'a, T> {
         unsafe { ffi::EndScissorMode() }
     }
 }
-impl<'a, T: 'a> std::ops::Deref for RaylibScissorMode<'a, T> {
-    type Target = T;
+impl<'a, T: 'a> Deref for RaylibScissorMode<'a, T>
+where
+    T: Deref<Target = RaylibHandle>,
+{
+    type Target = RaylibHandle;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
-impl<'a, T: 'a> std::ops::DerefMut for RaylibScissorMode<'a, T> {
+impl<'a, T: 'a> DerefMut for RaylibScissorMode<'a, T>
+where
+    T: DerefMut<Target = RaylibHandle>,
+{
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
 }
@@ -543,1736 +652,1936 @@ unsafe impl<'a, T: 'a + RaylibDraw3D> RaylibDraw3D for RaylibScissorMode<'a, T> 
 
 // Actual drawing functions
 
-/// Types through which it is safe to call standard Raylib drawing functions.
+/// Permits external implementation of [`RaylibDraw`].
+///
+/// Implementing this trait on your type will automatically impl the default
+/// definition of [`RaylibDraw`] for it.
 ///
 /// # Safety
 ///
-/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
-/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
-/// and expect for there to be a window and buffer to target--all without any checks.
+/// This trait implements [`RaylibDraw`] for your type. Implementors of
+/// [`RaylibDrawImpl`] must uphold the safety contract of [`RaylibDraw`].
 ///
-/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
-/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
-/// [`ffi::BeginDrawing`] or [`ffi::BeginTextureMode`] has been called this frame without the corresponding
-/// [`ffi::EndDrawing`]/[`ffi::EndTextureMode`] having been called yet.
-pub unsafe trait RaylibDraw {
-    /// Sets background color (framebuffer clear `color.into()`).
-    #[inline]
-    fn clear_background(&mut self, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::ClearBackground(color.into());
-        }
-    }
-
-    /// Get texture that is used for shapes drawing
-    #[inline]
-    #[must_use]
-    fn get_shapes_texture(&self) -> Texture2D {
-        Texture2D(unsafe { ffi::GetShapesTexture() })
-    }
-
-    /// Get texture source rectangle that is used for shapes drawing
-    #[inline]
-    #[must_use]
-    fn get_shapes_texture_rectangle(&self) -> Rectangle {
-        unsafe { ffi::GetShapesTextureRectangle() }
-    }
-
-    /// Define default texture used to draw shapes
-    #[inline]
-    fn set_shapes_texture(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        source: impl Into<ffi::Rectangle>,
-    ) {
-        unsafe { ffi::SetShapesTexture(*texture.as_ref(), source.into()) }
-    }
-
-    // // Draw gui widget
-    // fn draw_gui<G: crate::rgui::GuiDraw>(&mut self, widget: G) -> crate::rgui::DrawResult {
-    //     widget.draw()
-    // }
-
-    // SHAPES
-    /// Draws a pixel.
-    #[inline]
-    fn draw_pixel(&mut self, x: i32, y: i32, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawPixel(x, y, color.into());
-        }
-    }
-
-    /// Draws a pixel (Vector version).
-    #[inline]
-    fn draw_pixel_v(&mut self, position: impl Into<ffi::Vector2>, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawPixelV(position.into(), color.into());
-        }
-    }
-
-    /// Draws a line.
-    #[inline]
-    fn draw_line(
-        &mut self,
-        start_pos_x: i32,
-        start_pos_y: i32,
-        end_pos_x: i32,
-        end_pos_y: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawLine(start_pos_x, start_pos_y, end_pos_x, end_pos_y, color.into());
-        }
-    }
-
-    /// Draws a line (Vector version).
-    #[inline]
-    fn draw_line_v(
-        &mut self,
-        start_pos: impl Into<ffi::Vector2>,
-        end_pos: impl Into<ffi::Vector2>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawLineV(start_pos.into(), end_pos.into(), color.into());
-        }
-    }
-
-    /// Draws a line with thickness.
-    #[inline]
-    fn draw_line_ex(
-        &mut self,
-        start_pos: impl Into<ffi::Vector2>,
-        end_pos: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawLineEx(start_pos.into(), end_pos.into(), thick, color.into());
-        }
-    }
-
-    /// Draws a line using cubic-bezier curves in-out.
-    #[inline]
-    fn draw_line_bezier(
-        &mut self,
-        start_pos: impl Into<ffi::Vector2>,
-        end_pos: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawLineBezier(start_pos.into(), end_pos.into(), thick, color.into());
-        }
-    }
-
-    /// Draw lines sequence
-    #[inline]
-    fn draw_line_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawLineStrip(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                color.into(),
-            );
-        }
-    }
-
-    /// Draws a color-filled circle.
-    #[inline]
-    fn draw_circle(
-        &mut self,
-        center_x: i32,
-        center_y: i32,
-        radius: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircle(center_x, center_y, radius, color.into());
-        }
-    }
-
-    /// Draw a piece of a circle
-    #[inline]
-    fn draw_circle_sector(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-        segments: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircleSector(
-                center.into(),
-                radius,
-                start_angle,
-                end_angle,
-                segments,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw circle sector outline
-    #[inline]
-    fn draw_circle_sector_lines(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-        segments: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircleSectorLines(
-                center.into(),
-                radius,
-                start_angle,
-                end_angle,
-                segments,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draws a gradient-filled circle.
-    #[inline]
-    fn draw_circle_gradient(
-        &mut self,
-        center_x: i32,
-        center_y: i32,
-        radius: f32,
-        color1: impl Into<ffi::Color>,
-        color2: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircleGradient(center_x, center_y, radius, color1.into(), color2.into());
-        }
-    }
-
-    /// Draws a color-filled circle (Vector version).
-    #[inline]
-    fn draw_circle_v(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        radius: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircleV(center.into(), radius, color.into());
-        }
-    }
-
-    /// Draws circle outline.
-    #[inline]
-    fn draw_circle_lines(
-        &mut self,
-        center_x: i32,
-        center_y: i32,
-        radius: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircleLines(center_x, center_y, radius, color.into());
-        }
-    }
-
-    /// Draws circle outline. (Vector Version)
-    #[inline]
-    fn draw_circle_lines_v(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        radius: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircleLinesV(center.into(), radius, color.into());
-        }
-    }
-
-    /// Draws ellipse.
-    #[inline]
-    fn draw_ellipse(
-        &mut self,
-        center_x: i32,
-        center_y: i32,
-        radius_h: f32,
-        radius_v: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawEllipse(center_x, center_y, radius_h, radius_v, color.into());
-        }
-    }
-
-    /// Draws ellipse.
-    #[inline]
-    fn draw_ellipse_lines(
-        &mut self,
-        center_x: i32,
-        center_y: i32,
-        radius_h: f32,
-        radius_v: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawEllipseLines(center_x, center_y, radius_h, radius_v, color.into());
-        }
-    }
-
-    /// Draw ring
-    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-    #[inline]
-    fn draw_ring(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        inner_radius: f32,
-        outer_radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-        segments: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRing(
-                center.into(),
-                inner_radius,
-                outer_radius,
-                start_angle,
-                end_angle,
-                segments,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw ring lines
-    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-    #[inline]
-    fn draw_ring_lines(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        inner_radius: f32,
-        outer_radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-        segments: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRingLines(
-                center.into(),
-                inner_radius,
-                outer_radius,
-                start_angle,
-                end_angle,
-                segments,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draws a color-filled rectangle.
-    #[inline]
-    fn draw_rectangle(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangle(x, y, width, height, color.into());
-        }
-    }
-
-    /// Draws a color-filled rectangle (Vector version).
-    #[inline]
-    fn draw_rectangle_v(
-        &mut self,
-        position: impl Into<ffi::Vector2>,
-        size: impl Into<ffi::Vector2>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleV(position.into(), size.into(), color.into());
-        }
-    }
-
-    /// Draws a color-filled rectangle from `rec`.
-    #[inline]
-    fn draw_rectangle_rec(&mut self, rec: impl Into<ffi::Rectangle>, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawRectangleRec(rec.into(), color.into());
-        }
-    }
-
-    /// Draws a color-filled rectangle with pro parameters.
-    #[inline]
-    fn draw_rectangle_pro(
-        &mut self,
-        rec: impl Into<ffi::Rectangle>,
-        origin: impl Into<ffi::Vector2>,
-        rotation: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectanglePro(rec.into(), origin.into(), rotation, color.into());
-        }
-    }
-
-    /// Draws a vertical-gradient-filled rectangle.
-    ///
-    /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
-    #[inline]
-    fn draw_rectangle_gradient_v(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        color1: impl Into<ffi::Color>,
-        color2: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleGradientV(x, y, width, height, color1.into(), color2.into());
-        }
-    }
-
-    /// Draws a horizontal-gradient-filled rectangle.
-    ///
-    /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
-    #[inline]
-    fn draw_rectangle_gradient_h(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        color1: impl Into<ffi::Color>,
-        color2: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleGradientH(x, y, width, height, color1.into(), color2.into());
-        }
-    }
-
-    /// Draws a gradient-filled rectangle with custom vertex colors.
-    ///
-    /// **NOTE**: Colors refer to corners, starting at top-left corner and going counter-clockwise.
-    #[inline]
-    fn draw_rectangle_gradient_ex(
-        &mut self,
-        rec: impl Into<ffi::Rectangle>,
-        col1: impl Into<ffi::Color>,
-        col2: impl Into<ffi::Color>,
-        col3: impl Into<ffi::Color>,
-        col4: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleGradientEx(
-                rec.into(),
-                col1.into(),
-                col2.into(),
-                col3.into(),
-                col4.into(),
-            );
-        }
-    }
-
-    /// Draws rectangle outline.
-    #[inline]
-    fn draw_rectangle_lines(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleLines(x, y, width, height, color.into());
-        }
-    }
-
-    /// Draws rectangle outline with extended parameters.
-    #[inline]
-    fn draw_rectangle_lines_ex(
-        &mut self,
-        rec: impl Into<ffi::Rectangle>,
-        line_thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleLinesEx(rec.into(), line_thick, color.into());
-        }
-    }
-
-    /// Draws rectangle with rounded edges.
-    #[inline]
-    fn draw_rectangle_rounded(
-        &mut self,
-        rec: impl Into<ffi::Rectangle>,
-        roundness: f32,
-        segments: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleRounded(rec.into(), roundness, segments, color.into());
-        }
-    }
-
-    /// Draws rectangle outline with rounded edges included.
-    #[inline]
-    fn draw_rectangle_rounded_lines(
-        &mut self,
-        rec: impl Into<ffi::Rectangle>,
-        roundness: f32,
-        segments: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleRoundedLines(rec.into(), roundness, segments, color.into());
-        }
-    }
-
-    /// Draw rectangle with rounded edges outline
-    #[inline]
-    fn draw_rectangle_rounded_lines_ex(
-        &mut self,
-        rec: impl Into<ffi::Rectangle>,
-        roundness: f32,
-        segments: i32,
-        line_thickness: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawRectangleRoundedLinesEx(
-                rec.into(),
-                roundness,
-                segments,
-                line_thickness,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draws a triangle.
-    #[inline]
-    fn draw_triangle(
-        &mut self,
-        v1: impl Into<ffi::Vector2>,
-        v2: impl Into<ffi::Vector2>,
-        v3: impl Into<ffi::Vector2>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTriangle(v1.into(), v2.into(), v3.into(), color.into());
-        }
-    }
-
-    /// Draws a triangle using lines.
-    #[inline]
-    fn draw_triangle_lines(
-        &mut self,
-        v1: impl Into<ffi::Vector2>,
-        v2: impl Into<ffi::Vector2>,
-        v3: impl Into<ffi::Vector2>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTriangleLines(v1.into(), v2.into(), v3.into(), color.into());
-        }
-    }
-
-    /// Draw a triangle fan defined by points.
-    #[inline]
-    fn draw_triangle_fan(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawTriangleFan(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw a triangle strip defined by points
-    #[inline]
-    fn draw_triangle_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawTriangleStrip(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                color.into(),
-            );
-        }
-    }
-
-    /// Draws a regular polygon of n sides (Vector version).
-    #[inline]
-    fn draw_poly(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        sides: i32,
-        radius: f32,
-        rotation: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawPoly(center.into(), sides, radius, rotation, color.into());
-        }
-    }
-
-    /// Draws a regular polygon of n sides (Vector version).
-    #[inline]
-    fn draw_poly_lines(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        sides: i32,
-        radius: f32,
-        rotation: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawPolyLines(center.into(), sides, radius, rotation, color.into());
-        }
-    }
-
-    /// Draws a `texture` using specified position and `tint` color.
-    #[inline]
-    fn draw_texture(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        x: i32,
-        y: i32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTexture(*texture.as_ref(), x, y, tint.into());
-        }
-    }
-
-    /// Draws a `texture` using specified `position` vector and `tint` color.
-    #[inline]
-    fn draw_texture_v(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        position: impl Into<ffi::Vector2>,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTextureV(*texture.as_ref(), position.into(), tint.into());
-        }
-    }
-
-    /// Draws a `texture` with extended parameters.
-    #[inline]
-    fn draw_texture_ex(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        position: impl Into<ffi::Vector2>,
-        rotation: f32,
-        scale: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTextureEx(
-                *texture.as_ref(),
-                position.into(),
-                rotation,
-                scale,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Draws from a region of `texture` defined by the `source_rec` rectangle.
-    #[inline]
-    fn draw_texture_rec(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        source_rec: impl Into<ffi::Rectangle>,
-        position: impl Into<ffi::Vector2>,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTextureRec(
-                *texture.as_ref(),
-                source_rec.into(),
-                position.into(),
-                tint.into(),
-            );
-        }
-    }
-
-    /// Draw from a region of `texture` defined by the `source_rec` rectangle with pro parameters.
-    #[inline]
-    fn draw_texture_pro(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        source_rec: impl Into<ffi::Rectangle>,
-        dest_rec: impl Into<ffi::Rectangle>,
-        origin: impl Into<ffi::Vector2>,
-        rotation: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTexturePro(
-                *texture.as_ref(),
-                source_rec.into(),
-                dest_rec.into(),
-                origin.into(),
-                rotation,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Draws a texture (or part of it) that stretches or shrinks nicely
-    #[inline]
-    fn draw_texture_n_patch(
-        &mut self,
-        texture: impl AsRef<ffi::Texture2D>,
-        n_patch_info: impl Into<ffi::NPatchInfo>,
-        dest_rec: impl Into<ffi::Rectangle>,
-        origin: impl Into<ffi::Vector2>,
-        rotation: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTextureNPatch(
-                *texture.as_ref(),
-                n_patch_info.into(),
-                dest_rec.into(),
-                origin.into(),
-                rotation,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Shows current FPS.
-    #[inline]
-    fn draw_fps(&mut self, x: i32, y: i32) {
-        unsafe {
-            ffi::DrawFPS(x, y);
-        }
-    }
-
-    /// Draws text (using default font).
-    /// This does not support UTF-8. Use `[RaylibDrawHandle::draw_text_codepoints]` for that.
-    #[inline]
-    fn draw_text(
-        &mut self,
-        text: &str,
-        x: i32,
-        y: i32,
-        font_size: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-
-        unsafe {
-            ffi::DrawText(c_text.as_ptr(), x, y, font_size, color.into());
-        }
-    }
-
-    /// Draws text (using default font) with support for UTF-8.
-    /// If you do not need UTF-8, use `[RaylibDrawHandle::draw_text]`.
-    fn draw_text_codepoints(
-        &mut self,
-        font: impl AsRef<ffi::Font>,
-        text: &str,
-        position: impl Into<ffi::Vector2>,
-        font_size: f32,
-        spacing: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-        let mut len = 0;
-        let u = unsafe { ffi::LoadCodepoints(c_text.as_ptr(), &raw mut len) };
-
-        unsafe {
-            ffi::DrawTextCodepoints(
-                *font.as_ref(),
-                u,
-                text.len()
-                    .try_into()
-                    .expect("text should not exceed i32::MAX elements"),
-                position.into(),
-                font_size,
-                spacing,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Draws text using `font` and additional parameters.
-    #[inline]
-    fn draw_text_ex(
-        &mut self,
-        font: impl AsRef<ffi::Font>,
-        text: &str,
-        position: impl Into<ffi::Vector2>,
-        font_size: f32,
-        spacing: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-        unsafe {
-            ffi::DrawTextEx(
-                *font.as_ref(),
-                c_text.as_ptr(),
-                position.into(),
-                font_size,
-                spacing,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Draw text using Font and pro parameters (rotation)
-    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-    #[inline]
-    fn draw_text_pro(
-        &mut self,
-        font: impl AsRef<ffi::Font>,
-        text: &str,
-        position: impl Into<ffi::Vector2>,
-        origin: impl Into<ffi::Vector2>,
-        rotation: f32,
-        font_size: f32,
-        spacing: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-        unsafe {
-            ffi::DrawTextPro(
-                *font.as_ref(),
-                c_text.as_ptr(),
-                position.into(),
-                origin.into(),
-                rotation,
-                font_size,
-                spacing,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Draw one character (codepoint)
-    #[inline]
-    fn draw_text_codepoint(
-        &mut self,
-        font: impl AsRef<ffi::Font>,
-        codepoint: i32,
-        position: impl Into<ffi::Vector2>,
-        scale: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTextCodepoint(
-                *font.as_ref(),
-                codepoint,
-                position.into(),
-                scale,
-                tint.into(),
-            );
-        }
-    }
-
-    /// Enable waiting for events when the handle is dropped, no automatic event polling
-    #[inline]
-    fn enable_event_waiting(&self) {
-        unsafe { ffi::EnableEventWaiting() }
-    }
-
-    /// Disable waiting for events when the handle is dropped, no automatic event polling
-    #[inline]
-    fn disable_event_waiting(&self) {
-        unsafe { ffi::DisableEventWaiting() }
-    }
-
-    /// Draw a polygon outline of n sides with extended parameters
-    #[inline]
-    fn draw_poly_lines_ex(
-        &mut self,
-        center: impl Into<ffi::Vector2>,
-        sides: i32,
-        radius: f32,
-        rotation: f32,
-        line_thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawPolyLinesEx(
-                center.into(),
-                sides,
-                radius,
-                rotation,
-                line_thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline: Linear, minimum 2 points
-    #[inline]
-    fn draw_spline_linear(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawSplineLinear(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline: B-Spline, minimum 4 points
-    #[inline]
-    fn draw_spline_basis(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawSplineBasis(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline: Catmull-Rom, minimum 4 points
-    #[inline]
-    fn draw_spline_catmull_rom(
-        &mut self,
-        points: &[Vector2],
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineCatmullRom(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
-    #[inline]
-    fn draw_spline_bezier_quadratic(
-        &mut self,
-        points: &[Vector2],
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineBezierQuadratic(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
-    #[inline]
-    fn draw_spline_bezier_cubic(
-        &mut self,
-        points: &[Vector2],
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineBezierCubic(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline segment: Linear, 2 points
-    #[inline]
-    fn draw_spline_segment_linear(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        p2: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe { ffi::DrawSplineSegmentLinear(p1.into(), p2.into(), thick, color.into()) }
-    }
-
-    /// Draw spline segment: B-Spline, 4 points
-    #[inline]
-    fn draw_spline_segment_basis(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        p2: impl Into<ffi::Vector2>,
-        p3: impl Into<ffi::Vector2>,
-        p4: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineSegmentBasis(
-                p1.into(),
-                p2.into(),
-                p3.into(),
-                p4.into(),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline segment: Catmull-Rom, 4 points
-    #[inline]
-    fn draw_spline_segment_catmull_rom(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        p2: impl Into<ffi::Vector2>,
-        p3: impl Into<ffi::Vector2>,
-        p4: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineSegmentCatmullRom(
-                p1.into(),
-                p2.into(),
-                p3.into(),
-                p4.into(),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
-    #[inline]
-    fn draw_spline_segment_bezier_quadratic(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        c2: impl Into<ffi::Vector2>,
-        p3: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineSegmentBezierQuadratic(
-                p1.into(),
-                c2.into(),
-                p3.into(),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Draw spline segment: Cubic Bezier, 2 points, 2 control points
-    #[inline]
-    fn draw_spline_segment_bezier_cubic(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        c2: impl Into<ffi::Vector2>,
-        c3: impl Into<ffi::Vector2>,
-        p4: impl Into<ffi::Vector2>,
-        thick: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSplineSegmentBezierCubic(
-                p1.into(),
-                c2.into(),
-                c3.into(),
-                p4.into(),
-                thick,
-                color.into(),
-            );
-        }
-    }
-
-    /// Get (evaluate) spline point: Linear
-    #[inline]
-    #[must_use]
-    fn get_spline_point_linear(
-        &mut self,
-        start_pos: impl Into<ffi::Vector2>,
-        end_pos: impl Into<ffi::Vector2>,
-        t: f32,
-    ) -> Vector2 {
-        unsafe { ffi::GetSplinePointLinear(start_pos.into(), end_pos.into(), t).into() }
-    }
-
-    /// Get (evaluate) spline point: B-Spline
-    #[inline]
-    #[must_use]
-    fn get_spline_point_basis(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        p2: impl Into<ffi::Vector2>,
-        p3: impl Into<ffi::Vector2>,
-        p4: impl Into<ffi::Vector2>,
-        t: f32,
-    ) -> Vector2 {
-        unsafe { ffi::GetSplinePointBasis(p1.into(), p2.into(), p3.into(), p4.into(), t).into() }
-    }
-
-    /// Get (evaluate) spline point: Catmull-Rom
-    #[inline]
-    #[must_use]
-    fn get_spline_point_catmull_rom(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        p2: impl Into<ffi::Vector2>,
-        p3: impl Into<ffi::Vector2>,
-        p4: impl Into<ffi::Vector2>,
-        t: f32,
-    ) -> Vector2 {
-        unsafe {
-            ffi::GetSplinePointCatmullRom(p1.into(), p2.into(), p3.into(), p4.into(), t).into()
-        }
-    }
-
-    /// Get (evaluate) spline point: Quadratic Bezier
-    #[inline]
-    #[must_use]
-    fn get_spline_point_bezier_quad(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        c2: impl Into<ffi::Vector2>,
-        p3: impl Into<ffi::Vector2>,
-        t: f32,
-    ) -> Vector2 {
-        unsafe { ffi::GetSplinePointBezierQuad(p1.into(), c2.into(), p3.into(), t).into() }
-    }
-
-    /// Get (evaluate) spline point: Cubic Bezier
-    #[inline]
-    #[must_use]
-    fn get_spline_point_bezier_cubic(
-        &mut self,
-        p1: impl Into<ffi::Vector2>,
-        c2: impl Into<ffi::Vector2>,
-        c3: impl Into<ffi::Vector2>,
-        p4: impl Into<ffi::Vector2>,
-        t: f32,
-    ) -> Vector2 {
-        unsafe {
-            ffi::GetSplinePointBezierCubic(p1.into(), c2.into(), c3.into(), p4.into(), t).into()
-        }
-    }
-}
-
-/// Types through which it is safe to call 3D Raylib drawing functions.
+/// # Example
+/// ```
+/// use raylib::prelude::*;
+///
+/// struct Foo<'a, D>(&'a mut D);
+///
+/// // SAFETY: `Foo` stores a mutable `RaylibDraw` reference without creating
+/// // unbalanced draw modes, proving it is safe to call draw functions.
+/// unsafe impl<D: RaylibDraw> RaylibDrawImpl for Foo<'_, D> {}
+///
+/// fn foo_draw(foo: &mut Foo<'_, impl RaylibDraw>) {
+///     foo.clear_background(Color::RAYWHITE);
+/// }
+///
+/// fn foo_draw_caller(d: &mut impl RaylibDraw) {
+///     foo_draw(&mut Foo(d));
+/// }
+/// ```
+pub unsafe trait RaylibDrawImpl {}
+
+/// Permits external implementation of [`RaylibDraw3D`].
+///
+/// Implementing this trait on your type will automatically impl the default
+/// definition of [`RaylibDraw3D`] for it.
 ///
 /// # Safety
 ///
-/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
-/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
-/// and expect for there to be a window, buffer, & projection matrix to target--all without any checks.
+/// This trait implements [`RaylibDraw3D`] for your type. Implementors of
+/// [`RaylibDraw3DImpl`] must uphold the safety contract of [`RaylibDraw3D`].
 ///
-/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
-/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
-/// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
-pub unsafe trait RaylibDraw3D {
-    /// Draw a point in 3D space, actually a small line
-    #[allow(non_snake_case, reason = "consistent style")]
-    #[inline]
-    fn draw_point3D(&mut self, position: impl Into<ffi::Vector3>, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawPoint3D(position.into(), color.into());
+/// # Example
+/// ```
+/// use raylib::prelude::*;
+///
+/// struct Bar<'a, D>(&'a mut D);
+///
+/// // SAFETY: `Bar` stores a mutable `RaylibDraw3D` reference without creating
+/// // unbalanced draw modes, proving it is safe to call draw functions.
+/// unsafe impl<D: RaylibDraw3D> RaylibDraw3DImpl for Bar<'_, D> {}
+///
+/// fn bar_draw(bar: &mut Bar<'_, impl RaylibDraw3D>) {
+///     bar.draw_point3D(Vector3::new(1.0, 5.0, -4.0), Color::RED);
+/// }
+///
+/// fn bar_draw_caller(d: &mut impl RaylibDraw3D) {
+///     bar_draw(&mut Bar(d));
+/// }
+/// ```
+pub unsafe trait RaylibDraw3DImpl {}
+
+mod sealed {
+    //! External impl of RaylibDraw/RaylibDraw3D is permitted, but redefinition is not.
+    use super::*;
+
+    // SAFETY: Implementors of `RaylibDrawImpl` must uphold `RaylibDraw`'s safety contract.
+    unsafe impl<D: ?Sized + RaylibDrawImpl> RaylibDraw for D {}
+
+    // SAFETY: Implementors of `RaylibDraw3DImpl` must uphold `RaylibDraw3D`'s safety contract.
+    unsafe impl<D: ?Sized + RaylibDraw3DImpl> RaylibDraw3D for D {}
+
+    /// Types through which it is safe to call standard Raylib drawing functions.
+    ///
+    /// # Safety
+    ///
+    /// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+    /// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+    /// and expect for there to be a window and buffer to target--all without any checks.
+    ///
+    /// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+    /// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+    /// [`ffi::BeginDrawing`] or [`ffi::BeginTextureMode`] has been called this frame without the corresponding
+    /// [`ffi::EndDrawing`]/[`ffi::EndTextureMode`] having been called yet.
+    pub unsafe trait RaylibDraw {
+        /// Sets background color (framebuffer clear `color.into()`).
+        #[inline]
+        fn clear_background(&mut self, color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::ClearBackground(color.into());
+            }
+        }
+
+        /// Get texture that is used for shapes drawing
+        #[inline]
+        #[must_use]
+        fn get_shapes_texture(&self) -> Texture2D {
+            // SAFETY: Implementor must uphold trait safety contract.
+            Texture2D(unsafe { ffi::GetShapesTexture() })
+        }
+
+        /// Get texture source rectangle that is used for shapes drawing
+        #[inline]
+        #[must_use]
+        fn get_shapes_texture_rectangle(&self) -> Rectangle {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::GetShapesTextureRectangle() }
+        }
+
+        /// Define default texture used to draw shapes
+        #[inline]
+        fn set_shapes_texture(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            source: impl Into<ffi::Rectangle>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::SetShapesTexture(*texture.as_ref(), source.into()) }
+        }
+
+        // // Draw gui widget
+        // fn draw_gui<G: crate::rgui::GuiDraw>(&mut self, widget: G) -> crate::rgui::DrawResult {
+        //     widget.draw()
+        // }
+
+        // SHAPES
+        /// Draws a pixel.
+        #[inline]
+        fn draw_pixel(&mut self, x: i32, y: i32, color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPixel(x, y, color.into());
+            }
+        }
+
+        /// Draws a pixel (Vector version).
+        #[inline]
+        fn draw_pixel_v(
+            &mut self,
+            position: impl Into<ffi::Vector2>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPixelV(position.into(), color.into());
+            }
+        }
+
+        /// Draws a line.
+        #[inline]
+        fn draw_line(
+            &mut self,
+            start_pos_x: i32,
+            start_pos_y: i32,
+            end_pos_x: i32,
+            end_pos_y: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawLine(start_pos_x, start_pos_y, end_pos_x, end_pos_y, color.into());
+            }
+        }
+
+        /// Draws a line (Vector version).
+        #[inline]
+        fn draw_line_v(
+            &mut self,
+            start_pos: impl Into<ffi::Vector2>,
+            end_pos: impl Into<ffi::Vector2>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawLineV(start_pos.into(), end_pos.into(), color.into());
+            }
+        }
+
+        /// Draws a line with thickness.
+        #[inline]
+        fn draw_line_ex(
+            &mut self,
+            start_pos: impl Into<ffi::Vector2>,
+            end_pos: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawLineEx(start_pos.into(), end_pos.into(), thick, color.into());
+            }
+        }
+
+        /// Draws a line using cubic-bezier curves in-out.
+        #[inline]
+        fn draw_line_bezier(
+            &mut self,
+            start_pos: impl Into<ffi::Vector2>,
+            end_pos: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawLineBezier(start_pos.into(), end_pos.into(), thick, color.into());
+            }
+        }
+
+        /// Draw lines sequence
+        #[inline]
+        fn draw_line_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawLineStrip(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draws a color-filled circle.
+        #[inline]
+        fn draw_circle(
+            &mut self,
+            center_x: i32,
+            center_y: i32,
+            radius: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircle(center_x, center_y, radius, color.into());
+            }
+        }
+
+        /// Draw a piece of a circle
+        #[inline]
+        fn draw_circle_sector(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            radius: f32,
+            start_angle: f32,
+            end_angle: f32,
+            segments: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircleSector(
+                    center.into(),
+                    radius,
+                    start_angle,
+                    end_angle,
+                    segments,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw circle sector outline
+        #[inline]
+        fn draw_circle_sector_lines(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            radius: f32,
+            start_angle: f32,
+            end_angle: f32,
+            segments: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircleSectorLines(
+                    center.into(),
+                    radius,
+                    start_angle,
+                    end_angle,
+                    segments,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draws a gradient-filled circle.
+        #[inline]
+        fn draw_circle_gradient(
+            &mut self,
+            center_x: i32,
+            center_y: i32,
+            radius: f32,
+            color1: impl Into<ffi::Color>,
+            color2: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircleGradient(center_x, center_y, radius, color1.into(), color2.into());
+            }
+        }
+
+        /// Draws a color-filled circle (Vector version).
+        #[inline]
+        fn draw_circle_v(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            radius: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircleV(center.into(), radius, color.into());
+            }
+        }
+
+        /// Draws circle outline.
+        #[inline]
+        fn draw_circle_lines(
+            &mut self,
+            center_x: i32,
+            center_y: i32,
+            radius: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircleLines(center_x, center_y, radius, color.into());
+            }
+        }
+
+        /// Draws circle outline. (Vector Version)
+        #[inline]
+        fn draw_circle_lines_v(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            radius: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircleLinesV(center.into(), radius, color.into());
+            }
+        }
+
+        /// Draws ellipse.
+        #[inline]
+        fn draw_ellipse(
+            &mut self,
+            center_x: i32,
+            center_y: i32,
+            radius_h: f32,
+            radius_v: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawEllipse(center_x, center_y, radius_h, radius_v, color.into());
+            }
+        }
+
+        /// Draws ellipse.
+        #[inline]
+        fn draw_ellipse_lines(
+            &mut self,
+            center_x: i32,
+            center_y: i32,
+            radius_h: f32,
+            radius_v: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawEllipseLines(center_x, center_y, radius_h, radius_v, color.into());
+            }
+        }
+
+        /// Draw ring
+        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+        #[inline]
+        fn draw_ring(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            inner_radius: f32,
+            outer_radius: f32,
+            start_angle: f32,
+            end_angle: f32,
+            segments: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRing(
+                    center.into(),
+                    inner_radius,
+                    outer_radius,
+                    start_angle,
+                    end_angle,
+                    segments,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw ring lines
+        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+        #[inline]
+        fn draw_ring_lines(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            inner_radius: f32,
+            outer_radius: f32,
+            start_angle: f32,
+            end_angle: f32,
+            segments: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRingLines(
+                    center.into(),
+                    inner_radius,
+                    outer_radius,
+                    start_angle,
+                    end_angle,
+                    segments,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draws a color-filled rectangle.
+        #[inline]
+        fn draw_rectangle(
+            &mut self,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangle(x, y, width, height, color.into());
+            }
+        }
+
+        /// Draws a color-filled rectangle (Vector version).
+        #[inline]
+        fn draw_rectangle_v(
+            &mut self,
+            position: impl Into<ffi::Vector2>,
+            size: impl Into<ffi::Vector2>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleV(position.into(), size.into(), color.into());
+            }
+        }
+
+        /// Draws a color-filled rectangle from `rec`.
+        #[inline]
+        fn draw_rectangle_rec(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleRec(rec.into(), color.into());
+            }
+        }
+
+        /// Draws a color-filled rectangle with pro parameters.
+        #[inline]
+        fn draw_rectangle_pro(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            origin: impl Into<ffi::Vector2>,
+            rotation: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectanglePro(rec.into(), origin.into(), rotation, color.into());
+            }
+        }
+
+        /// Draws a vertical-gradient-filled rectangle.
+        ///
+        /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
+        #[inline]
+        fn draw_rectangle_gradient_v(
+            &mut self,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+            color1: impl Into<ffi::Color>,
+            color2: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleGradientV(x, y, width, height, color1.into(), color2.into());
+            }
+        }
+
+        /// Draws a horizontal-gradient-filled rectangle.
+        ///
+        /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
+        #[inline]
+        fn draw_rectangle_gradient_h(
+            &mut self,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+            color1: impl Into<ffi::Color>,
+            color2: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleGradientH(x, y, width, height, color1.into(), color2.into());
+            }
+        }
+
+        /// Draws a gradient-filled rectangle with custom vertex colors.
+        ///
+        /// **NOTE**: Colors refer to corners, starting at top-left corner and going counter-clockwise.
+        #[inline]
+        fn draw_rectangle_gradient_ex(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            col1: impl Into<ffi::Color>,
+            col2: impl Into<ffi::Color>,
+            col3: impl Into<ffi::Color>,
+            col4: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleGradientEx(
+                    rec.into(),
+                    col1.into(),
+                    col2.into(),
+                    col3.into(),
+                    col4.into(),
+                );
+            }
+        }
+
+        /// Draws rectangle outline.
+        #[inline]
+        fn draw_rectangle_lines(
+            &mut self,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleLines(x, y, width, height, color.into());
+            }
+        }
+
+        /// Draws rectangle outline with extended parameters.
+        #[inline]
+        fn draw_rectangle_lines_ex(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            line_thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleLinesEx(rec.into(), line_thick, color.into());
+            }
+        }
+
+        /// Draws rectangle with rounded edges.
+        #[inline]
+        fn draw_rectangle_rounded(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            roundness: f32,
+            segments: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleRounded(rec.into(), roundness, segments, color.into());
+            }
+        }
+
+        /// Draws rectangle outline with rounded edges included.
+        #[inline]
+        fn draw_rectangle_rounded_lines(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            roundness: f32,
+            segments: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleRoundedLines(rec.into(), roundness, segments, color.into());
+            }
+        }
+
+        /// Draw rectangle with rounded edges outline
+        #[inline]
+        fn draw_rectangle_rounded_lines_ex(
+            &mut self,
+            rec: impl Into<ffi::Rectangle>,
+            roundness: f32,
+            segments: i32,
+            line_thickness: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRectangleRoundedLinesEx(
+                    rec.into(),
+                    roundness,
+                    segments,
+                    line_thickness,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draws a triangle.
+        #[inline]
+        fn draw_triangle(
+            &mut self,
+            v1: impl Into<ffi::Vector2>,
+            v2: impl Into<ffi::Vector2>,
+            v3: impl Into<ffi::Vector2>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTriangle(v1.into(), v2.into(), v3.into(), color.into());
+            }
+        }
+
+        /// Draws a triangle using lines.
+        #[inline]
+        fn draw_triangle_lines(
+            &mut self,
+            v1: impl Into<ffi::Vector2>,
+            v2: impl Into<ffi::Vector2>,
+            v3: impl Into<ffi::Vector2>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTriangleLines(v1.into(), v2.into(), v3.into(), color.into());
+            }
+        }
+
+        /// Draw a triangle fan defined by points.
+        #[inline]
+        fn draw_triangle_fan(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTriangleFan(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw a triangle strip defined by points
+        #[inline]
+        fn draw_triangle_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTriangleStrip(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draws a regular polygon of n sides (Vector version).
+        #[inline]
+        fn draw_poly(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            sides: i32,
+            radius: f32,
+            rotation: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPoly(center.into(), sides, radius, rotation, color.into());
+            }
+        }
+
+        /// Draws a regular polygon of n sides (Vector version).
+        #[inline]
+        fn draw_poly_lines(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            sides: i32,
+            radius: f32,
+            rotation: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPolyLines(center.into(), sides, radius, rotation, color.into());
+            }
+        }
+
+        /// Draws a `texture` using specified position and `tint` color.
+        #[inline]
+        fn draw_texture(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            x: i32,
+            y: i32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTexture(*texture.as_ref(), x, y, tint.into());
+            }
+        }
+
+        /// Draws a `texture` using specified `position` vector and `tint` color.
+        #[inline]
+        fn draw_texture_v(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            position: impl Into<ffi::Vector2>,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextureV(*texture.as_ref(), position.into(), tint.into());
+            }
+        }
+
+        /// Draws a `texture` with extended parameters.
+        #[inline]
+        fn draw_texture_ex(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            position: impl Into<ffi::Vector2>,
+            rotation: f32,
+            scale: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextureEx(
+                    *texture.as_ref(),
+                    position.into(),
+                    rotation,
+                    scale,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draws from a region of `texture` defined by the `source_rec` rectangle.
+        #[inline]
+        fn draw_texture_rec(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            source_rec: impl Into<ffi::Rectangle>,
+            position: impl Into<ffi::Vector2>,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextureRec(
+                    *texture.as_ref(),
+                    source_rec.into(),
+                    position.into(),
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draw from a region of `texture` defined by the `source_rec` rectangle with pro parameters.
+        #[inline]
+        fn draw_texture_pro(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            source_rec: impl Into<ffi::Rectangle>,
+            dest_rec: impl Into<ffi::Rectangle>,
+            origin: impl Into<ffi::Vector2>,
+            rotation: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTexturePro(
+                    *texture.as_ref(),
+                    source_rec.into(),
+                    dest_rec.into(),
+                    origin.into(),
+                    rotation,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draws a texture (or part of it) that stretches or shrinks nicely
+        #[inline]
+        fn draw_texture_n_patch(
+            &mut self,
+            texture: impl AsRef<ffi::Texture2D>,
+            n_patch_info: impl Into<ffi::NPatchInfo>,
+            dest_rec: impl Into<ffi::Rectangle>,
+            origin: impl Into<ffi::Vector2>,
+            rotation: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextureNPatch(
+                    *texture.as_ref(),
+                    n_patch_info.into(),
+                    dest_rec.into(),
+                    origin.into(),
+                    rotation,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Shows current FPS.
+        #[inline]
+        fn draw_fps(&mut self, x: i32, y: i32) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawFPS(x, y);
+            }
+        }
+
+        /// Draws text (using default font).
+        /// This does not support UTF-8. Use `[RaylibDrawHandle::draw_text_codepoints]` for that.
+        #[inline]
+        fn draw_text(
+            &mut self,
+            text: &str,
+            x: i32,
+            y: i32,
+            font_size: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawText(c_text.as_ptr(), x, y, font_size, color.into());
+            }
+        }
+
+        /// Draws text (using default font) with support for UTF-8.
+        /// If you do not need UTF-8, use `[RaylibDrawHandle::draw_text]`.
+        fn draw_text_codepoints(
+            &mut self,
+            font: impl AsRef<ffi::Font>,
+            text: &str,
+            position: impl Into<ffi::Vector2>,
+            font_size: f32,
+            spacing: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+            let mut len = 0;
+            // SAFETY: Implementor must uphold trait safety contract.
+            let u = unsafe { ffi::LoadCodepoints(c_text.as_ptr(), &raw mut len) };
+
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextCodepoints(
+                    *font.as_ref(),
+                    u,
+                    text.len()
+                        .try_into()
+                        .expect("text should not exceed i32::MAX elements"),
+                    position.into(),
+                    font_size,
+                    spacing,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draws text using `font` and additional parameters.
+        #[inline]
+        fn draw_text_ex(
+            &mut self,
+            font: impl AsRef<ffi::Font>,
+            text: &str,
+            position: impl Into<ffi::Vector2>,
+            font_size: f32,
+            spacing: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextEx(
+                    *font.as_ref(),
+                    c_text.as_ptr(),
+                    position.into(),
+                    font_size,
+                    spacing,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draw text using Font and pro parameters (rotation)
+        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+        #[inline]
+        fn draw_text_pro(
+            &mut self,
+            font: impl AsRef<ffi::Font>,
+            text: &str,
+            position: impl Into<ffi::Vector2>,
+            origin: impl Into<ffi::Vector2>,
+            rotation: f32,
+            font_size: f32,
+            spacing: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextPro(
+                    *font.as_ref(),
+                    c_text.as_ptr(),
+                    position.into(),
+                    origin.into(),
+                    rotation,
+                    font_size,
+                    spacing,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draw one character (codepoint)
+        #[inline]
+        fn draw_text_codepoint(
+            &mut self,
+            font: impl AsRef<ffi::Font>,
+            codepoint: i32,
+            position: impl Into<ffi::Vector2>,
+            scale: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTextCodepoint(
+                    *font.as_ref(),
+                    codepoint,
+                    position.into(),
+                    scale,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Enable waiting for events when the handle is dropped, no automatic event polling
+        #[inline]
+        fn enable_event_waiting(&self) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::EnableEventWaiting() }
+        }
+
+        /// Disable waiting for events when the handle is dropped, no automatic event polling
+        #[inline]
+        fn disable_event_waiting(&self) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::DisableEventWaiting() }
+        }
+
+        /// Draw a polygon outline of n sides with extended parameters
+        #[inline]
+        fn draw_poly_lines_ex(
+            &mut self,
+            center: impl Into<ffi::Vector2>,
+            sides: i32,
+            radius: f32,
+            rotation: f32,
+            line_thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPolyLinesEx(
+                    center.into(),
+                    sides,
+                    radius,
+                    rotation,
+                    line_thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline: Linear, minimum 2 points
+        #[inline]
+        fn draw_spline_linear(
+            &mut self,
+            points: &[Vector2],
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineLinear(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline: B-Spline, minimum 4 points
+        #[inline]
+        fn draw_spline_basis(
+            &mut self,
+            points: &[Vector2],
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineBasis(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline: Catmull-Rom, minimum 4 points
+        #[inline]
+        fn draw_spline_catmull_rom(
+            &mut self,
+            points: &[Vector2],
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineCatmullRom(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
+        #[inline]
+        fn draw_spline_bezier_quadratic(
+            &mut self,
+            points: &[Vector2],
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineBezierQuadratic(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
+        #[inline]
+        fn draw_spline_bezier_cubic(
+            &mut self,
+            points: &[Vector2],
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineBezierCubic(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline segment: Linear, 2 points
+        #[inline]
+        fn draw_spline_segment_linear(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            p2: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::DrawSplineSegmentLinear(p1.into(), p2.into(), thick, color.into()) }
+        }
+
+        /// Draw spline segment: B-Spline, 4 points
+        #[inline]
+        fn draw_spline_segment_basis(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            p2: impl Into<ffi::Vector2>,
+            p3: impl Into<ffi::Vector2>,
+            p4: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineSegmentBasis(
+                    p1.into(),
+                    p2.into(),
+                    p3.into(),
+                    p4.into(),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline segment: Catmull-Rom, 4 points
+        #[inline]
+        fn draw_spline_segment_catmull_rom(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            p2: impl Into<ffi::Vector2>,
+            p3: impl Into<ffi::Vector2>,
+            p4: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineSegmentCatmullRom(
+                    p1.into(),
+                    p2.into(),
+                    p3.into(),
+                    p4.into(),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
+        #[inline]
+        fn draw_spline_segment_bezier_quadratic(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            c2: impl Into<ffi::Vector2>,
+            p3: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineSegmentBezierQuadratic(
+                    p1.into(),
+                    c2.into(),
+                    p3.into(),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Draw spline segment: Cubic Bezier, 2 points, 2 control points
+        #[inline]
+        fn draw_spline_segment_bezier_cubic(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            c2: impl Into<ffi::Vector2>,
+            c3: impl Into<ffi::Vector2>,
+            p4: impl Into<ffi::Vector2>,
+            thick: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSplineSegmentBezierCubic(
+                    p1.into(),
+                    c2.into(),
+                    c3.into(),
+                    p4.into(),
+                    thick,
+                    color.into(),
+                );
+            }
+        }
+
+        /// Get (evaluate) spline point: Linear
+        #[inline]
+        #[must_use]
+        fn get_spline_point_linear(
+            &mut self,
+            start_pos: impl Into<ffi::Vector2>,
+            end_pos: impl Into<ffi::Vector2>,
+            t: f32,
+        ) -> Vector2 {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::GetSplinePointLinear(start_pos.into(), end_pos.into(), t).into() }
+        }
+
+        /// Get (evaluate) spline point: B-Spline
+        #[inline]
+        #[must_use]
+        fn get_spline_point_basis(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            p2: impl Into<ffi::Vector2>,
+            p3: impl Into<ffi::Vector2>,
+            p4: impl Into<ffi::Vector2>,
+            t: f32,
+        ) -> Vector2 {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::GetSplinePointBasis(p1.into(), p2.into(), p3.into(), p4.into(), t).into()
+            }
+        }
+
+        /// Get (evaluate) spline point: Catmull-Rom
+        #[inline]
+        #[must_use]
+        fn get_spline_point_catmull_rom(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            p2: impl Into<ffi::Vector2>,
+            p3: impl Into<ffi::Vector2>,
+            p4: impl Into<ffi::Vector2>,
+            t: f32,
+        ) -> Vector2 {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::GetSplinePointCatmullRom(p1.into(), p2.into(), p3.into(), p4.into(), t).into()
+            }
+        }
+
+        /// Get (evaluate) spline point: Quadratic Bezier
+        #[inline]
+        #[must_use]
+        fn get_spline_point_bezier_quad(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            c2: impl Into<ffi::Vector2>,
+            p3: impl Into<ffi::Vector2>,
+            t: f32,
+        ) -> Vector2 {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::GetSplinePointBezierQuad(p1.into(), c2.into(), p3.into(), t).into() }
+        }
+
+        /// Get (evaluate) spline point: Cubic Bezier
+        #[inline]
+        #[must_use]
+        fn get_spline_point_bezier_cubic(
+            &mut self,
+            p1: impl Into<ffi::Vector2>,
+            c2: impl Into<ffi::Vector2>,
+            c3: impl Into<ffi::Vector2>,
+            p4: impl Into<ffi::Vector2>,
+            t: f32,
+        ) -> Vector2 {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::GetSplinePointBezierCubic(p1.into(), c2.into(), c3.into(), p4.into(), t).into()
+            }
         }
     }
 
-    /// Draw a color-filled triangle (vertex in counter-clockwise order!)
-    #[allow(non_snake_case, reason = "consistent style")]
-    #[inline]
-    fn draw_triangle3D(
-        &mut self,
-        v1: impl Into<ffi::Vector3>,
-        v2: impl Into<ffi::Vector3>,
-        v3: impl Into<ffi::Vector3>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawTriangle3D(v1.into(), v2.into(), v3.into(), color.into());
+    /// Types through which it is safe to call 3D Raylib drawing functions.
+    ///
+    /// # Safety
+    ///
+    /// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+    /// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+    /// and expect for there to be a window, buffer, & projection matrix to target--all without any checks.
+    ///
+    /// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+    /// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+    /// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
+    pub unsafe trait RaylibDraw3D {
+        /// Draw a point in 3D space, actually a small line
+        #[allow(non_snake_case, reason = "consistent style")]
+        #[inline]
+        fn draw_point3D(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPoint3D(position.into(), color.into());
+            }
         }
-    }
 
-    /// Draw a triangle strip defined by points
-    #[allow(non_snake_case, reason = "consistent style")]
-    #[inline]
-    fn draw_triangle_strip3D(&mut self, points: &[Vector3], color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawTriangleStrip3D(
-                points.as_ptr().cast(),
-                points
-                    .len()
-                    .try_into()
-                    .expect("points should not exceed i32::MAX elements"),
-                color.into(),
-            );
+        /// Draw a color-filled triangle (vertex in counter-clockwise order!)
+        #[allow(non_snake_case, reason = "consistent style")]
+        #[inline]
+        fn draw_triangle3D(
+            &mut self,
+            v1: impl Into<ffi::Vector3>,
+            v2: impl Into<ffi::Vector3>,
+            v3: impl Into<ffi::Vector3>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTriangle3D(v1.into(), v2.into(), v3.into(), color.into());
+            }
         }
-    }
 
-    /// Draws a line in 3D world space.
-    #[allow(non_snake_case, reason = "consistent style")]
-    #[inline]
-    fn draw_line3D(
-        &mut self,
-        start_pos: impl Into<ffi::Vector3>,
-        end_pos: impl Into<ffi::Vector3>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawLine3D(start_pos.into(), end_pos.into(), color.into());
+        /// Draw a triangle strip defined by points
+        #[allow(non_snake_case, reason = "consistent style")]
+        #[inline]
+        fn draw_triangle_strip3D(&mut self, points: &[Vector3], color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawTriangleStrip3D(
+                    points.as_ptr().cast(),
+                    points
+                        .len()
+                        .try_into()
+                        .expect("points should not exceed i32::MAX elements"),
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a circle in 3D world space.
-    #[allow(non_snake_case, reason = "consistent style")]
-    #[inline]
-    fn draw_circle3D(
-        &mut self,
-        center: impl Into<ffi::Vector3>,
-        radius: f32,
-        rotation_axis: impl Into<ffi::Vector3>,
-        rotation_angle: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCircle3D(
-                center.into(),
-                radius,
-                rotation_axis.into(),
-                rotation_angle,
-                color.into(),
-            );
+        /// Draws a line in 3D world space.
+        #[allow(non_snake_case, reason = "consistent style")]
+        #[inline]
+        fn draw_line3D(
+            &mut self,
+            start_pos: impl Into<ffi::Vector3>,
+            end_pos: impl Into<ffi::Vector3>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawLine3D(start_pos.into(), end_pos.into(), color.into());
+            }
         }
-    }
 
-    /// Draws a cube.
-    #[inline]
-    fn draw_cube(
-        &mut self,
-        position: impl Into<ffi::Vector3>,
-        width: f32,
-        height: f32,
-        length: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCube(position.into(), width, height, length, color.into());
+        /// Draws a circle in 3D world space.
+        #[allow(non_snake_case, reason = "consistent style")]
+        #[inline]
+        fn draw_circle3D(
+            &mut self,
+            center: impl Into<ffi::Vector3>,
+            radius: f32,
+            rotation_axis: impl Into<ffi::Vector3>,
+            rotation_angle: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCircle3D(
+                    center.into(),
+                    radius,
+                    rotation_axis.into(),
+                    rotation_angle,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a cube (Vector version).
-    #[inline]
-    fn draw_cube_v(
-        &mut self,
-        position: impl Into<ffi::Vector3>,
-        size: impl Into<ffi::Vector3>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCubeV(position.into(), size.into(), color.into());
+        /// Draws a cube.
+        #[inline]
+        fn draw_cube(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            width: f32,
+            height: f32,
+            length: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCube(position.into(), width, height, length, color.into());
+            }
         }
-    }
 
-    /// Draws a cube in wireframe.
-    #[inline]
-    fn draw_cube_wires(
-        &mut self,
-        position: impl Into<ffi::Vector3>,
-        width: f32,
-        height: f32,
-        length: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCubeWires(position.into(), width, height, length, color.into());
+        /// Draws a cube (Vector version).
+        #[inline]
+        fn draw_cube_v(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            size: impl Into<ffi::Vector3>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCubeV(position.into(), size.into(), color.into());
+            }
         }
-    }
 
-    /// Draws a cube in wireframe. (Vector Version)
-    #[inline]
-    fn draw_cube_wires_v(
-        &mut self,
-        position: impl Into<ffi::Vector3>,
-        size: impl Into<ffi::Vector3>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCubeWiresV(position.into(), size.into(), color.into());
+        /// Draws a cube in wireframe.
+        #[inline]
+        fn draw_cube_wires(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            width: f32,
+            height: f32,
+            length: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCubeWires(position.into(), width, height, length, color.into());
+            }
         }
-    }
 
-    /// Draw a 3d mesh with material and transform
-    #[inline]
-    fn draw_mesh(
-        &mut self,
-        mesh: impl AsRef<ffi::Mesh>,
-        material: WeakMaterial,
-        transform: impl Into<ffi::Matrix>,
-    ) {
-        unsafe { ffi::DrawMesh(*mesh.as_ref(), material.0, transform.into()) }
-    }
-
-    /// Draw multiple mesh instances with material and different transforms
-    #[inline]
-    fn draw_mesh_instanced(
-        &mut self,
-        mesh: impl AsRef<ffi::Mesh>,
-        material: WeakMaterial,
-        transforms: &[Matrix],
-    ) {
-        unsafe {
-            ffi::DrawMeshInstanced(
-                *mesh.as_ref(),
-                material.0,
-                transforms.as_ptr().cast(),
-                transforms
-                    .len()
-                    .try_into()
-                    .expect("transforms should not exceed i32::MAX elements"),
-            );
+        /// Draws a cube in wireframe. (Vector Version)
+        #[inline]
+        fn draw_cube_wires_v(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            size: impl Into<ffi::Vector3>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCubeWiresV(position.into(), size.into(), color.into());
+            }
         }
-    }
 
-    /// Draws a sphere.
-    #[inline]
-    fn draw_sphere(
-        &mut self,
-        center_pos: impl Into<ffi::Vector3>,
-        radius: f32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSphere(center_pos.into(), radius, color.into());
+        /// Draw a 3d mesh with material and transform
+        #[inline]
+        fn draw_mesh(
+            &mut self,
+            mesh: impl AsRef<ffi::Mesh>,
+            material: WeakMaterial,
+            transform: impl Into<ffi::Matrix>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe { ffi::DrawMesh(*mesh.as_ref(), material.0, transform.into()) }
         }
-    }
 
-    /// Draws a sphere with extended parameters.
-    #[inline]
-    fn draw_sphere_ex(
-        &mut self,
-        center_pos: impl Into<ffi::Vector3>,
-        radius: f32,
-        rings: i32,
-        slices: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSphereEx(center_pos.into(), radius, rings, slices, color.into());
+        /// Draw multiple mesh instances with material and different transforms
+        #[inline]
+        fn draw_mesh_instanced(
+            &mut self,
+            mesh: impl AsRef<ffi::Mesh>,
+            material: WeakMaterial,
+            transforms: &[Matrix],
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawMeshInstanced(
+                    *mesh.as_ref(),
+                    material.0,
+                    transforms.as_ptr().cast(),
+                    transforms
+                        .len()
+                        .try_into()
+                        .expect("transforms should not exceed i32::MAX elements"),
+                );
+            }
         }
-    }
 
-    /// Draws a sphere in wireframe.
-    #[inline]
-    fn draw_sphere_wires(
-        &mut self,
-        center_pos: impl Into<ffi::Vector3>,
-        radius: f32,
-        rings: i32,
-        slices: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawSphereWires(center_pos.into(), radius, rings, slices, color.into());
+        /// Draws a sphere.
+        #[inline]
+        fn draw_sphere(
+            &mut self,
+            center_pos: impl Into<ffi::Vector3>,
+            radius: f32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSphere(center_pos.into(), radius, color.into());
+            }
         }
-    }
 
-    /// Draws a cylinder.
-    #[inline]
-    fn draw_cylinder(
-        &mut self,
-        position: impl Into<ffi::Vector3>,
-        radius_top: f32,
-        radius_bottom: f32,
-        height: f32,
-        slices: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCylinder(
-                position.into(),
-                radius_top,
-                radius_bottom,
-                height,
-                slices,
-                color.into(),
-            );
+        /// Draws a sphere with extended parameters.
+        #[inline]
+        fn draw_sphere_ex(
+            &mut self,
+            center_pos: impl Into<ffi::Vector3>,
+            radius: f32,
+            rings: i32,
+            slices: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSphereEx(center_pos.into(), radius, rings, slices, color.into());
+            }
         }
-    }
 
-    /// Draws a cylinder with extended parameters.
-    #[inline]
-    fn draw_cylinder_ex(
-        &mut self,
-        start_position: impl Into<ffi::Vector3>,
-        end_position: impl Into<ffi::Vector3>,
-        radius_start: f32,
-        radius_end: f32,
-        slices: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCylinderEx(
-                start_position.into(),
-                end_position.into(),
-                radius_start,
-                radius_end,
-                slices,
-                color.into(),
-            );
+        /// Draws a sphere in wireframe.
+        #[inline]
+        fn draw_sphere_wires(
+            &mut self,
+            center_pos: impl Into<ffi::Vector3>,
+            radius: f32,
+            rings: i32,
+            slices: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawSphereWires(center_pos.into(), radius, rings, slices, color.into());
+            }
         }
-    }
 
-    /// Draws a cylinder in wireframe.
-    #[inline]
-    fn draw_cylinder_wires(
-        &mut self,
-        position: impl Into<ffi::Vector3>,
-        radius_top: f32,
-        radius_bottom: f32,
-        height: f32,
-        slices: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCylinderWires(
-                position.into(),
-                radius_top,
-                radius_bottom,
-                height,
-                slices,
-                color.into(),
-            );
+        /// Draws a cylinder.
+        #[inline]
+        fn draw_cylinder(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            radius_top: f32,
+            radius_bottom: f32,
+            height: f32,
+            slices: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCylinder(
+                    position.into(),
+                    radius_top,
+                    radius_bottom,
+                    height,
+                    slices,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a cylinder in wireframe with extended parameters.
-    #[inline]
-    fn draw_cylinder_wires_ex(
-        &mut self,
-        start_position: impl Into<ffi::Vector3>,
-        end_position: impl Into<ffi::Vector3>,
-        radius_start: f32,
-        radius_end: f32,
-        slices: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCylinderWiresEx(
-                start_position.into(),
-                end_position.into(),
-                radius_start,
-                radius_end,
-                slices,
-                color.into(),
-            );
+        /// Draws a cylinder with extended parameters.
+        #[inline]
+        fn draw_cylinder_ex(
+            &mut self,
+            start_position: impl Into<ffi::Vector3>,
+            end_position: impl Into<ffi::Vector3>,
+            radius_start: f32,
+            radius_end: f32,
+            slices: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCylinderEx(
+                    start_position.into(),
+                    end_position.into(),
+                    radius_start,
+                    radius_end,
+                    slices,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draw capsule with the center of its sphere caps at startPos and endPos
-    #[inline]
-    fn draw_capsule(
-        &mut self,
-        start_pos: impl Into<ffi::Vector3>,
-        end_pos: impl Into<ffi::Vector3>,
-        radius: f32,
-        slices: i32,
-        rings: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCapsule(
-                start_pos.into(),
-                end_pos.into(),
-                radius,
-                slices,
-                rings,
-                color.into(),
-            );
+        /// Draws a cylinder in wireframe.
+        #[inline]
+        fn draw_cylinder_wires(
+            &mut self,
+            position: impl Into<ffi::Vector3>,
+            radius_top: f32,
+            radius_bottom: f32,
+            height: f32,
+            slices: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCylinderWires(
+                    position.into(),
+                    radius_top,
+                    radius_bottom,
+                    height,
+                    slices,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    ///Draw capsule wireframe with the center of its sphere caps at startPos and endPos
-    #[inline]
-    fn draw_capsule_wires(
-        &mut self,
-        start_pos: impl Into<ffi::Vector3>,
-        end_pos: impl Into<ffi::Vector3>,
-        radius: f32,
-        slices: i32,
-        rings: i32,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawCapsuleWires(
-                start_pos.into(),
-                end_pos.into(),
-                radius,
-                slices,
-                rings,
-                color.into(),
-            );
+        /// Draws a cylinder in wireframe with extended parameters.
+        #[inline]
+        fn draw_cylinder_wires_ex(
+            &mut self,
+            start_position: impl Into<ffi::Vector3>,
+            end_position: impl Into<ffi::Vector3>,
+            radius_start: f32,
+            radius_end: f32,
+            slices: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCylinderWiresEx(
+                    start_position.into(),
+                    end_position.into(),
+                    radius_start,
+                    radius_end,
+                    slices,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draws an X/Z plane.
-    #[inline]
-    fn draw_plane(
-        &mut self,
-        center_pos: impl Into<ffi::Vector3>,
-        size: impl Into<ffi::Vector2>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawPlane(center_pos.into(), size.into(), color.into());
+        /// Draw capsule with the center of its sphere caps at startPos and endPos
+        #[inline]
+        fn draw_capsule(
+            &mut self,
+            start_pos: impl Into<ffi::Vector3>,
+            end_pos: impl Into<ffi::Vector3>,
+            radius: f32,
+            slices: i32,
+            rings: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCapsule(
+                    start_pos.into(),
+                    end_pos.into(),
+                    radius,
+                    slices,
+                    rings,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a ray line.
-    #[inline]
-    fn draw_ray(&mut self, ray: impl Into<ffi::Ray>, color: impl Into<ffi::Color>) {
-        unsafe {
-            ffi::DrawRay(ray.into(), color.into());
+        ///Draw capsule wireframe with the center of its sphere caps at startPos and endPos
+        #[inline]
+        fn draw_capsule_wires(
+            &mut self,
+            start_pos: impl Into<ffi::Vector3>,
+            end_pos: impl Into<ffi::Vector3>,
+            radius: f32,
+            slices: i32,
+            rings: i32,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawCapsuleWires(
+                    start_pos.into(),
+                    end_pos.into(),
+                    radius,
+                    slices,
+                    rings,
+                    color.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a grid (centered at (0, 0, 0)).
-    #[inline]
-    fn draw_grid(&mut self, slices: i32, spacing: f32) {
-        unsafe {
-            ffi::DrawGrid(slices, spacing);
+        /// Draws an X/Z plane.
+        #[inline]
+        fn draw_plane(
+            &mut self,
+            center_pos: impl Into<ffi::Vector3>,
+            size: impl Into<ffi::Vector2>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawPlane(center_pos.into(), size.into(), color.into());
+            }
         }
-    }
 
-    /// Draws a model (with texture if set).
-    #[inline]
-    fn draw_model(
-        &mut self,
-        model: impl AsRef<ffi::Model>,
-        position: impl Into<ffi::Vector3>,
-        scale: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawModel(*model.as_ref(), position.into(), scale, tint.into());
+        /// Draws a ray line.
+        #[inline]
+        fn draw_ray(&mut self, ray: impl Into<ffi::Ray>, color: impl Into<ffi::Color>) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawRay(ray.into(), color.into());
+            }
         }
-    }
 
-    /// Draws a model with extended parameters.
-    #[inline]
-    fn draw_model_ex(
-        &mut self,
-        model: impl AsRef<ffi::Model>,
-        position: impl Into<ffi::Vector3>,
-        rotation_axis: impl Into<ffi::Vector3>,
-        rotation_angle: f32,
-        scale: impl Into<ffi::Vector3>,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawModelEx(
-                *model.as_ref(),
-                position.into(),
-                rotation_axis.into(),
-                rotation_angle,
-                scale.into(),
-                tint.into(),
-            );
+        /// Draws a grid (centered at (0, 0, 0)).
+        #[inline]
+        fn draw_grid(&mut self, slices: i32, spacing: f32) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawGrid(slices, spacing);
+            }
         }
-    }
 
-    /// Draws a model with wires (with texture if set).
-    #[inline]
-    fn draw_model_wires(
-        &mut self,
-        model: impl AsRef<ffi::Model>,
-        position: impl Into<ffi::Vector3>,
-        scale: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawModelWires(*model.as_ref(), position.into(), scale, tint.into());
+        /// Draws a model (with texture if set).
+        #[inline]
+        fn draw_model(
+            &mut self,
+            model: impl AsRef<ffi::Model>,
+            position: impl Into<ffi::Vector3>,
+            scale: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawModel(*model.as_ref(), position.into(), scale, tint.into());
+            }
         }
-    }
 
-    /// Draws a model with wires.
-    #[inline]
-    fn draw_model_wires_ex(
-        &mut self,
-        model: impl AsRef<ffi::Model>,
-        position: impl Into<ffi::Vector3>,
-        rotation_axis: impl Into<ffi::Vector3>,
-        rotation_angle: f32,
-        scale: impl Into<ffi::Vector3>,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawModelWiresEx(
-                *model.as_ref(),
-                position.into(),
-                rotation_axis.into(),
-                rotation_angle,
-                scale.into(),
-                tint.into(),
-            );
+        /// Draws a model with extended parameters.
+        #[inline]
+        fn draw_model_ex(
+            &mut self,
+            model: impl AsRef<ffi::Model>,
+            position: impl Into<ffi::Vector3>,
+            rotation_axis: impl Into<ffi::Vector3>,
+            rotation_angle: f32,
+            scale: impl Into<ffi::Vector3>,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawModelEx(
+                    *model.as_ref(),
+                    position.into(),
+                    rotation_axis.into(),
+                    rotation_angle,
+                    scale.into(),
+                    tint.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a bounding box (wires).
-    #[inline]
-    fn draw_bounding_box(
-        &mut self,
-        bbox: impl Into<ffi::BoundingBox>,
-        color: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawBoundingBox(bbox.into(), color.into());
+        /// Draws a model with wires (with texture if set).
+        #[inline]
+        fn draw_model_wires(
+            &mut self,
+            model: impl AsRef<ffi::Model>,
+            position: impl Into<ffi::Vector3>,
+            scale: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawModelWires(*model.as_ref(), position.into(), scale, tint.into());
+            }
         }
-    }
 
-    /// Draws a billboard texture.
-    #[inline]
-    fn draw_billboard(
-        &mut self,
-        camera: impl Into<ffi::Camera3D>,
-        texture: &Texture2D,
-        center: impl Into<ffi::Vector3>,
-        size: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawBillboard(camera.into(), texture.0, center.into(), size, tint.into());
+        /// Draws a model with wires.
+        #[inline]
+        fn draw_model_wires_ex(
+            &mut self,
+            model: impl AsRef<ffi::Model>,
+            position: impl Into<ffi::Vector3>,
+            rotation_axis: impl Into<ffi::Vector3>,
+            rotation_angle: f32,
+            scale: impl Into<ffi::Vector3>,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawModelWiresEx(
+                    *model.as_ref(),
+                    position.into(),
+                    rotation_axis.into(),
+                    rotation_angle,
+                    scale.into(),
+                    tint.into(),
+                );
+            }
         }
-    }
 
-    /// Draws a billboard texture defined by `source_rec`.
-    #[inline]
-    fn draw_billboard_rec(
-        &mut self,
-        camera: impl Into<ffi::Camera3D>,
-        texture: &Texture2D,
-        source_rec: impl Into<ffi::Rectangle>,
-        center: impl Into<ffi::Vector3>,
-        size: impl Into<ffi::Vector2>,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawBillboardRec(
-                camera.into(),
-                texture.0,
-                source_rec.into(),
-                center.into(),
-                size.into(),
-                tint.into(),
-            );
+        /// Draws a bounding box (wires).
+        #[inline]
+        fn draw_bounding_box(
+            &mut self,
+            bbox: impl Into<ffi::BoundingBox>,
+            color: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawBoundingBox(bbox.into(), color.into());
+            }
         }
-    }
 
-    /// Draw a billboard texture defined by source and rotation
-    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-    #[inline]
-    fn draw_billboard_pro(
-        &mut self,
-        camera: impl Into<ffi::Camera>,
-        texture: impl Into<ffi::Texture2D>,
-        source: impl Into<ffi::Rectangle>,
-        position: impl Into<ffi::Vector3>,
-        up: impl Into<ffi::Vector3>,
-        size: impl Into<ffi::Vector2>,
-        origin: impl Into<ffi::Vector2>,
-        rotation: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawBillboardPro(
-                camera.into(),
-                texture.into(),
-                source.into(),
-                position.into(),
-                up.into(),
-                size.into(),
-                origin.into(),
-                rotation,
-                tint.into(),
-            );
+        /// Draws a billboard texture.
+        #[inline]
+        fn draw_billboard(
+            &mut self,
+            camera: impl Into<ffi::Camera3D>,
+            texture: &Texture2D,
+            center: impl Into<ffi::Vector3>,
+            size: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawBillboard(camera.into(), texture.0, center.into(), size, tint.into());
+            }
         }
-    }
 
-    /// Draw a model as points
-    #[inline]
-    fn draw_model_points(
-        &mut self,
-        model: impl Into<ffi::Model>,
-        position: impl Into<ffi::Vector3>,
-        scale: f32,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawModelPoints(model.into(), position.into(), scale, tint.into());
+        /// Draws a billboard texture defined by `source_rec`.
+        #[inline]
+        fn draw_billboard_rec(
+            &mut self,
+            camera: impl Into<ffi::Camera3D>,
+            texture: &Texture2D,
+            source_rec: impl Into<ffi::Rectangle>,
+            center: impl Into<ffi::Vector3>,
+            size: impl Into<ffi::Vector2>,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawBillboardRec(
+                    camera.into(),
+                    texture.0,
+                    source_rec.into(),
+                    center.into(),
+                    size.into(),
+                    tint.into(),
+                );
+            }
         }
-    }
 
-    /// Draw a model as points with extended parameters
-    #[inline]
-    fn draw_model_points_ex(
-        &mut self,
-        model: impl Into<ffi::Model>,
-        position: impl Into<ffi::Vector3>,
-        rotation_axis: impl Into<ffi::Vector3>,
-        angle: f32,
-        scale: impl Into<ffi::Vector3>,
-        tint: impl Into<ffi::Color>,
-    ) {
-        unsafe {
-            ffi::DrawModelPointsEx(
-                model.into(),
-                position.into(),
-                rotation_axis.into(),
-                angle,
-                scale.into(),
-                tint.into(),
-            );
+        /// Draw a billboard texture defined by source and rotation
+        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+        #[inline]
+        fn draw_billboard_pro(
+            &mut self,
+            camera: impl Into<ffi::Camera>,
+            texture: impl Into<ffi::Texture2D>,
+            source: impl Into<ffi::Rectangle>,
+            position: impl Into<ffi::Vector3>,
+            up: impl Into<ffi::Vector3>,
+            size: impl Into<ffi::Vector2>,
+            origin: impl Into<ffi::Vector2>,
+            rotation: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawBillboardPro(
+                    camera.into(),
+                    texture.into(),
+                    source.into(),
+                    position.into(),
+                    up.into(),
+                    size.into(),
+                    origin.into(),
+                    rotation,
+                    tint.into(),
+                );
+            }
+        }
+
+        /// Draw a model as points
+        #[inline]
+        fn draw_model_points(
+            &mut self,
+            model: impl Into<ffi::Model>,
+            position: impl Into<ffi::Vector3>,
+            scale: f32,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawModelPoints(model.into(), position.into(), scale, tint.into());
+            }
+        }
+
+        /// Draw a model as points with extended parameters
+        #[inline]
+        fn draw_model_points_ex(
+            &mut self,
+            model: impl Into<ffi::Model>,
+            position: impl Into<ffi::Vector3>,
+            rotation_axis: impl Into<ffi::Vector3>,
+            angle: f32,
+            scale: impl Into<ffi::Vector3>,
+            tint: impl Into<ffi::Color>,
+        ) {
+            // SAFETY: Implementor must uphold trait safety contract.
+            unsafe {
+                ffi::DrawModelPointsEx(
+                    model.into(),
+                    position.into(),
+                    rotation_axis.into(),
+                    angle,
+                    scale.into(),
+                    tint.into(),
+                );
+            }
         }
     }
 }
+pub use sealed::{RaylibDraw, RaylibDraw3D};

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -652,1936 +652,1840 @@ unsafe impl<'a, T: 'a + RaylibDraw3D> RaylibDraw3D for RaylibScissorMode<'a, T> 
 
 // Actual drawing functions
 
-/// Permits external implementation of [`RaylibDraw`].
-///
-/// Implementing this trait on your type will automatically impl the default
-/// definition of [`RaylibDraw`] for it.
+/// Types through which it is safe to call standard Raylib drawing functions.
 ///
 /// # Safety
 ///
-/// This trait implements [`RaylibDraw`] for your type. Implementors of
-/// [`RaylibDrawImpl`] must uphold the safety contract of [`RaylibDraw`].
+/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+/// and expect for there to be a window and buffer to target--all without any checks.
 ///
-/// # Example
-/// ```
-/// use raylib::prelude::*;
-///
-/// struct Foo<'a, D>(&'a mut D);
-///
-/// // SAFETY: `Foo` stores a mutable `RaylibDraw` reference without creating
-/// // unbalanced draw modes, proving it is safe to call draw functions.
-/// unsafe impl<D: RaylibDraw> RaylibDrawImpl for Foo<'_, D> {}
-///
-/// fn foo_draw(foo: &mut Foo<'_, impl RaylibDraw>) {
-///     foo.clear_background(Color::RAYWHITE);
-/// }
-///
-/// fn foo_draw_caller(d: &mut impl RaylibDraw) {
-///     foo_draw(&mut Foo(d));
-/// }
-/// ```
-pub unsafe trait RaylibDrawImpl {}
-
-/// Permits external implementation of [`RaylibDraw3D`].
-///
-/// Implementing this trait on your type will automatically impl the default
-/// definition of [`RaylibDraw3D`] for it.
-///
-/// # Safety
-///
-/// This trait implements [`RaylibDraw3D`] for your type. Implementors of
-/// [`RaylibDraw3DImpl`] must uphold the safety contract of [`RaylibDraw3D`].
-///
-/// # Example
-/// ```
-/// use raylib::prelude::*;
-///
-/// struct Bar<'a, D>(&'a mut D);
-///
-/// // SAFETY: `Bar` stores a mutable `RaylibDraw3D` reference without creating
-/// // unbalanced draw modes, proving it is safe to call draw functions.
-/// unsafe impl<D: RaylibDraw3D> RaylibDraw3DImpl for Bar<'_, D> {}
-///
-/// fn bar_draw(bar: &mut Bar<'_, impl RaylibDraw3D>) {
-///     bar.draw_point3D(Vector3::new(1.0, 5.0, -4.0), Color::RED);
-/// }
-///
-/// fn bar_draw_caller(d: &mut impl RaylibDraw3D) {
-///     bar_draw(&mut Bar(d));
-/// }
-/// ```
-pub unsafe trait RaylibDraw3DImpl {}
-
-mod sealed {
-    //! External impl of RaylibDraw/RaylibDraw3D is permitted, but redefinition is not.
-    use super::*;
-
-    // SAFETY: Implementors of `RaylibDrawImpl` must uphold `RaylibDraw`'s safety contract.
-    unsafe impl<D: ?Sized + RaylibDrawImpl> RaylibDraw for D {}
-
-    // SAFETY: Implementors of `RaylibDraw3DImpl` must uphold `RaylibDraw3D`'s safety contract.
-    unsafe impl<D: ?Sized + RaylibDraw3DImpl> RaylibDraw3D for D {}
-
-    /// Types through which it is safe to call standard Raylib drawing functions.
-    ///
-    /// # Safety
-    ///
-    /// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
-    /// access global static memory without locking, perform calls with function pointers that may not have been loaded,
-    /// and expect for there to be a window and buffer to target--all without any checks.
-    ///
-    /// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
-    /// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
-    /// [`ffi::BeginDrawing`] or [`ffi::BeginTextureMode`] has been called this frame without the corresponding
-    /// [`ffi::EndDrawing`]/[`ffi::EndTextureMode`] having been called yet.
-    pub unsafe trait RaylibDraw {
-        /// Sets background color (framebuffer clear `color.into()`).
-        #[inline]
-        fn clear_background(&mut self, color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::ClearBackground(color.into());
-            }
-        }
-
-        /// Get texture that is used for shapes drawing
-        #[inline]
-        #[must_use]
-        fn get_shapes_texture(&self) -> Texture2D {
-            // SAFETY: Implementor must uphold trait safety contract.
-            Texture2D(unsafe { ffi::GetShapesTexture() })
-        }
-
-        /// Get texture source rectangle that is used for shapes drawing
-        #[inline]
-        #[must_use]
-        fn get_shapes_texture_rectangle(&self) -> Rectangle {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::GetShapesTextureRectangle() }
-        }
-
-        /// Define default texture used to draw shapes
-        #[inline]
-        fn set_shapes_texture(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            source: impl Into<ffi::Rectangle>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::SetShapesTexture(*texture.as_ref(), source.into()) }
-        }
-
-        // // Draw gui widget
-        // fn draw_gui<G: crate::rgui::GuiDraw>(&mut self, widget: G) -> crate::rgui::DrawResult {
-        //     widget.draw()
-        // }
-
-        // SHAPES
-        /// Draws a pixel.
-        #[inline]
-        fn draw_pixel(&mut self, x: i32, y: i32, color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPixel(x, y, color.into());
-            }
-        }
-
-        /// Draws a pixel (Vector version).
-        #[inline]
-        fn draw_pixel_v(
-            &mut self,
-            position: impl Into<ffi::Vector2>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPixelV(position.into(), color.into());
-            }
-        }
-
-        /// Draws a line.
-        #[inline]
-        fn draw_line(
-            &mut self,
-            start_pos_x: i32,
-            start_pos_y: i32,
-            end_pos_x: i32,
-            end_pos_y: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawLine(start_pos_x, start_pos_y, end_pos_x, end_pos_y, color.into());
-            }
-        }
-
-        /// Draws a line (Vector version).
-        #[inline]
-        fn draw_line_v(
-            &mut self,
-            start_pos: impl Into<ffi::Vector2>,
-            end_pos: impl Into<ffi::Vector2>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawLineV(start_pos.into(), end_pos.into(), color.into());
-            }
-        }
-
-        /// Draws a line with thickness.
-        #[inline]
-        fn draw_line_ex(
-            &mut self,
-            start_pos: impl Into<ffi::Vector2>,
-            end_pos: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawLineEx(start_pos.into(), end_pos.into(), thick, color.into());
-            }
-        }
-
-        /// Draws a line using cubic-bezier curves in-out.
-        #[inline]
-        fn draw_line_bezier(
-            &mut self,
-            start_pos: impl Into<ffi::Vector2>,
-            end_pos: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawLineBezier(start_pos.into(), end_pos.into(), thick, color.into());
-            }
-        }
-
-        /// Draw lines sequence
-        #[inline]
-        fn draw_line_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawLineStrip(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draws a color-filled circle.
-        #[inline]
-        fn draw_circle(
-            &mut self,
-            center_x: i32,
-            center_y: i32,
-            radius: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircle(center_x, center_y, radius, color.into());
-            }
-        }
-
-        /// Draw a piece of a circle
-        #[inline]
-        fn draw_circle_sector(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            radius: f32,
-            start_angle: f32,
-            end_angle: f32,
-            segments: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircleSector(
-                    center.into(),
-                    radius,
-                    start_angle,
-                    end_angle,
-                    segments,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw circle sector outline
-        #[inline]
-        fn draw_circle_sector_lines(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            radius: f32,
-            start_angle: f32,
-            end_angle: f32,
-            segments: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircleSectorLines(
-                    center.into(),
-                    radius,
-                    start_angle,
-                    end_angle,
-                    segments,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draws a gradient-filled circle.
-        #[inline]
-        fn draw_circle_gradient(
-            &mut self,
-            center_x: i32,
-            center_y: i32,
-            radius: f32,
-            color1: impl Into<ffi::Color>,
-            color2: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircleGradient(center_x, center_y, radius, color1.into(), color2.into());
-            }
-        }
-
-        /// Draws a color-filled circle (Vector version).
-        #[inline]
-        fn draw_circle_v(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            radius: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircleV(center.into(), radius, color.into());
-            }
-        }
-
-        /// Draws circle outline.
-        #[inline]
-        fn draw_circle_lines(
-            &mut self,
-            center_x: i32,
-            center_y: i32,
-            radius: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircleLines(center_x, center_y, radius, color.into());
-            }
-        }
-
-        /// Draws circle outline. (Vector Version)
-        #[inline]
-        fn draw_circle_lines_v(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            radius: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircleLinesV(center.into(), radius, color.into());
-            }
-        }
-
-        /// Draws ellipse.
-        #[inline]
-        fn draw_ellipse(
-            &mut self,
-            center_x: i32,
-            center_y: i32,
-            radius_h: f32,
-            radius_v: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawEllipse(center_x, center_y, radius_h, radius_v, color.into());
-            }
-        }
-
-        /// Draws ellipse.
-        #[inline]
-        fn draw_ellipse_lines(
-            &mut self,
-            center_x: i32,
-            center_y: i32,
-            radius_h: f32,
-            radius_v: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawEllipseLines(center_x, center_y, radius_h, radius_v, color.into());
-            }
-        }
-
-        /// Draw ring
-        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-        #[inline]
-        fn draw_ring(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            inner_radius: f32,
-            outer_radius: f32,
-            start_angle: f32,
-            end_angle: f32,
-            segments: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRing(
-                    center.into(),
-                    inner_radius,
-                    outer_radius,
-                    start_angle,
-                    end_angle,
-                    segments,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw ring lines
-        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-        #[inline]
-        fn draw_ring_lines(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            inner_radius: f32,
-            outer_radius: f32,
-            start_angle: f32,
-            end_angle: f32,
-            segments: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRingLines(
-                    center.into(),
-                    inner_radius,
-                    outer_radius,
-                    start_angle,
-                    end_angle,
-                    segments,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draws a color-filled rectangle.
-        #[inline]
-        fn draw_rectangle(
-            &mut self,
-            x: i32,
-            y: i32,
-            width: i32,
-            height: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangle(x, y, width, height, color.into());
-            }
-        }
-
-        /// Draws a color-filled rectangle (Vector version).
-        #[inline]
-        fn draw_rectangle_v(
-            &mut self,
-            position: impl Into<ffi::Vector2>,
-            size: impl Into<ffi::Vector2>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleV(position.into(), size.into(), color.into());
-            }
-        }
-
-        /// Draws a color-filled rectangle from `rec`.
-        #[inline]
-        fn draw_rectangle_rec(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleRec(rec.into(), color.into());
-            }
-        }
-
-        /// Draws a color-filled rectangle with pro parameters.
-        #[inline]
-        fn draw_rectangle_pro(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            origin: impl Into<ffi::Vector2>,
-            rotation: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectanglePro(rec.into(), origin.into(), rotation, color.into());
-            }
-        }
-
-        /// Draws a vertical-gradient-filled rectangle.
-        ///
-        /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
-        #[inline]
-        fn draw_rectangle_gradient_v(
-            &mut self,
-            x: i32,
-            y: i32,
-            width: i32,
-            height: i32,
-            color1: impl Into<ffi::Color>,
-            color2: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleGradientV(x, y, width, height, color1.into(), color2.into());
-            }
-        }
-
-        /// Draws a horizontal-gradient-filled rectangle.
-        ///
-        /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
-        #[inline]
-        fn draw_rectangle_gradient_h(
-            &mut self,
-            x: i32,
-            y: i32,
-            width: i32,
-            height: i32,
-            color1: impl Into<ffi::Color>,
-            color2: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleGradientH(x, y, width, height, color1.into(), color2.into());
-            }
-        }
-
-        /// Draws a gradient-filled rectangle with custom vertex colors.
-        ///
-        /// **NOTE**: Colors refer to corners, starting at top-left corner and going counter-clockwise.
-        #[inline]
-        fn draw_rectangle_gradient_ex(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            col1: impl Into<ffi::Color>,
-            col2: impl Into<ffi::Color>,
-            col3: impl Into<ffi::Color>,
-            col4: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleGradientEx(
-                    rec.into(),
-                    col1.into(),
-                    col2.into(),
-                    col3.into(),
-                    col4.into(),
-                );
-            }
-        }
-
-        /// Draws rectangle outline.
-        #[inline]
-        fn draw_rectangle_lines(
-            &mut self,
-            x: i32,
-            y: i32,
-            width: i32,
-            height: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleLines(x, y, width, height, color.into());
-            }
-        }
-
-        /// Draws rectangle outline with extended parameters.
-        #[inline]
-        fn draw_rectangle_lines_ex(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            line_thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleLinesEx(rec.into(), line_thick, color.into());
-            }
-        }
-
-        /// Draws rectangle with rounded edges.
-        #[inline]
-        fn draw_rectangle_rounded(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            roundness: f32,
-            segments: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleRounded(rec.into(), roundness, segments, color.into());
-            }
-        }
-
-        /// Draws rectangle outline with rounded edges included.
-        #[inline]
-        fn draw_rectangle_rounded_lines(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            roundness: f32,
-            segments: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleRoundedLines(rec.into(), roundness, segments, color.into());
-            }
-        }
-
-        /// Draw rectangle with rounded edges outline
-        #[inline]
-        fn draw_rectangle_rounded_lines_ex(
-            &mut self,
-            rec: impl Into<ffi::Rectangle>,
-            roundness: f32,
-            segments: i32,
-            line_thickness: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRectangleRoundedLinesEx(
-                    rec.into(),
-                    roundness,
-                    segments,
-                    line_thickness,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draws a triangle.
-        #[inline]
-        fn draw_triangle(
-            &mut self,
-            v1: impl Into<ffi::Vector2>,
-            v2: impl Into<ffi::Vector2>,
-            v3: impl Into<ffi::Vector2>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTriangle(v1.into(), v2.into(), v3.into(), color.into());
-            }
-        }
-
-        /// Draws a triangle using lines.
-        #[inline]
-        fn draw_triangle_lines(
-            &mut self,
-            v1: impl Into<ffi::Vector2>,
-            v2: impl Into<ffi::Vector2>,
-            v3: impl Into<ffi::Vector2>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTriangleLines(v1.into(), v2.into(), v3.into(), color.into());
-            }
-        }
-
-        /// Draw a triangle fan defined by points.
-        #[inline]
-        fn draw_triangle_fan(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTriangleFan(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw a triangle strip defined by points
-        #[inline]
-        fn draw_triangle_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTriangleStrip(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draws a regular polygon of n sides (Vector version).
-        #[inline]
-        fn draw_poly(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            sides: i32,
-            radius: f32,
-            rotation: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPoly(center.into(), sides, radius, rotation, color.into());
-            }
-        }
-
-        /// Draws a regular polygon of n sides (Vector version).
-        #[inline]
-        fn draw_poly_lines(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            sides: i32,
-            radius: f32,
-            rotation: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPolyLines(center.into(), sides, radius, rotation, color.into());
-            }
-        }
-
-        /// Draws a `texture` using specified position and `tint` color.
-        #[inline]
-        fn draw_texture(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            x: i32,
-            y: i32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTexture(*texture.as_ref(), x, y, tint.into());
-            }
-        }
-
-        /// Draws a `texture` using specified `position` vector and `tint` color.
-        #[inline]
-        fn draw_texture_v(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            position: impl Into<ffi::Vector2>,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextureV(*texture.as_ref(), position.into(), tint.into());
-            }
-        }
-
-        /// Draws a `texture` with extended parameters.
-        #[inline]
-        fn draw_texture_ex(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            position: impl Into<ffi::Vector2>,
-            rotation: f32,
-            scale: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextureEx(
-                    *texture.as_ref(),
-                    position.into(),
-                    rotation,
-                    scale,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Draws from a region of `texture` defined by the `source_rec` rectangle.
-        #[inline]
-        fn draw_texture_rec(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            source_rec: impl Into<ffi::Rectangle>,
-            position: impl Into<ffi::Vector2>,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextureRec(
-                    *texture.as_ref(),
-                    source_rec.into(),
-                    position.into(),
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Draw from a region of `texture` defined by the `source_rec` rectangle with pro parameters.
-        #[inline]
-        fn draw_texture_pro(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            source_rec: impl Into<ffi::Rectangle>,
-            dest_rec: impl Into<ffi::Rectangle>,
-            origin: impl Into<ffi::Vector2>,
-            rotation: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTexturePro(
-                    *texture.as_ref(),
-                    source_rec.into(),
-                    dest_rec.into(),
-                    origin.into(),
-                    rotation,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Draws a texture (or part of it) that stretches or shrinks nicely
-        #[inline]
-        fn draw_texture_n_patch(
-            &mut self,
-            texture: impl AsRef<ffi::Texture2D>,
-            n_patch_info: impl Into<ffi::NPatchInfo>,
-            dest_rec: impl Into<ffi::Rectangle>,
-            origin: impl Into<ffi::Vector2>,
-            rotation: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextureNPatch(
-                    *texture.as_ref(),
-                    n_patch_info.into(),
-                    dest_rec.into(),
-                    origin.into(),
-                    rotation,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Shows current FPS.
-        #[inline]
-        fn draw_fps(&mut self, x: i32, y: i32) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawFPS(x, y);
-            }
-        }
-
-        /// Draws text (using default font).
-        /// This does not support UTF-8. Use `[RaylibDrawHandle::draw_text_codepoints]` for that.
-        #[inline]
-        fn draw_text(
-            &mut self,
-            text: &str,
-            x: i32,
-            y: i32,
-            font_size: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawText(c_text.as_ptr(), x, y, font_size, color.into());
-            }
-        }
-
-        /// Draws text (using default font) with support for UTF-8.
-        /// If you do not need UTF-8, use `[RaylibDrawHandle::draw_text]`.
-        fn draw_text_codepoints(
-            &mut self,
-            font: impl AsRef<ffi::Font>,
-            text: &str,
-            position: impl Into<ffi::Vector2>,
-            font_size: f32,
-            spacing: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-            let mut len = 0;
-            // SAFETY: Implementor must uphold trait safety contract.
-            let u = unsafe { ffi::LoadCodepoints(c_text.as_ptr(), &raw mut len) };
-
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextCodepoints(
-                    *font.as_ref(),
-                    u,
-                    text.len()
-                        .try_into()
-                        .expect("text should not exceed i32::MAX elements"),
-                    position.into(),
-                    font_size,
-                    spacing,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Draws text using `font` and additional parameters.
-        #[inline]
-        fn draw_text_ex(
-            &mut self,
-            font: impl AsRef<ffi::Font>,
-            text: &str,
-            position: impl Into<ffi::Vector2>,
-            font_size: f32,
-            spacing: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextEx(
-                    *font.as_ref(),
-                    c_text.as_ptr(),
-                    position.into(),
-                    font_size,
-                    spacing,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Draw text using Font and pro parameters (rotation)
-        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-        #[inline]
-        fn draw_text_pro(
-            &mut self,
-            font: impl AsRef<ffi::Font>,
-            text: &str,
-            position: impl Into<ffi::Vector2>,
-            origin: impl Into<ffi::Vector2>,
-            rotation: f32,
-            font_size: f32,
-            spacing: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextPro(
-                    *font.as_ref(),
-                    c_text.as_ptr(),
-                    position.into(),
-                    origin.into(),
-                    rotation,
-                    font_size,
-                    spacing,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Draw one character (codepoint)
-        #[inline]
-        fn draw_text_codepoint(
-            &mut self,
-            font: impl AsRef<ffi::Font>,
-            codepoint: i32,
-            position: impl Into<ffi::Vector2>,
-            scale: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTextCodepoint(
-                    *font.as_ref(),
-                    codepoint,
-                    position.into(),
-                    scale,
-                    tint.into(),
-                );
-            }
-        }
-
-        /// Enable waiting for events when the handle is dropped, no automatic event polling
-        #[inline]
-        fn enable_event_waiting(&self) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::EnableEventWaiting() }
-        }
-
-        /// Disable waiting for events when the handle is dropped, no automatic event polling
-        #[inline]
-        fn disable_event_waiting(&self) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::DisableEventWaiting() }
-        }
-
-        /// Draw a polygon outline of n sides with extended parameters
-        #[inline]
-        fn draw_poly_lines_ex(
-            &mut self,
-            center: impl Into<ffi::Vector2>,
-            sides: i32,
-            radius: f32,
-            rotation: f32,
-            line_thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPolyLinesEx(
-                    center.into(),
-                    sides,
-                    radius,
-                    rotation,
-                    line_thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline: Linear, minimum 2 points
-        #[inline]
-        fn draw_spline_linear(
-            &mut self,
-            points: &[Vector2],
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineLinear(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline: B-Spline, minimum 4 points
-        #[inline]
-        fn draw_spline_basis(
-            &mut self,
-            points: &[Vector2],
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineBasis(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline: Catmull-Rom, minimum 4 points
-        #[inline]
-        fn draw_spline_catmull_rom(
-            &mut self,
-            points: &[Vector2],
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineCatmullRom(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
-        #[inline]
-        fn draw_spline_bezier_quadratic(
-            &mut self,
-            points: &[Vector2],
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineBezierQuadratic(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
-        #[inline]
-        fn draw_spline_bezier_cubic(
-            &mut self,
-            points: &[Vector2],
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineBezierCubic(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline segment: Linear, 2 points
-        #[inline]
-        fn draw_spline_segment_linear(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            p2: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::DrawSplineSegmentLinear(p1.into(), p2.into(), thick, color.into()) }
-        }
-
-        /// Draw spline segment: B-Spline, 4 points
-        #[inline]
-        fn draw_spline_segment_basis(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            p2: impl Into<ffi::Vector2>,
-            p3: impl Into<ffi::Vector2>,
-            p4: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineSegmentBasis(
-                    p1.into(),
-                    p2.into(),
-                    p3.into(),
-                    p4.into(),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline segment: Catmull-Rom, 4 points
-        #[inline]
-        fn draw_spline_segment_catmull_rom(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            p2: impl Into<ffi::Vector2>,
-            p3: impl Into<ffi::Vector2>,
-            p4: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineSegmentCatmullRom(
-                    p1.into(),
-                    p2.into(),
-                    p3.into(),
-                    p4.into(),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
-        #[inline]
-        fn draw_spline_segment_bezier_quadratic(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            c2: impl Into<ffi::Vector2>,
-            p3: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineSegmentBezierQuadratic(
-                    p1.into(),
-                    c2.into(),
-                    p3.into(),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Draw spline segment: Cubic Bezier, 2 points, 2 control points
-        #[inline]
-        fn draw_spline_segment_bezier_cubic(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            c2: impl Into<ffi::Vector2>,
-            c3: impl Into<ffi::Vector2>,
-            p4: impl Into<ffi::Vector2>,
-            thick: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSplineSegmentBezierCubic(
-                    p1.into(),
-                    c2.into(),
-                    c3.into(),
-                    p4.into(),
-                    thick,
-                    color.into(),
-                );
-            }
-        }
-
-        /// Get (evaluate) spline point: Linear
-        #[inline]
-        #[must_use]
-        fn get_spline_point_linear(
-            &mut self,
-            start_pos: impl Into<ffi::Vector2>,
-            end_pos: impl Into<ffi::Vector2>,
-            t: f32,
-        ) -> Vector2 {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::GetSplinePointLinear(start_pos.into(), end_pos.into(), t).into() }
-        }
-
-        /// Get (evaluate) spline point: B-Spline
-        #[inline]
-        #[must_use]
-        fn get_spline_point_basis(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            p2: impl Into<ffi::Vector2>,
-            p3: impl Into<ffi::Vector2>,
-            p4: impl Into<ffi::Vector2>,
-            t: f32,
-        ) -> Vector2 {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::GetSplinePointBasis(p1.into(), p2.into(), p3.into(), p4.into(), t).into()
-            }
-        }
-
-        /// Get (evaluate) spline point: Catmull-Rom
-        #[inline]
-        #[must_use]
-        fn get_spline_point_catmull_rom(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            p2: impl Into<ffi::Vector2>,
-            p3: impl Into<ffi::Vector2>,
-            p4: impl Into<ffi::Vector2>,
-            t: f32,
-        ) -> Vector2 {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::GetSplinePointCatmullRom(p1.into(), p2.into(), p3.into(), p4.into(), t).into()
-            }
-        }
-
-        /// Get (evaluate) spline point: Quadratic Bezier
-        #[inline]
-        #[must_use]
-        fn get_spline_point_bezier_quad(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            c2: impl Into<ffi::Vector2>,
-            p3: impl Into<ffi::Vector2>,
-            t: f32,
-        ) -> Vector2 {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::GetSplinePointBezierQuad(p1.into(), c2.into(), p3.into(), t).into() }
-        }
-
-        /// Get (evaluate) spline point: Cubic Bezier
-        #[inline]
-        #[must_use]
-        fn get_spline_point_bezier_cubic(
-            &mut self,
-            p1: impl Into<ffi::Vector2>,
-            c2: impl Into<ffi::Vector2>,
-            c3: impl Into<ffi::Vector2>,
-            p4: impl Into<ffi::Vector2>,
-            t: f32,
-        ) -> Vector2 {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::GetSplinePointBezierCubic(p1.into(), c2.into(), c3.into(), p4.into(), t).into()
-            }
+/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+/// [`ffi::BeginDrawing`] or [`ffi::BeginTextureMode`] has been called this frame without the corresponding
+/// [`ffi::EndDrawing`]/[`ffi::EndTextureMode`] having been called yet.
+pub unsafe trait RaylibDraw {
+    /// Sets background color (framebuffer clear `color.into()`).
+    #[inline]
+    fn clear_background(&mut self, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::ClearBackground(color.into());
         }
     }
 
-    /// Types through which it is safe to call 3D Raylib drawing functions.
+    /// Get texture that is used for shapes drawing
+    #[inline]
+    #[must_use]
+    fn get_shapes_texture(&self) -> Texture2D {
+        // SAFETY: Implementor must uphold trait safety contract.
+        Texture2D(unsafe { ffi::GetShapesTexture() })
+    }
+
+    /// Get texture source rectangle that is used for shapes drawing
+    #[inline]
+    #[must_use]
+    fn get_shapes_texture_rectangle(&self) -> Rectangle {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::GetShapesTextureRectangle() }
+    }
+
+    /// Define default texture used to draw shapes
+    #[inline]
+    fn set_shapes_texture(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        source: impl Into<ffi::Rectangle>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::SetShapesTexture(*texture.as_ref(), source.into()) }
+    }
+
+    // // Draw gui widget
+    // fn draw_gui<G: crate::rgui::GuiDraw>(&mut self, widget: G) -> crate::rgui::DrawResult {
+    //     widget.draw()
+    // }
+
+    // SHAPES
+    /// Draws a pixel.
+    #[inline]
+    fn draw_pixel(&mut self, x: i32, y: i32, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPixel(x, y, color.into());
+        }
+    }
+
+    /// Draws a pixel (Vector version).
+    #[inline]
+    fn draw_pixel_v(&mut self, position: impl Into<ffi::Vector2>, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPixelV(position.into(), color.into());
+        }
+    }
+
+    /// Draws a line.
+    #[inline]
+    fn draw_line(
+        &mut self,
+        start_pos_x: i32,
+        start_pos_y: i32,
+        end_pos_x: i32,
+        end_pos_y: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawLine(start_pos_x, start_pos_y, end_pos_x, end_pos_y, color.into());
+        }
+    }
+
+    /// Draws a line (Vector version).
+    #[inline]
+    fn draw_line_v(
+        &mut self,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawLineV(start_pos.into(), end_pos.into(), color.into());
+        }
+    }
+
+    /// Draws a line with thickness.
+    #[inline]
+    fn draw_line_ex(
+        &mut self,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawLineEx(start_pos.into(), end_pos.into(), thick, color.into());
+        }
+    }
+
+    /// Draws a line using cubic-bezier curves in-out.
+    #[inline]
+    fn draw_line_bezier(
+        &mut self,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawLineBezier(start_pos.into(), end_pos.into(), thick, color.into());
+        }
+    }
+
+    /// Draw lines sequence
+    #[inline]
+    fn draw_line_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawLineStrip(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a color-filled circle.
+    #[inline]
+    fn draw_circle(
+        &mut self,
+        center_x: i32,
+        center_y: i32,
+        radius: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircle(center_x, center_y, radius, color.into());
+        }
+    }
+
+    /// Draw a piece of a circle
+    #[inline]
+    fn draw_circle_sector(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        segments: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircleSector(
+                center.into(),
+                radius,
+                start_angle,
+                end_angle,
+                segments,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draw circle sector outline
+    #[inline]
+    fn draw_circle_sector_lines(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        segments: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircleSectorLines(
+                center.into(),
+                radius,
+                start_angle,
+                end_angle,
+                segments,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a gradient-filled circle.
+    #[inline]
+    fn draw_circle_gradient(
+        &mut self,
+        center_x: i32,
+        center_y: i32,
+        radius: f32,
+        color1: impl Into<ffi::Color>,
+        color2: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircleGradient(center_x, center_y, radius, color1.into(), color2.into());
+        }
+    }
+
+    /// Draws a color-filled circle (Vector version).
+    #[inline]
+    fn draw_circle_v(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        radius: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircleV(center.into(), radius, color.into());
+        }
+    }
+
+    /// Draws circle outline.
+    #[inline]
+    fn draw_circle_lines(
+        &mut self,
+        center_x: i32,
+        center_y: i32,
+        radius: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircleLines(center_x, center_y, radius, color.into());
+        }
+    }
+
+    /// Draws circle outline. (Vector Version)
+    #[inline]
+    fn draw_circle_lines_v(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        radius: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircleLinesV(center.into(), radius, color.into());
+        }
+    }
+
+    /// Draws ellipse.
+    #[inline]
+    fn draw_ellipse(
+        &mut self,
+        center_x: i32,
+        center_y: i32,
+        radius_h: f32,
+        radius_v: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawEllipse(center_x, center_y, radius_h, radius_v, color.into());
+        }
+    }
+
+    /// Draws ellipse.
+    #[inline]
+    fn draw_ellipse_lines(
+        &mut self,
+        center_x: i32,
+        center_y: i32,
+        radius_h: f32,
+        radius_v: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawEllipseLines(center_x, center_y, radius_h, radius_v, color.into());
+        }
+    }
+
+    /// Draw ring
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+    #[inline]
+    fn draw_ring(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        inner_radius: f32,
+        outer_radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        segments: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRing(
+                center.into(),
+                inner_radius,
+                outer_radius,
+                start_angle,
+                end_angle,
+                segments,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draw ring lines
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+    #[inline]
+    fn draw_ring_lines(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        inner_radius: f32,
+        outer_radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        segments: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRingLines(
+                center.into(),
+                inner_radius,
+                outer_radius,
+                start_angle,
+                end_angle,
+                segments,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a color-filled rectangle.
+    #[inline]
+    fn draw_rectangle(
+        &mut self,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangle(x, y, width, height, color.into());
+        }
+    }
+
+    /// Draws a color-filled rectangle (Vector version).
+    #[inline]
+    fn draw_rectangle_v(
+        &mut self,
+        position: impl Into<ffi::Vector2>,
+        size: impl Into<ffi::Vector2>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleV(position.into(), size.into(), color.into());
+        }
+    }
+
+    /// Draws a color-filled rectangle from `rec`.
+    #[inline]
+    fn draw_rectangle_rec(&mut self, rec: impl Into<ffi::Rectangle>, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleRec(rec.into(), color.into());
+        }
+    }
+
+    /// Draws a color-filled rectangle with pro parameters.
+    #[inline]
+    fn draw_rectangle_pro(
+        &mut self,
+        rec: impl Into<ffi::Rectangle>,
+        origin: impl Into<ffi::Vector2>,
+        rotation: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectanglePro(rec.into(), origin.into(), rotation, color.into());
+        }
+    }
+
+    /// Draws a vertical-gradient-filled rectangle.
     ///
-    /// # Safety
+    /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
+    #[inline]
+    fn draw_rectangle_gradient_v(
+        &mut self,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        color1: impl Into<ffi::Color>,
+        color2: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleGradientV(x, y, width, height, color1.into(), color2.into());
+        }
+    }
+
+    /// Draws a horizontal-gradient-filled rectangle.
     ///
-    /// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
-    /// access global static memory without locking, perform calls with function pointers that may not have been loaded,
-    /// and expect for there to be a window, buffer, & projection matrix to target--all without any checks.
+    /// **NOTE**: Gradient goes from bottom (`color1`) to top (`color2`).
+    #[inline]
+    fn draw_rectangle_gradient_h(
+        &mut self,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        color1: impl Into<ffi::Color>,
+        color2: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleGradientH(x, y, width, height, color1.into(), color2.into());
+        }
+    }
+
+    /// Draws a gradient-filled rectangle with custom vertex colors.
     ///
-    /// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
-    /// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
-    /// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
-    pub unsafe trait RaylibDraw3D {
-        /// Draw a point in 3D space, actually a small line
-        #[allow(non_snake_case, reason = "consistent style")]
-        #[inline]
-        fn draw_point3D(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPoint3D(position.into(), color.into());
-            }
+    /// **NOTE**: Colors refer to corners, starting at top-left corner and going counter-clockwise.
+    #[inline]
+    fn draw_rectangle_gradient_ex(
+        &mut self,
+        rec: impl Into<ffi::Rectangle>,
+        col1: impl Into<ffi::Color>,
+        col2: impl Into<ffi::Color>,
+        col3: impl Into<ffi::Color>,
+        col4: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleGradientEx(
+                rec.into(),
+                col1.into(),
+                col2.into(),
+                col3.into(),
+                col4.into(),
+            );
         }
+    }
 
-        /// Draw a color-filled triangle (vertex in counter-clockwise order!)
-        #[allow(non_snake_case, reason = "consistent style")]
-        #[inline]
-        fn draw_triangle3D(
-            &mut self,
-            v1: impl Into<ffi::Vector3>,
-            v2: impl Into<ffi::Vector3>,
-            v3: impl Into<ffi::Vector3>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTriangle3D(v1.into(), v2.into(), v3.into(), color.into());
-            }
+    /// Draws rectangle outline.
+    #[inline]
+    fn draw_rectangle_lines(
+        &mut self,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleLines(x, y, width, height, color.into());
         }
+    }
 
-        /// Draw a triangle strip defined by points
-        #[allow(non_snake_case, reason = "consistent style")]
-        #[inline]
-        fn draw_triangle_strip3D(&mut self, points: &[Vector3], color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawTriangleStrip3D(
-                    points.as_ptr().cast(),
-                    points
-                        .len()
-                        .try_into()
-                        .expect("points should not exceed i32::MAX elements"),
-                    color.into(),
-                );
-            }
+    /// Draws rectangle outline with extended parameters.
+    #[inline]
+    fn draw_rectangle_lines_ex(
+        &mut self,
+        rec: impl Into<ffi::Rectangle>,
+        line_thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleLinesEx(rec.into(), line_thick, color.into());
         }
+    }
 
-        /// Draws a line in 3D world space.
-        #[allow(non_snake_case, reason = "consistent style")]
-        #[inline]
-        fn draw_line3D(
-            &mut self,
-            start_pos: impl Into<ffi::Vector3>,
-            end_pos: impl Into<ffi::Vector3>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawLine3D(start_pos.into(), end_pos.into(), color.into());
-            }
+    /// Draws rectangle with rounded edges.
+    #[inline]
+    fn draw_rectangle_rounded(
+        &mut self,
+        rec: impl Into<ffi::Rectangle>,
+        roundness: f32,
+        segments: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleRounded(rec.into(), roundness, segments, color.into());
         }
+    }
 
-        /// Draws a circle in 3D world space.
-        #[allow(non_snake_case, reason = "consistent style")]
-        #[inline]
-        fn draw_circle3D(
-            &mut self,
-            center: impl Into<ffi::Vector3>,
-            radius: f32,
-            rotation_axis: impl Into<ffi::Vector3>,
-            rotation_angle: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCircle3D(
-                    center.into(),
-                    radius,
-                    rotation_axis.into(),
-                    rotation_angle,
-                    color.into(),
-                );
-            }
+    /// Draws rectangle outline with rounded edges included.
+    #[inline]
+    fn draw_rectangle_rounded_lines(
+        &mut self,
+        rec: impl Into<ffi::Rectangle>,
+        roundness: f32,
+        segments: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleRoundedLines(rec.into(), roundness, segments, color.into());
         }
+    }
 
-        /// Draws a cube.
-        #[inline]
-        fn draw_cube(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            width: f32,
-            height: f32,
-            length: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCube(position.into(), width, height, length, color.into());
-            }
+    /// Draw rectangle with rounded edges outline
+    #[inline]
+    fn draw_rectangle_rounded_lines_ex(
+        &mut self,
+        rec: impl Into<ffi::Rectangle>,
+        roundness: f32,
+        segments: i32,
+        line_thickness: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRectangleRoundedLinesEx(
+                rec.into(),
+                roundness,
+                segments,
+                line_thickness,
+                color.into(),
+            );
         }
+    }
 
-        /// Draws a cube (Vector version).
-        #[inline]
-        fn draw_cube_v(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            size: impl Into<ffi::Vector3>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCubeV(position.into(), size.into(), color.into());
-            }
+    /// Draws a triangle.
+    #[inline]
+    fn draw_triangle(
+        &mut self,
+        v1: impl Into<ffi::Vector2>,
+        v2: impl Into<ffi::Vector2>,
+        v3: impl Into<ffi::Vector2>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTriangle(v1.into(), v2.into(), v3.into(), color.into());
         }
+    }
 
-        /// Draws a cube in wireframe.
-        #[inline]
-        fn draw_cube_wires(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            width: f32,
-            height: f32,
-            length: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCubeWires(position.into(), width, height, length, color.into());
-            }
+    /// Draws a triangle using lines.
+    #[inline]
+    fn draw_triangle_lines(
+        &mut self,
+        v1: impl Into<ffi::Vector2>,
+        v2: impl Into<ffi::Vector2>,
+        v3: impl Into<ffi::Vector2>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTriangleLines(v1.into(), v2.into(), v3.into(), color.into());
         }
+    }
 
-        /// Draws a cube in wireframe. (Vector Version)
-        #[inline]
-        fn draw_cube_wires_v(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            size: impl Into<ffi::Vector3>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCubeWiresV(position.into(), size.into(), color.into());
-            }
+    /// Draw a triangle fan defined by points.
+    #[inline]
+    fn draw_triangle_fan(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTriangleFan(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                color.into(),
+            );
         }
+    }
 
-        /// Draw a 3d mesh with material and transform
-        #[inline]
-        fn draw_mesh(
-            &mut self,
-            mesh: impl AsRef<ffi::Mesh>,
-            material: WeakMaterial,
-            transform: impl Into<ffi::Matrix>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe { ffi::DrawMesh(*mesh.as_ref(), material.0, transform.into()) }
+    /// Draw a triangle strip defined by points
+    #[inline]
+    fn draw_triangle_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTriangleStrip(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                color.into(),
+            );
         }
+    }
 
-        /// Draw multiple mesh instances with material and different transforms
-        #[inline]
-        fn draw_mesh_instanced(
-            &mut self,
-            mesh: impl AsRef<ffi::Mesh>,
-            material: WeakMaterial,
-            transforms: &[Matrix],
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawMeshInstanced(
-                    *mesh.as_ref(),
-                    material.0,
-                    transforms.as_ptr().cast(),
-                    transforms
-                        .len()
-                        .try_into()
-                        .expect("transforms should not exceed i32::MAX elements"),
-                );
-            }
+    /// Draws a regular polygon of n sides (Vector version).
+    #[inline]
+    fn draw_poly(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        sides: i32,
+        radius: f32,
+        rotation: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPoly(center.into(), sides, radius, rotation, color.into());
         }
+    }
 
-        /// Draws a sphere.
-        #[inline]
-        fn draw_sphere(
-            &mut self,
-            center_pos: impl Into<ffi::Vector3>,
-            radius: f32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSphere(center_pos.into(), radius, color.into());
-            }
+    /// Draws a regular polygon of n sides (Vector version).
+    #[inline]
+    fn draw_poly_lines(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        sides: i32,
+        radius: f32,
+        rotation: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPolyLines(center.into(), sides, radius, rotation, color.into());
         }
+    }
 
-        /// Draws a sphere with extended parameters.
-        #[inline]
-        fn draw_sphere_ex(
-            &mut self,
-            center_pos: impl Into<ffi::Vector3>,
-            radius: f32,
-            rings: i32,
-            slices: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSphereEx(center_pos.into(), radius, rings, slices, color.into());
-            }
+    /// Draws a `texture` using specified position and `tint` color.
+    #[inline]
+    fn draw_texture(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        x: i32,
+        y: i32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTexture(*texture.as_ref(), x, y, tint.into());
         }
+    }
 
-        /// Draws a sphere in wireframe.
-        #[inline]
-        fn draw_sphere_wires(
-            &mut self,
-            center_pos: impl Into<ffi::Vector3>,
-            radius: f32,
-            rings: i32,
-            slices: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawSphereWires(center_pos.into(), radius, rings, slices, color.into());
-            }
+    /// Draws a `texture` using specified `position` vector and `tint` color.
+    #[inline]
+    fn draw_texture_v(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        position: impl Into<ffi::Vector2>,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextureV(*texture.as_ref(), position.into(), tint.into());
         }
+    }
 
-        /// Draws a cylinder.
-        #[inline]
-        fn draw_cylinder(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            radius_top: f32,
-            radius_bottom: f32,
-            height: f32,
-            slices: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCylinder(
-                    position.into(),
-                    radius_top,
-                    radius_bottom,
-                    height,
-                    slices,
-                    color.into(),
-                );
-            }
+    /// Draws a `texture` with extended parameters.
+    #[inline]
+    fn draw_texture_ex(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        position: impl Into<ffi::Vector2>,
+        rotation: f32,
+        scale: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextureEx(
+                *texture.as_ref(),
+                position.into(),
+                rotation,
+                scale,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a cylinder with extended parameters.
-        #[inline]
-        fn draw_cylinder_ex(
-            &mut self,
-            start_position: impl Into<ffi::Vector3>,
-            end_position: impl Into<ffi::Vector3>,
-            radius_start: f32,
-            radius_end: f32,
-            slices: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCylinderEx(
-                    start_position.into(),
-                    end_position.into(),
-                    radius_start,
-                    radius_end,
-                    slices,
-                    color.into(),
-                );
-            }
+    /// Draws from a region of `texture` defined by the `source_rec` rectangle.
+    #[inline]
+    fn draw_texture_rec(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        source_rec: impl Into<ffi::Rectangle>,
+        position: impl Into<ffi::Vector2>,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextureRec(
+                *texture.as_ref(),
+                source_rec.into(),
+                position.into(),
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a cylinder in wireframe.
-        #[inline]
-        fn draw_cylinder_wires(
-            &mut self,
-            position: impl Into<ffi::Vector3>,
-            radius_top: f32,
-            radius_bottom: f32,
-            height: f32,
-            slices: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCylinderWires(
-                    position.into(),
-                    radius_top,
-                    radius_bottom,
-                    height,
-                    slices,
-                    color.into(),
-                );
-            }
+    /// Draw from a region of `texture` defined by the `source_rec` rectangle with pro parameters.
+    #[inline]
+    fn draw_texture_pro(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        source_rec: impl Into<ffi::Rectangle>,
+        dest_rec: impl Into<ffi::Rectangle>,
+        origin: impl Into<ffi::Vector2>,
+        rotation: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTexturePro(
+                *texture.as_ref(),
+                source_rec.into(),
+                dest_rec.into(),
+                origin.into(),
+                rotation,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a cylinder in wireframe with extended parameters.
-        #[inline]
-        fn draw_cylinder_wires_ex(
-            &mut self,
-            start_position: impl Into<ffi::Vector3>,
-            end_position: impl Into<ffi::Vector3>,
-            radius_start: f32,
-            radius_end: f32,
-            slices: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCylinderWiresEx(
-                    start_position.into(),
-                    end_position.into(),
-                    radius_start,
-                    radius_end,
-                    slices,
-                    color.into(),
-                );
-            }
+    /// Draws a texture (or part of it) that stretches or shrinks nicely
+    #[inline]
+    fn draw_texture_n_patch(
+        &mut self,
+        texture: impl AsRef<ffi::Texture2D>,
+        n_patch_info: impl Into<ffi::NPatchInfo>,
+        dest_rec: impl Into<ffi::Rectangle>,
+        origin: impl Into<ffi::Vector2>,
+        rotation: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextureNPatch(
+                *texture.as_ref(),
+                n_patch_info.into(),
+                dest_rec.into(),
+                origin.into(),
+                rotation,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draw capsule with the center of its sphere caps at startPos and endPos
-        #[inline]
-        fn draw_capsule(
-            &mut self,
-            start_pos: impl Into<ffi::Vector3>,
-            end_pos: impl Into<ffi::Vector3>,
-            radius: f32,
-            slices: i32,
-            rings: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCapsule(
-                    start_pos.into(),
-                    end_pos.into(),
-                    radius,
-                    slices,
-                    rings,
-                    color.into(),
-                );
-            }
+    /// Shows current FPS.
+    #[inline]
+    fn draw_fps(&mut self, x: i32, y: i32) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawFPS(x, y);
         }
+    }
 
-        ///Draw capsule wireframe with the center of its sphere caps at startPos and endPos
-        #[inline]
-        fn draw_capsule_wires(
-            &mut self,
-            start_pos: impl Into<ffi::Vector3>,
-            end_pos: impl Into<ffi::Vector3>,
-            radius: f32,
-            slices: i32,
-            rings: i32,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawCapsuleWires(
-                    start_pos.into(),
-                    end_pos.into(),
-                    radius,
-                    slices,
-                    rings,
-                    color.into(),
-                );
-            }
+    /// Draws text (using default font).
+    /// This does not support UTF-8. Use `[RaylibDrawHandle::draw_text_codepoints]` for that.
+    #[inline]
+    fn draw_text(
+        &mut self,
+        text: &str,
+        x: i32,
+        y: i32,
+        font_size: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawText(c_text.as_ptr(), x, y, font_size, color.into());
         }
+    }
 
-        /// Draws an X/Z plane.
-        #[inline]
-        fn draw_plane(
-            &mut self,
-            center_pos: impl Into<ffi::Vector3>,
-            size: impl Into<ffi::Vector2>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawPlane(center_pos.into(), size.into(), color.into());
-            }
+    /// Draws text (using default font) with support for UTF-8.
+    /// If you do not need UTF-8, use `[RaylibDrawHandle::draw_text]`.
+    fn draw_text_codepoints(
+        &mut self,
+        font: impl AsRef<ffi::Font>,
+        text: &str,
+        position: impl Into<ffi::Vector2>,
+        font_size: f32,
+        spacing: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+        let mut len = 0;
+        // SAFETY: Implementor must uphold trait safety contract.
+        let u = unsafe { ffi::LoadCodepoints(c_text.as_ptr(), &raw mut len) };
+
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextCodepoints(
+                *font.as_ref(),
+                u,
+                text.len()
+                    .try_into()
+                    .expect("text should not exceed i32::MAX elements"),
+                position.into(),
+                font_size,
+                spacing,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a ray line.
-        #[inline]
-        fn draw_ray(&mut self, ray: impl Into<ffi::Ray>, color: impl Into<ffi::Color>) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawRay(ray.into(), color.into());
-            }
+    /// Draws text using `font` and additional parameters.
+    #[inline]
+    fn draw_text_ex(
+        &mut self,
+        font: impl AsRef<ffi::Font>,
+        text: &str,
+        position: impl Into<ffi::Vector2>,
+        font_size: f32,
+        spacing: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextEx(
+                *font.as_ref(),
+                c_text.as_ptr(),
+                position.into(),
+                font_size,
+                spacing,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a grid (centered at (0, 0, 0)).
-        #[inline]
-        fn draw_grid(&mut self, slices: i32, spacing: f32) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawGrid(slices, spacing);
-            }
+    /// Draw text using Font and pro parameters (rotation)
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+    #[inline]
+    fn draw_text_pro(
+        &mut self,
+        font: impl AsRef<ffi::Font>,
+        text: &str,
+        position: impl Into<ffi::Vector2>,
+        origin: impl Into<ffi::Vector2>,
+        rotation: f32,
+        font_size: f32,
+        spacing: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextPro(
+                *font.as_ref(),
+                c_text.as_ptr(),
+                position.into(),
+                origin.into(),
+                rotation,
+                font_size,
+                spacing,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a model (with texture if set).
-        #[inline]
-        fn draw_model(
-            &mut self,
-            model: impl AsRef<ffi::Model>,
-            position: impl Into<ffi::Vector3>,
-            scale: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawModel(*model.as_ref(), position.into(), scale, tint.into());
-            }
+    /// Draw one character (codepoint)
+    #[inline]
+    fn draw_text_codepoint(
+        &mut self,
+        font: impl AsRef<ffi::Font>,
+        codepoint: i32,
+        position: impl Into<ffi::Vector2>,
+        scale: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTextCodepoint(
+                *font.as_ref(),
+                codepoint,
+                position.into(),
+                scale,
+                tint.into(),
+            );
         }
+    }
 
-        /// Draws a model with extended parameters.
-        #[inline]
-        fn draw_model_ex(
-            &mut self,
-            model: impl AsRef<ffi::Model>,
-            position: impl Into<ffi::Vector3>,
-            rotation_axis: impl Into<ffi::Vector3>,
-            rotation_angle: f32,
-            scale: impl Into<ffi::Vector3>,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawModelEx(
-                    *model.as_ref(),
-                    position.into(),
-                    rotation_axis.into(),
-                    rotation_angle,
-                    scale.into(),
-                    tint.into(),
-                );
-            }
+    /// Enable waiting for events when the handle is dropped, no automatic event polling
+    #[inline]
+    fn enable_event_waiting(&self) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::EnableEventWaiting() }
+    }
+
+    /// Disable waiting for events when the handle is dropped, no automatic event polling
+    #[inline]
+    fn disable_event_waiting(&self) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::DisableEventWaiting() }
+    }
+
+    /// Draw a polygon outline of n sides with extended parameters
+    #[inline]
+    fn draw_poly_lines_ex(
+        &mut self,
+        center: impl Into<ffi::Vector2>,
+        sides: i32,
+        radius: f32,
+        rotation: f32,
+        line_thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPolyLinesEx(
+                center.into(),
+                sides,
+                radius,
+                rotation,
+                line_thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draws a model with wires (with texture if set).
-        #[inline]
-        fn draw_model_wires(
-            &mut self,
-            model: impl AsRef<ffi::Model>,
-            position: impl Into<ffi::Vector3>,
-            scale: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawModelWires(*model.as_ref(), position.into(), scale, tint.into());
-            }
+    /// Draw spline: Linear, minimum 2 points
+    #[inline]
+    fn draw_spline_linear(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineLinear(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draws a model with wires.
-        #[inline]
-        fn draw_model_wires_ex(
-            &mut self,
-            model: impl AsRef<ffi::Model>,
-            position: impl Into<ffi::Vector3>,
-            rotation_axis: impl Into<ffi::Vector3>,
-            rotation_angle: f32,
-            scale: impl Into<ffi::Vector3>,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawModelWiresEx(
-                    *model.as_ref(),
-                    position.into(),
-                    rotation_axis.into(),
-                    rotation_angle,
-                    scale.into(),
-                    tint.into(),
-                );
-            }
+    /// Draw spline: B-Spline, minimum 4 points
+    #[inline]
+    fn draw_spline_basis(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineBasis(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draws a bounding box (wires).
-        #[inline]
-        fn draw_bounding_box(
-            &mut self,
-            bbox: impl Into<ffi::BoundingBox>,
-            color: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawBoundingBox(bbox.into(), color.into());
-            }
+    /// Draw spline: Catmull-Rom, minimum 4 points
+    #[inline]
+    fn draw_spline_catmull_rom(
+        &mut self,
+        points: &[Vector2],
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineCatmullRom(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draws a billboard texture.
-        #[inline]
-        fn draw_billboard(
-            &mut self,
-            camera: impl Into<ffi::Camera3D>,
-            texture: &Texture2D,
-            center: impl Into<ffi::Vector3>,
-            size: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawBillboard(camera.into(), texture.0, center.into(), size, tint.into());
-            }
+    /// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
+    #[inline]
+    fn draw_spline_bezier_quadratic(
+        &mut self,
+        points: &[Vector2],
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineBezierQuadratic(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draws a billboard texture defined by `source_rec`.
-        #[inline]
-        fn draw_billboard_rec(
-            &mut self,
-            camera: impl Into<ffi::Camera3D>,
-            texture: &Texture2D,
-            source_rec: impl Into<ffi::Rectangle>,
-            center: impl Into<ffi::Vector3>,
-            size: impl Into<ffi::Vector2>,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawBillboardRec(
-                    camera.into(),
-                    texture.0,
-                    source_rec.into(),
-                    center.into(),
-                    size.into(),
-                    tint.into(),
-                );
-            }
+    /// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
+    #[inline]
+    fn draw_spline_bezier_cubic(
+        &mut self,
+        points: &[Vector2],
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineBezierCubic(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draw a billboard texture defined by source and rotation
-        #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
-        #[inline]
-        fn draw_billboard_pro(
-            &mut self,
-            camera: impl Into<ffi::Camera>,
-            texture: impl Into<ffi::Texture2D>,
-            source: impl Into<ffi::Rectangle>,
-            position: impl Into<ffi::Vector3>,
-            up: impl Into<ffi::Vector3>,
-            size: impl Into<ffi::Vector2>,
-            origin: impl Into<ffi::Vector2>,
-            rotation: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawBillboardPro(
-                    camera.into(),
-                    texture.into(),
-                    source.into(),
-                    position.into(),
-                    up.into(),
-                    size.into(),
-                    origin.into(),
-                    rotation,
-                    tint.into(),
-                );
-            }
+    /// Draw spline segment: Linear, 2 points
+    #[inline]
+    fn draw_spline_segment_linear(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::DrawSplineSegmentLinear(p1.into(), p2.into(), thick, color.into()) }
+    }
+
+    /// Draw spline segment: B-Spline, 4 points
+    #[inline]
+    fn draw_spline_segment_basis(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineSegmentBasis(
+                p1.into(),
+                p2.into(),
+                p3.into(),
+                p4.into(),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draw a model as points
-        #[inline]
-        fn draw_model_points(
-            &mut self,
-            model: impl Into<ffi::Model>,
-            position: impl Into<ffi::Vector3>,
-            scale: f32,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawModelPoints(model.into(), position.into(), scale, tint.into());
-            }
+    /// Draw spline segment: Catmull-Rom, 4 points
+    #[inline]
+    fn draw_spline_segment_catmull_rom(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineSegmentCatmullRom(
+                p1.into(),
+                p2.into(),
+                p3.into(),
+                p4.into(),
+                thick,
+                color.into(),
+            );
         }
+    }
 
-        /// Draw a model as points with extended parameters
-        #[inline]
-        fn draw_model_points_ex(
-            &mut self,
-            model: impl Into<ffi::Model>,
-            position: impl Into<ffi::Vector3>,
-            rotation_axis: impl Into<ffi::Vector3>,
-            angle: f32,
-            scale: impl Into<ffi::Vector3>,
-            tint: impl Into<ffi::Color>,
-        ) {
-            // SAFETY: Implementor must uphold trait safety contract.
-            unsafe {
-                ffi::DrawModelPointsEx(
-                    model.into(),
-                    position.into(),
-                    rotation_axis.into(),
-                    angle,
-                    scale.into(),
-                    tint.into(),
-                );
-            }
+    /// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
+    #[inline]
+    fn draw_spline_segment_bezier_quadratic(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineSegmentBezierQuadratic(
+                p1.into(),
+                c2.into(),
+                p3.into(),
+                thick,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draw spline segment: Cubic Bezier, 2 points, 2 control points
+    #[inline]
+    fn draw_spline_segment_bezier_cubic(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        c3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
+        thick: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSplineSegmentBezierCubic(
+                p1.into(),
+                c2.into(),
+                c3.into(),
+                p4.into(),
+                thick,
+                color.into(),
+            );
+        }
+    }
+
+    /// Get (evaluate) spline point: Linear
+    #[inline]
+    #[must_use]
+    fn get_spline_point_linear(
+        &mut self,
+        start_pos: impl Into<ffi::Vector2>,
+        end_pos: impl Into<ffi::Vector2>,
+        t: f32,
+    ) -> Vector2 {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::GetSplinePointLinear(start_pos.into(), end_pos.into(), t).into() }
+    }
+
+    /// Get (evaluate) spline point: B-Spline
+    #[inline]
+    #[must_use]
+    fn get_spline_point_basis(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
+        t: f32,
+    ) -> Vector2 {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::GetSplinePointBasis(p1.into(), p2.into(), p3.into(), p4.into(), t).into() }
+    }
+
+    /// Get (evaluate) spline point: Catmull-Rom
+    #[inline]
+    #[must_use]
+    fn get_spline_point_catmull_rom(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        p2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
+        t: f32,
+    ) -> Vector2 {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::GetSplinePointCatmullRom(p1.into(), p2.into(), p3.into(), p4.into(), t).into()
+        }
+    }
+
+    /// Get (evaluate) spline point: Quadratic Bezier
+    #[inline]
+    #[must_use]
+    fn get_spline_point_bezier_quad(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        p3: impl Into<ffi::Vector2>,
+        t: f32,
+    ) -> Vector2 {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::GetSplinePointBezierQuad(p1.into(), c2.into(), p3.into(), t).into() }
+    }
+
+    /// Get (evaluate) spline point: Cubic Bezier
+    #[inline]
+    #[must_use]
+    fn get_spline_point_bezier_cubic(
+        &mut self,
+        p1: impl Into<ffi::Vector2>,
+        c2: impl Into<ffi::Vector2>,
+        c3: impl Into<ffi::Vector2>,
+        p4: impl Into<ffi::Vector2>,
+        t: f32,
+    ) -> Vector2 {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::GetSplinePointBezierCubic(p1.into(), c2.into(), c3.into(), p4.into(), t).into()
         }
     }
 }
-pub use sealed::{RaylibDraw, RaylibDraw3D};
+
+/// Types through which it is safe to call 3D Raylib drawing functions.
+///
+/// # Safety
+///
+/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+/// and expect for there to be a window, buffer, & projection matrix to target--all without any checks.
+///
+/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+/// [`ffi::BeginMode3D`] has been called this frame without the corresponding [`ffi::EndMode3D`] having been called yet.
+pub unsafe trait RaylibDraw3D {
+    /// Draw a point in 3D space, actually a small line
+    #[allow(non_snake_case, reason = "consistent style")]
+    #[inline]
+    fn draw_point3D(&mut self, position: impl Into<ffi::Vector3>, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPoint3D(position.into(), color.into());
+        }
+    }
+
+    /// Draw a color-filled triangle (vertex in counter-clockwise order!)
+    #[allow(non_snake_case, reason = "consistent style")]
+    #[inline]
+    fn draw_triangle3D(
+        &mut self,
+        v1: impl Into<ffi::Vector3>,
+        v2: impl Into<ffi::Vector3>,
+        v3: impl Into<ffi::Vector3>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTriangle3D(v1.into(), v2.into(), v3.into(), color.into());
+        }
+    }
+
+    /// Draw a triangle strip defined by points
+    #[allow(non_snake_case, reason = "consistent style")]
+    #[inline]
+    fn draw_triangle_strip3D(&mut self, points: &[Vector3], color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawTriangleStrip3D(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a line in 3D world space.
+    #[allow(non_snake_case, reason = "consistent style")]
+    #[inline]
+    fn draw_line3D(
+        &mut self,
+        start_pos: impl Into<ffi::Vector3>,
+        end_pos: impl Into<ffi::Vector3>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawLine3D(start_pos.into(), end_pos.into(), color.into());
+        }
+    }
+
+    /// Draws a circle in 3D world space.
+    #[allow(non_snake_case, reason = "consistent style")]
+    #[inline]
+    fn draw_circle3D(
+        &mut self,
+        center: impl Into<ffi::Vector3>,
+        radius: f32,
+        rotation_axis: impl Into<ffi::Vector3>,
+        rotation_angle: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCircle3D(
+                center.into(),
+                radius,
+                rotation_axis.into(),
+                rotation_angle,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a cube.
+    #[inline]
+    fn draw_cube(
+        &mut self,
+        position: impl Into<ffi::Vector3>,
+        width: f32,
+        height: f32,
+        length: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCube(position.into(), width, height, length, color.into());
+        }
+    }
+
+    /// Draws a cube (Vector version).
+    #[inline]
+    fn draw_cube_v(
+        &mut self,
+        position: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector3>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCubeV(position.into(), size.into(), color.into());
+        }
+    }
+
+    /// Draws a cube in wireframe.
+    #[inline]
+    fn draw_cube_wires(
+        &mut self,
+        position: impl Into<ffi::Vector3>,
+        width: f32,
+        height: f32,
+        length: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCubeWires(position.into(), width, height, length, color.into());
+        }
+    }
+
+    /// Draws a cube in wireframe. (Vector Version)
+    #[inline]
+    fn draw_cube_wires_v(
+        &mut self,
+        position: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector3>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCubeWiresV(position.into(), size.into(), color.into());
+        }
+    }
+
+    /// Draw a 3d mesh with material and transform
+    #[inline]
+    fn draw_mesh(
+        &mut self,
+        mesh: impl AsRef<ffi::Mesh>,
+        material: WeakMaterial,
+        transform: impl Into<ffi::Matrix>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe { ffi::DrawMesh(*mesh.as_ref(), material.0, transform.into()) }
+    }
+
+    /// Draw multiple mesh instances with material and different transforms
+    #[inline]
+    fn draw_mesh_instanced(
+        &mut self,
+        mesh: impl AsRef<ffi::Mesh>,
+        material: WeakMaterial,
+        transforms: &[Matrix],
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawMeshInstanced(
+                *mesh.as_ref(),
+                material.0,
+                transforms.as_ptr().cast(),
+                transforms
+                    .len()
+                    .try_into()
+                    .expect("transforms should not exceed i32::MAX elements"),
+            );
+        }
+    }
+
+    /// Draws a sphere.
+    #[inline]
+    fn draw_sphere(
+        &mut self,
+        center_pos: impl Into<ffi::Vector3>,
+        radius: f32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSphere(center_pos.into(), radius, color.into());
+        }
+    }
+
+    /// Draws a sphere with extended parameters.
+    #[inline]
+    fn draw_sphere_ex(
+        &mut self,
+        center_pos: impl Into<ffi::Vector3>,
+        radius: f32,
+        rings: i32,
+        slices: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSphereEx(center_pos.into(), radius, rings, slices, color.into());
+        }
+    }
+
+    /// Draws a sphere in wireframe.
+    #[inline]
+    fn draw_sphere_wires(
+        &mut self,
+        center_pos: impl Into<ffi::Vector3>,
+        radius: f32,
+        rings: i32,
+        slices: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawSphereWires(center_pos.into(), radius, rings, slices, color.into());
+        }
+    }
+
+    /// Draws a cylinder.
+    #[inline]
+    fn draw_cylinder(
+        &mut self,
+        position: impl Into<ffi::Vector3>,
+        radius_top: f32,
+        radius_bottom: f32,
+        height: f32,
+        slices: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCylinder(
+                position.into(),
+                radius_top,
+                radius_bottom,
+                height,
+                slices,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a cylinder with extended parameters.
+    #[inline]
+    fn draw_cylinder_ex(
+        &mut self,
+        start_position: impl Into<ffi::Vector3>,
+        end_position: impl Into<ffi::Vector3>,
+        radius_start: f32,
+        radius_end: f32,
+        slices: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCylinderEx(
+                start_position.into(),
+                end_position.into(),
+                radius_start,
+                radius_end,
+                slices,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a cylinder in wireframe.
+    #[inline]
+    fn draw_cylinder_wires(
+        &mut self,
+        position: impl Into<ffi::Vector3>,
+        radius_top: f32,
+        radius_bottom: f32,
+        height: f32,
+        slices: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCylinderWires(
+                position.into(),
+                radius_top,
+                radius_bottom,
+                height,
+                slices,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws a cylinder in wireframe with extended parameters.
+    #[inline]
+    fn draw_cylinder_wires_ex(
+        &mut self,
+        start_position: impl Into<ffi::Vector3>,
+        end_position: impl Into<ffi::Vector3>,
+        radius_start: f32,
+        radius_end: f32,
+        slices: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCylinderWiresEx(
+                start_position.into(),
+                end_position.into(),
+                radius_start,
+                radius_end,
+                slices,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draw capsule with the center of its sphere caps at startPos and endPos
+    #[inline]
+    fn draw_capsule(
+        &mut self,
+        start_pos: impl Into<ffi::Vector3>,
+        end_pos: impl Into<ffi::Vector3>,
+        radius: f32,
+        slices: i32,
+        rings: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCapsule(
+                start_pos.into(),
+                end_pos.into(),
+                radius,
+                slices,
+                rings,
+                color.into(),
+            );
+        }
+    }
+
+    ///Draw capsule wireframe with the center of its sphere caps at startPos and endPos
+    #[inline]
+    fn draw_capsule_wires(
+        &mut self,
+        start_pos: impl Into<ffi::Vector3>,
+        end_pos: impl Into<ffi::Vector3>,
+        radius: f32,
+        slices: i32,
+        rings: i32,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawCapsuleWires(
+                start_pos.into(),
+                end_pos.into(),
+                radius,
+                slices,
+                rings,
+                color.into(),
+            );
+        }
+    }
+
+    /// Draws an X/Z plane.
+    #[inline]
+    fn draw_plane(
+        &mut self,
+        center_pos: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector2>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawPlane(center_pos.into(), size.into(), color.into());
+        }
+    }
+
+    /// Draws a ray line.
+    #[inline]
+    fn draw_ray(&mut self, ray: impl Into<ffi::Ray>, color: impl Into<ffi::Color>) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawRay(ray.into(), color.into());
+        }
+    }
+
+    /// Draws a grid (centered at (0, 0, 0)).
+    #[inline]
+    fn draw_grid(&mut self, slices: i32, spacing: f32) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawGrid(slices, spacing);
+        }
+    }
+
+    /// Draws a model (with texture if set).
+    #[inline]
+    fn draw_model(
+        &mut self,
+        model: impl AsRef<ffi::Model>,
+        position: impl Into<ffi::Vector3>,
+        scale: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawModel(*model.as_ref(), position.into(), scale, tint.into());
+        }
+    }
+
+    /// Draws a model with extended parameters.
+    #[inline]
+    fn draw_model_ex(
+        &mut self,
+        model: impl AsRef<ffi::Model>,
+        position: impl Into<ffi::Vector3>,
+        rotation_axis: impl Into<ffi::Vector3>,
+        rotation_angle: f32,
+        scale: impl Into<ffi::Vector3>,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawModelEx(
+                *model.as_ref(),
+                position.into(),
+                rotation_axis.into(),
+                rotation_angle,
+                scale.into(),
+                tint.into(),
+            );
+        }
+    }
+
+    /// Draws a model with wires (with texture if set).
+    #[inline]
+    fn draw_model_wires(
+        &mut self,
+        model: impl AsRef<ffi::Model>,
+        position: impl Into<ffi::Vector3>,
+        scale: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawModelWires(*model.as_ref(), position.into(), scale, tint.into());
+        }
+    }
+
+    /// Draws a model with wires.
+    #[inline]
+    fn draw_model_wires_ex(
+        &mut self,
+        model: impl AsRef<ffi::Model>,
+        position: impl Into<ffi::Vector3>,
+        rotation_axis: impl Into<ffi::Vector3>,
+        rotation_angle: f32,
+        scale: impl Into<ffi::Vector3>,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawModelWiresEx(
+                *model.as_ref(),
+                position.into(),
+                rotation_axis.into(),
+                rotation_angle,
+                scale.into(),
+                tint.into(),
+            );
+        }
+    }
+
+    /// Draws a bounding box (wires).
+    #[inline]
+    fn draw_bounding_box(
+        &mut self,
+        bbox: impl Into<ffi::BoundingBox>,
+        color: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawBoundingBox(bbox.into(), color.into());
+        }
+    }
+
+    /// Draws a billboard texture.
+    #[inline]
+    fn draw_billboard(
+        &mut self,
+        camera: impl Into<ffi::Camera3D>,
+        texture: &Texture2D,
+        center: impl Into<ffi::Vector3>,
+        size: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawBillboard(camera.into(), texture.0, center.into(), size, tint.into());
+        }
+    }
+
+    /// Draws a billboard texture defined by `source_rec`.
+    #[inline]
+    fn draw_billboard_rec(
+        &mut self,
+        camera: impl Into<ffi::Camera3D>,
+        texture: &Texture2D,
+        source_rec: impl Into<ffi::Rectangle>,
+        center: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector2>,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawBillboardRec(
+                camera.into(),
+                texture.0,
+                source_rec.into(),
+                center.into(),
+                size.into(),
+                tint.into(),
+            );
+        }
+    }
+
+    /// Draw a billboard texture defined by source and rotation
+    #[allow(clippy::too_many_arguments, reason = "consistency with Raylib")]
+    #[inline]
+    fn draw_billboard_pro(
+        &mut self,
+        camera: impl Into<ffi::Camera>,
+        texture: impl Into<ffi::Texture2D>,
+        source: impl Into<ffi::Rectangle>,
+        position: impl Into<ffi::Vector3>,
+        up: impl Into<ffi::Vector3>,
+        size: impl Into<ffi::Vector2>,
+        origin: impl Into<ffi::Vector2>,
+        rotation: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawBillboardPro(
+                camera.into(),
+                texture.into(),
+                source.into(),
+                position.into(),
+                up.into(),
+                size.into(),
+                origin.into(),
+                rotation,
+                tint.into(),
+            );
+        }
+    }
+
+    /// Draw a model as points
+    #[inline]
+    fn draw_model_points(
+        &mut self,
+        model: impl Into<ffi::Model>,
+        position: impl Into<ffi::Vector3>,
+        scale: f32,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawModelPoints(model.into(), position.into(), scale, tint.into());
+        }
+    }
+
+    /// Draw a model as points with extended parameters
+    #[inline]
+    fn draw_model_points_ex(
+        &mut self,
+        model: impl Into<ffi::Model>,
+        position: impl Into<ffi::Vector3>,
+        rotation_axis: impl Into<ffi::Vector3>,
+        angle: f32,
+        scale: impl Into<ffi::Vector3>,
+        tint: impl Into<ffi::Color>,
+    ) {
+        // SAFETY: Implementor must uphold trait safety contract.
+        unsafe {
+            ffi::DrawModelPointsEx(
+                model.into(),
+                position.into(),
+                rotation_axis.into(),
+                angle,
+                scale.into(),
+                tint.into(),
+            );
+        }
+    }
+}

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -1,34 +1,27 @@
 //! Contains code related to drawing. Types that can be set as a surface to draw will implement the [`RaylibDraw`] trait
 
-use raylib_sys::Rectangle;
-
-use crate::core::texture::Texture2D;
-use crate::core::vr::VrStereoConfig;
-use crate::core::{RaylibHandle, RaylibThread};
-use crate::math::Matrix;
-use crate::math::Vector2;
-use crate::math::Vector3;
-use crate::models::WeakMaterial;
-use crate::{MintMatrix, MintVec2};
-use crate::{MintVec3, ffi};
-use std::ffi::CString;
-use std::{convert::AsRef, marker::PhantomData};
-
-use super::shaders::Shader;
+use crate::{
+    MintVec2, MintVec3,
+    core::{RaylibHandle, RaylibThread, texture::Texture2D, vr::VrStereoConfig},
+    ffi,
+    math::{Matrix, Rectangle, Vector2, Vector3},
+    models::WeakMaterial,
+    shaders::Shader,
+};
+use std::{convert::AsRef, ffi::CString, marker::PhantomData};
 
 /// Seems like all draw commands must be issued from the main thread
 impl RaylibHandle {
     #[inline]
     #[must_use]
     /// Setup canvas (framebuffer) to start drawing.
-    /// Prefer using the closure version, [RaylibHandle::draw]. This version returns a handle that calls [raylib_sys::EndDrawing] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    /// Prefer using the closure version, [`RaylibHandle::draw`]. This version returns a handle that calls [`ffi::EndDrawing`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     pub fn begin_drawing<'a>(&'a mut self, _: &RaylibThread) -> RaylibDrawHandle<'a> {
         unsafe {
             ffi::BeginDrawing();
         };
 
-        let d = RaylibDrawHandle(self);
-        d
+        RaylibDrawHandle(self)
     }
     /// Setup canvas (framebuffer) to start drawing.
     // Every FnMut is a FnOnce, but not every FnOnce is a FnMut. The closure may possibly execute multiple times throughout the program, but not multiple times in a single call to this method.
@@ -47,10 +40,10 @@ impl RaylibHandle {
 
 pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle);
 
-impl<'a> RaylibDrawHandle<'a> {
+impl RaylibDrawHandle<'_> {
     #[deprecated = "Calling begin_drawing within RaylibDrawHandle will result in a runtime error."]
     #[doc(hidden)]
-    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle {
+    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle<'_> {
         panic!("Nested begin_drawing call")
     }
     #[deprecated = "Calling draw within RaylibDrawHandle will result in a runtime error."]
@@ -60,7 +53,7 @@ impl<'a> RaylibDrawHandle<'a> {
     }
 }
 
-impl<'a> Drop for RaylibDrawHandle<'a> {
+impl Drop for RaylibDrawHandle<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::EndDrawing();
@@ -68,20 +61,20 @@ impl<'a> Drop for RaylibDrawHandle<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for RaylibDrawHandle<'a> {
+impl std::ops::Deref for RaylibDrawHandle<'_> {
     type Target = RaylibHandle;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 
-impl<'a> std::ops::DerefMut for RaylibDrawHandle<'a> {
+impl std::ops::DerefMut for RaylibDrawHandle<'_> {
     fn deref_mut(&mut self) -> &mut RaylibHandle {
         self.0
     }
 }
-impl<'a> RaylibDraw for RaylibDrawHandle<'a> {}
+impl RaylibDraw for RaylibDrawHandle<'_> {}
 
 // Texture2D Stuff
 
@@ -93,19 +86,19 @@ impl<'a> RaylibDraw for RaylibDrawHandle<'a> {}
 // The PhantomData will ensure that the borrow checker still analyzes as though the mutable texture reference was held, without physically storing it in the runtime memory.
 pub struct RaylibTextureMode<'a, 'b, T: 'a>(&'a mut T, PhantomData<&'b mut ffi::RenderTexture2D>);
 
-impl<'a, 'b, T: 'a> Drop for RaylibTextureMode<'a, 'b, T> {
+impl<'a, T: 'a> Drop for RaylibTextureMode<'a, '_, T> {
     fn drop(&mut self) {
         unsafe { ffi::EndTextureMode() }
     }
 }
-impl<'a, 'b, T: 'a> std::ops::Deref for RaylibTextureMode<'a, 'b, T> {
+impl<'a, T: 'a> std::ops::Deref for RaylibTextureMode<'a, '_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
-impl<'a, 'b, T: 'a> std::ops::DerefMut for RaylibTextureMode<'a, 'b, T> {
+impl<'a, T: 'a> std::ops::DerefMut for RaylibTextureMode<'a, '_, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
@@ -117,7 +110,9 @@ where
     Self: Sized,
 {
     /// Begin drawing to render texture.
-    /// Prefer using the closure version, [RaylibTextureModeExt::draw_texture_mode] . This version returns a handle that calls [raylib_sys::EndTextureMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibTextureModeExt::draw_texture_mode`].
+    /// This version returns a handle that calls [`ffi::EndTextureMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[inline]
     #[must_use]
     fn begin_texture_mode<'a, 'b>(
@@ -144,9 +139,9 @@ where
 }
 
 // Only the DrawHandle and the RaylibHandle can start a texture
-impl<'a> RaylibTextureModeExt for RaylibDrawHandle<'a> {}
+impl RaylibTextureModeExt for RaylibDrawHandle<'_> {}
 impl RaylibTextureModeExt for RaylibHandle {}
-impl<'a, 'b, T: 'a> RaylibDraw for RaylibTextureMode<'a, 'b, T> {}
+impl<'a, T: 'a> RaylibDraw for RaylibTextureMode<'a, '_, T> {}
 
 // VR Stuff
 
@@ -156,16 +151,16 @@ pub struct RaylibVRMode<'a, 'b, T: 'a>(
     PhantomData<&'a mut T>,
     PhantomData<&'b mut VrStereoConfig>,
 );
-impl<'a, 'b, T: 'a> Drop for RaylibVRMode<'a, 'b, T> {
+impl<'a, T: 'a> Drop for RaylibVRMode<'a, '_, T> {
     fn drop(&mut self) {
         unsafe { ffi::EndVrStereoMode() }
     }
 }
-impl<'a, 'b, T: 'a> std::ops::Deref for RaylibVRMode<'a, 'b, T> {
+impl<'a, T: 'a> std::ops::Deref for RaylibVRMode<'a, '_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 
@@ -174,7 +169,9 @@ where
     Self: Sized,
 {
     /// Begin stereo rendering (requires VR simulator).
-    /// Prefer using the closure version, [RaylibVRModeExt::draw_vr_stereo_mode] . This version returns a handle that calls [raylib_sys::EndVrStereoMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibVRModeExt::draw_vr_stereo_mode`].
+    /// This version returns a handle that calls [`ffi::EndVrStereoMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[inline]
     #[must_use]
     fn begin_vr_stereo_mode<'a, 'b>(
@@ -200,7 +197,7 @@ where
 }
 
 impl<D: RaylibDraw> RaylibVRModeExt for D {}
-impl<'a, 'b, T: 'a> RaylibDraw for RaylibVRMode<'a, 'b, T> {}
+impl<'a, T: 'a> RaylibDraw for RaylibVRMode<'a, '_, T> {}
 
 // 2D Mode
 
@@ -214,7 +211,7 @@ impl<'a, T: 'a> std::ops::Deref for RaylibMode2D<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibMode2D<'a, T> {
@@ -228,7 +225,9 @@ where
     Self: Sized,
 {
     /// Begin 2D mode with custom camera (2D).
-    /// Prefer using the closure version, [RaylibMode2DExt::draw_mode2D]. This version returns a handle that calls [raylib_sys::EndMode2D] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibMode2DExt::draw_mode2D`].
+    /// This version returns a handle that calls [`ffi::EndMode2D`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[allow(non_snake_case)]
     #[inline]
     #[must_use]
@@ -272,7 +271,7 @@ impl<'a, T: 'a> std::ops::Deref for RaylibMode3D<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibMode3D<'a, T> {
@@ -286,7 +285,9 @@ where
     Self: Sized,
 {
     /// Begin 3D mode with custom camera (3D).
-    /// Prefer using the closure version, [RaylibMode3DExt::draw_mode3D]. This version returns a handle that calls [raylib_sys::EndMode3D] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibMode3DExt::draw_mode3D`].
+    /// This version returns a handle that calls [`ffi::EndMode3D`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[allow(non_snake_case)]
     #[must_use]
     #[inline]
@@ -323,19 +324,19 @@ impl<'a, T: 'a> RaylibDraw3D for RaylibMode3D<'a, T> {}
 
 pub struct RaylibShaderMode<'a, 'b, T: 'a>(&'a mut T, PhantomData<&'b mut Shader>);
 
-impl<'a, 'b, T: 'a> Drop for RaylibShaderMode<'a, 'b, T> {
+impl<'a, T: 'a> Drop for RaylibShaderMode<'a, '_, T> {
     fn drop(&mut self) {
         unsafe { ffi::EndShaderMode() }
     }
 }
-impl<'a, 'b, T: 'a> std::ops::Deref for RaylibShaderMode<'a, 'b, T> {
+impl<'a, T: 'a> std::ops::Deref for RaylibShaderMode<'a, '_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
-impl<'a, 'b, T: 'a> std::ops::DerefMut for RaylibShaderMode<'a, 'b, T> {
+impl<'a, T: 'a> std::ops::DerefMut for RaylibShaderMode<'a, '_, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.0
     }
@@ -346,7 +347,9 @@ where
     Self: Sized,
 {
     /// Begin custom shader drawing.
-    /// Prefer using the closure version, [RaylibShaderModeExt::draw_shader_mode]. This version returns a handle that calls [raylib_sys::EndShaderMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibShaderModeExt::draw_shader_mode`].
+    /// This version returns a handle that calls [`ffi::EndShaderMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[must_use]
     #[inline]
     fn begin_shader_mode<'a, 'b>(
@@ -371,8 +374,8 @@ where
 }
 
 impl<D: RaylibDraw> RaylibShaderModeExt for D {}
-impl<'a, 'b, T: 'a> RaylibDraw for RaylibShaderMode<'a, 'b, T> {}
-impl<'a, 'b, T: 'a> RaylibDraw3D for RaylibShaderMode<'a, 'b, T> {}
+impl<'a, T: 'a> RaylibDraw for RaylibShaderMode<'a, '_, T> {}
+impl<'a, T: 'a> RaylibDraw3D for RaylibShaderMode<'a, '_, T> {}
 
 // Blend Mode
 
@@ -386,7 +389,7 @@ impl<'a, T: 'a> std::ops::Deref for RaylibBlendMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibBlendMode<'a, T> {
@@ -400,14 +403,16 @@ where
     Self: Sized,
 {
     /// Begin blending mode (alpha, additive, multiplied, subtract, custom).
-    /// Prefer using the closure version, [RaylibBlendModeExt::draw_blend_mode]. This version returns a handle that calls [raylib_sys::EndBlendMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibBlendModeExt::draw_blend_mode`].
+    /// This version returns a handle that calls [`ffi::EndBlendMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[inline]
     #[must_use]
     fn begin_blend_mode(
         &mut self,
         blend_mode: crate::consts::BlendMode,
     ) -> RaylibBlendMode<'_, Self> {
-        unsafe { ffi::BeginBlendMode((blend_mode as u32) as i32) }
+        unsafe { ffi::BeginBlendMode(blend_mode as i32) }
         RaylibBlendMode(self)
     }
 
@@ -417,7 +422,7 @@ where
         blend_mode: crate::consts::BlendMode,
         func: impl FnOnce(RaylibBlendMode<'a, Self>),
     ) {
-        unsafe { ffi::BeginBlendMode((blend_mode as u32) as i32) }
+        unsafe { ffi::BeginBlendMode(blend_mode as i32) }
         func(RaylibBlendMode(self));
         // Uncomment the following if RaylibBlendMode has been changed to no longer call EndBlendMode() in its drop implementation:
         // unsafe { ffi::EndBlendMode(); }
@@ -440,7 +445,7 @@ impl<'a, T: 'a> std::ops::Deref for RaylibScissorMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T: 'a> std::ops::DerefMut for RaylibScissorMode<'a, T> {
@@ -454,7 +459,9 @@ where
     Self: Sized,
 {
     /// Begin scissor mode (define screen area for following drawing).
-    /// Prefer using the closure version, [RaylibScissorModeExt::draw_scissor_mode]. This version returns a handle that calls [raylib_sys::EndScissorMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
+    ///
+    /// Prefer using the closure version, [`RaylibScissorModeExt::draw_scissor_mode`].
+    /// This version returns a handle that calls [`ffi::EndScissorMode`] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[must_use]
     #[inline]
     fn begin_scissor_mode(
@@ -491,7 +498,7 @@ impl<'a, T: 'a + RaylibDraw3D> RaylibDraw3D for RaylibScissorMode<'a, T> {}
 // Actual drawing functions
 
 pub trait RaylibDraw {
-    /// Sets background color (framebuffer clear color.into()).
+    /// Sets background color (framebuffer clear `color.into()`).
     #[inline]
     fn clear_background(&mut self, color: impl Into<ffi::Color>) {
         unsafe {
@@ -606,8 +613,11 @@ pub trait RaylibDraw {
     fn draw_line_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawLineStrip(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 color.into(),
             );
         }
@@ -758,6 +768,7 @@ pub trait RaylibDraw {
     }
 
     /// Draw ring
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     fn draw_ring(
         &mut self,
@@ -783,6 +794,7 @@ pub trait RaylibDraw {
     }
 
     /// Draw ring lines
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     fn draw_ring_lines(
         &mut self,
@@ -988,8 +1000,8 @@ pub trait RaylibDraw {
                 segments,
                 line_thickness,
                 color.into(),
-            )
-        };
+            );
+        }
     }
     /// Draws a triangle.
     #[inline]
@@ -1024,8 +1036,11 @@ pub trait RaylibDraw {
     fn draw_triangle_fan(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawTriangleFan(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 color.into(),
             );
         }
@@ -1036,8 +1051,11 @@ pub trait RaylibDraw {
     fn draw_triangle_strip(&mut self, points: &[Vector2], color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawTriangleStrip(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 color.into(),
             );
         }
@@ -1205,7 +1223,7 @@ pub trait RaylibDraw {
         font_size: i32,
         color: impl Into<ffi::Color>,
     ) {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
 
         unsafe {
             ffi::DrawText(c_text.as_ptr(), x, y, font_size, color.into());
@@ -1223,21 +1241,22 @@ pub trait RaylibDraw {
         spacing: f32,
         tint: impl Into<ffi::Color>,
     ) {
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+        let mut len = 0;
+        let u = unsafe { ffi::LoadCodepoints(c_text.as_ptr(), &raw mut len) };
+
         unsafe {
-            let c_text = CString::new(text).unwrap();
-
-            let mut len = 0;
-            let u = ffi::LoadCodepoints(c_text.as_ptr(), &mut len);
-
             ffi::DrawTextCodepoints(
                 *font.as_ref(),
                 u,
-                text.len() as i32,
+                text.len()
+                    .try_into()
+                    .expect("text should not exceed i32::MAX elements"),
                 position.into(),
                 font_size,
                 spacing,
                 tint.into(),
-            )
+            );
         }
     }
     /// Draws text using `font` and additional parameters.
@@ -1251,7 +1270,7 @@ pub trait RaylibDraw {
         spacing: f32,
         tint: impl Into<ffi::Color>,
     ) {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             ffi::DrawTextEx(
                 *font.as_ref(),
@@ -1265,6 +1284,7 @@ pub trait RaylibDraw {
     }
 
     /// Draw text using Font and pro parameters (rotation)
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     fn draw_text_pro(
         &mut self,
@@ -1277,7 +1297,7 @@ pub trait RaylibDraw {
         spacing: f32,
         tint: impl Into<ffi::Color>,
     ) {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             ffi::DrawTextPro(
                 *font.as_ref(),
@@ -1352,11 +1372,14 @@ pub trait RaylibDraw {
     fn draw_spline_linear(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawSplineLinear(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
     /// Draw spline: B-Spline, minimum 4 points
@@ -1364,11 +1387,14 @@ pub trait RaylibDraw {
     fn draw_spline_basis(&mut self, points: &[Vector2], thick: f32, color: impl Into<ffi::Color>) {
         unsafe {
             ffi::DrawSplineBasis(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
     /// Draw spline: Catmull-Rom, minimum 4 points
@@ -1381,11 +1407,14 @@ pub trait RaylibDraw {
     ) {
         unsafe {
             ffi::DrawSplineCatmullRom(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1399,11 +1428,14 @@ pub trait RaylibDraw {
     ) {
         unsafe {
             ffi::DrawSplineBezierQuadratic(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1417,11 +1449,14 @@ pub trait RaylibDraw {
     ) {
         unsafe {
             ffi::DrawSplineBezierCubic(
-                points.as_ptr() as *mut ffi::Vector2,
-                points.len() as i32,
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1456,7 +1491,7 @@ pub trait RaylibDraw {
                 p4.into(),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1479,7 +1514,7 @@ pub trait RaylibDraw {
                 p4.into(),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1500,7 +1535,7 @@ pub trait RaylibDraw {
                 p3.into(),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1523,7 +1558,7 @@ pub trait RaylibDraw {
                 p4.into(),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1629,7 +1664,14 @@ pub trait RaylibDraw3D {
     #[inline]
     fn draw_triangle_strip3D(&mut self, points: &[Vector3], color: impl Into<ffi::Color>) {
         unsafe {
-            ffi::DrawTriangleStrip3D(points.as_ptr() as *mut _, points.len() as i32, color.into());
+            ffi::DrawTriangleStrip3D(
+                points.as_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
+                color.into(),
+            );
         }
     }
 
@@ -1748,9 +1790,12 @@ pub trait RaylibDraw3D {
             ffi::DrawMeshInstanced(
                 *mesh.as_ref(),
                 material.0,
-                transforms.as_ptr() as *const MintMatrix,
-                transforms.len() as i32,
-            )
+                transforms.as_ptr().cast(),
+                transforms
+                    .len()
+                    .try_into()
+                    .expect("transforms should not exceed i32::MAX elements"),
+            );
         }
     }
 
@@ -1908,7 +1953,7 @@ pub trait RaylibDraw3D {
                 slices,
                 rings,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -1931,7 +1976,7 @@ pub trait RaylibDraw3D {
                 slices,
                 rings,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -2089,6 +2134,7 @@ pub trait RaylibDraw3D {
     }
 
     /// Draw a billboard texture defined by source and rotation
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     fn draw_billboard_pro(
         &mut self,
@@ -2113,7 +2159,7 @@ pub trait RaylibDraw3D {
                 origin.into(),
                 rotation,
                 tint.into(),
-            )
+            );
         }
     }
 

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -2,168 +2,271 @@
 
 use thiserror::Error;
 
+#[allow(unused_imports, reason = "used in documentation")]
+use crate::{
+    audio::{Music, RaylibAudio, Sound, Wave},
+    models::{Material, Mesh, Model, ModelAnimation},
+    text::Font,
+    texture::{Image, RenderTexture2D, Texture2D},
+};
+
+/// Error occurring while initializing audio.
 #[derive(Error, Debug)]
 pub enum AudioInitError {
+    /// [`RaylibAudio`] cannot be instantiated more then once at a time
     #[error("RaylibAudio cannot be instantiated more then once at a time")]
     DoubleInit,
+    /// Raylib failed to initialize audio device
     #[error("failed to initialize audio device")]
     InitFailed,
 }
 
+/// Error occurring while exporting a [`Wave`].
 #[derive(Error, Debug)]
 pub enum ExportWaveError {
+    /// [`Wave`] data must be 16 bit per sample for QOA format export
     #[error("wave data must be 16 bit per sample for QOA format export (actual: {0})")]
     QoaBadSamples(i32),
+    /// Failed to export [`Wave`] data
     #[error("failed to export wave data")]
     ExportFailed,
 }
 
+/// Error occurring while loading a [`Sound`].
 #[derive(Error, Debug)]
 pub enum LoadSoundError {
+    /// Failed to load [`Sound`]
     #[error("failed to load sound\npath: {path:?}")]
-    LoadFailed { path: String },
+    LoadFailed {
+        /// Path to the file that failed to be loaded as a [`Sound`].
+        path: String,
+    },
+    /// failed to load [`Sound`] from [`Wave`]
     #[error("failed to load sound from wave")]
     LoadFromWaveFailed,
+    /// cannot load [`Wave`]
     #[error("cannot load wave\npath: {path:?}")]
-    LoadWaveFromFileFailed { path: String },
+    LoadWaveFromFileFailed {
+        /// Path to the file that failed to be loaded as a [`Wave`].
+        path: String,
+    },
+    /// [`Wave`] `data` is null
     #[error("wave data is null, check provided buffer data")]
     Null,
+    /// [`Music`] could not be loaded from file
     #[error("music could not be loaded from file\npath: {path:?}")]
-    LoadMusicFromFileFailed { path: String },
-    #[error("music's buffer data data is null, check provided buffer data")]
+    LoadMusicFromFileFailed {
+        /// Path to the file that failed to be loaded as [`Music`].
+        path: String,
+    },
+    /// [`Music`] buffer `data` is null
+    #[error("music's buffer data is null, check provided buffer data")]
     MusicNull,
 }
 
+/// Error occurring while allocating memory with [`MemAlloc`](crate::ffi::MemAlloc)/[`MemRealloc`](crate::ffi::MemRealloc).
 #[derive(Error, Debug)]
 pub enum AllocationError {
-    /// [`MemAlloc`](crate::ffi::MemAlloc) returned null.
+    /// [`MemAlloc`](crate::ffi::MemAlloc)/[`MemRealloc`](crate::ffi::MemRealloc) returned null.
     #[error("memory request exceeds capacity")]
     NullAlloc,
     /// The size of `[T; count]` in bytes exceeds [`u32::MAX`]
-    /// (the largest value [`MemAlloc`](crate::ffi::MemAlloc) can be passed).
+    /// (the largest value [`MemAlloc`](crate::ffi::MemAlloc)/[`MemRealloc`](crate::ffi::MemRealloc) can be passed).
     #[error("memory request in bytes exceeds unsigned integer maximum")]
     IntoUIntFailed,
-    /// Attempted to pass 0 to [`MemAlloc`](crate::ffi::MemAlloc).
+    /// Attempted to pass 0 to [`MemAlloc`](crate::ffi::MemAlloc)/[`MemRealloc`](crate::ffi::MemRealloc).
     #[error("requested zero bytes of memory")]
     ZeroBytes,
 }
 
+/// Error occurring while compressing data.
 #[derive(Error, Debug)]
 pub enum CompressionError {
+    /// Could not compress data
     #[error("could not compress data")]
     CompressionFailed,
 }
 
+/// Error occurring while loading a [`Model`].
 #[derive(Error, Debug)]
 pub enum LoadModelError {
+    /// Could not load [`Model`]
     #[error("could not load model\npath: {path:?}")]
-    LoadFromFileFailed { path: String },
+    LoadFromFileFailed {
+        /// Path to the file that failed to be loaded as a [`Model`]
+        path: String,
+    },
+    /// could not load [`Model`] from [`Mesh`]
     #[error("could not load model from mesh")]
     LoadFromMeshFailed,
 }
 
+/// Error occurring while loading a [`ModelAnimation`].
 #[derive(Error, Debug)]
 pub enum LoadModelAnimError {
+    /// No [`ModelAnimation`]s loaded
     #[error("no model animations loaded\npath: {path:?}")]
-    NoAnimationsLoaded { path: String },
+    NoAnimationsLoaded {
+        /// Path to the file that failed to be loaded as a [`ModelAnimation`].
+        path: String,
+    },
 }
 
+/// Error occurring while setting a [`Model`]'s [`Material`].
 #[derive(Error, Debug)]
 pub enum SetMaterialError {
+    /// `mesh_id` greater than [`Mesh`] count
     #[error("mesh_id greater than mesh count")]
     MeshIdOutOfBounds,
+    /// `material_id` greater than [`Material`] count
     #[error("material_id greater than material count")]
     MaterialIdOutOfBounds,
 }
 
+/// Error occurring while loading a [`Material`].
 #[derive(Error, Debug)]
 pub enum LoadMaterialError {
+    /// No [`Material`]s loaded
     #[error("no materials loaded\npath: {path:?}")]
-    NoneLoaded { path: String },
+    NoneLoaded {
+        /// Path to the file that failed to be loaded as a [`Material`].
+        path: String,
+    },
 }
 
+/// Error occurring while loading a [`Material`].
 #[derive(Error, Debug)]
 pub enum LoadFontError {
-    #[error("error loading font; check if the file exists and if it's the right type\npath: {path:?}")]
-    LoadFromFileFailed { path: String },
+    /// Error loading [`Font`] from a file
+    #[error(
+        "error loading font; check if the file exists and if it's the right type\npath: {path:?}"
+    )]
+    LoadFromFileFailed {
+        /// Path to the file that failed to be loaded as a [`Font`].
+        path: String,
+    },
+    /// Error loading [`Font`] from [`Image`]
     #[error("error loading font from image")]
     LoadFromImageFailed,
+    /// Error loading [`Font`] from memory
     #[error("error loading font from memory; check if the file's type is correct")]
     LoadFromMemoryFailed,
 }
 
+/// Error regarding [`Image`] data.
 #[derive(Error, Debug)]
 pub enum InvalidImageError {
+    /// `width` is 0
     #[error("invalid image: width is 0")]
     ZeroWidth,
+    /// `height` is 0
     #[error("invalid image: height is 0")]
     ZeroHeight,
+    /// `data` is null
     #[error("invalid image: data is null")]
     NullData,
+    /// `data` loaded from file is null
     #[error("image data is null, either the file doesnt exist or the image type is unsupported")]
     NullDataFromFile,
+    /// Invalid file data
     #[error("invalid file data")]
     InvalidFile,
+    /// `data` loaded from memory is null
     #[error("image data is null, check provided buffer data")]
     NullDataFromMemory,
+    /// Failed to retrieve pixel data
     #[error("failed to retrieve pixel data")]
     NullDataFromTexture,
+    /// Unsupported format
     #[error("unsupported format")]
     UnsupportedFormat,
+    /// Convolution kernel must be square to be applied
     #[error("convolution kernel must be square to be applied")]
     NonSquareKernel,
 }
 
+/// Error occurring while updating a [`Texture2D`].
 #[derive(Error, Debug)]
 pub enum UpdateTextureError {
+    /// Data is wrong size
     #[error("data is wrong size (expected {expect} bytes, got {actual})")]
-    WrongDataSize { expect: usize, actual: usize },
+    WrongDataSize {
+        /// Bytes expected based on destination
+        expect: usize,
+        /// Bytes found based on source
+        actual: usize,
+    },
+    /// Destination rectangle cannot exceed texture bounds
     #[error("destination rectangle cannot exceed texture bounds")]
     OutOfBounds,
+    /// Destination rectangle cannot have negative extents
     #[error("destination rectangle cannot have negative extents")]
     NegativeSize,
 }
 
+/// Error occurring while loading a texture.
 #[derive(Error, Debug)]
 pub enum LoadTextureError {
+    /// Failed to load the [`Texture2D`]
     #[error("failed to load the texture\npath: {path:?}")]
-    TextureFromFileFailed { path: String },
+    TextureFromFileFailed {
+        /// Path to the file that failed to be loaded as a [`Texture2D`].
+        path: String,
+    },
+    /// Failed to load [`Image`] as a texture cubemap
     #[error("failed to load image as a texture cubemap")]
     CubemapFromImageFailed,
+    /// Failed to load [`Image`] as a [`Texture2D`]
     #[error("failed to load image as a texture")]
     TextureFromImageFailed,
+    /// Failed to create [`RenderTexture2D`]
     #[error("failed to create render texture")]
     CreateRenderTextureFailed,
+    /// Data is not valid to load texture
     #[error("data is not valid to load texture")]
     InvalidData,
 }
 
+/// General Raylib error
 #[derive(Error, Debug)]
 pub enum RaylibError {
+    /// [`AudioInitError`]
     #[error("audio initialization error")]
     AudioInit(#[from] AudioInitError),
+    /// [`ExportWaveError`]
     #[error("wave export error")]
     ExportWave(#[from] ExportWaveError),
+    /// [`LoadSoundError`]
     #[error("sound loading error")]
     LoadSound(#[from] LoadSoundError),
+    /// [`AllocationError`]
     #[error("allocation error")]
     Allocation(#[from] AllocationError),
+    /// [`CompressionError`]
     #[error("compression error")]
     Compression(#[from] CompressionError),
+    /// [`LoadModelError`]
     #[error("model loading error")]
     LoadModel(#[from] LoadModelError),
+    /// [`LoadModelAnimError`]
     #[error("model animation loading error")]
     LoadModelAnim(#[from] LoadModelAnimError),
+    /// [`SetMaterialError`]
     #[error("material update error")]
     SetMaterial(#[from] SetMaterialError),
+    /// [`LoadMaterialError`]
     #[error("material loading error")]
     LoadMaterial(#[from] LoadMaterialError),
+    /// [`LoadFontError`]
     #[error("font loading error")]
     LoadFont(#[from] LoadFontError),
+    /// [`InvalidImageError`]
     #[error("image error")]
     InvalidImage(#[from] InvalidImageError),
+    /// [`UpdateTextureError`]
     #[error("texture update error")]
     UpdateTexture(#[from] UpdateTextureError),
+    /// [`LoadTextureError`]
     #[error("texture loading error")]
     LoadTexture(#[from] LoadTextureError),
 }

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -140,12 +140,14 @@ impl FilePathList {
     pub const fn count(&self) -> u32 {
         self.0.count
     }
+
     /// The amount of files that can be held in this list.
     #[inline]
     #[must_use]
     pub const fn capacity(&self) -> u32 {
         self.0.capacity
     }
+
     /// The paths held in this list.
     /// This function is NOT constant and the inner array will be copied into the returned Vec every time you call this.
     ///
@@ -164,6 +166,7 @@ impl FilePathList {
             })
             .collect()
     }
+
     /// An iterator over the paths held in this list.
     #[must_use]
     pub fn iter(&self) -> FilePathIter<'_> {
@@ -188,12 +191,14 @@ impl DroppedFilePathList {
     pub const fn count(&self) -> u32 {
         self.0.count
     }
+
     /// The amount of files that can be held in this list.
     #[inline]
     #[must_use]
     pub const fn capacity(&self) -> u32 {
         self.0.capacity
     }
+
     /// The paths held in this list.
     /// This function is NOT constant and the inner array will be copied into the returned [`Vec`] every time you call this.
     ///
@@ -211,6 +216,7 @@ impl DroppedFilePathList {
             })
             .collect()
     }
+
     /// An iterator over the paths held in this list.
     #[must_use]
     pub fn iter(&self) -> FilePathIter<'_> {
@@ -254,6 +260,7 @@ impl RaylibHandle {
             .expect("lossy file_ext string should not have an internal 0 byte");
         unsafe { ffi::IsFileExtension(file_name.as_ptr(), file_ext.as_ptr()) }
     }
+
     /// Get the directory of the running application.
     ///
     /// # Panics

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -2,6 +2,9 @@
 use crate::{core::RaylibHandle, ffi};
 use std::ffi::{CStr, CString, OsString, c_char};
 
+/// Iterator over file paths
+///
+/// Created by [`FilePathList::iter`].
 #[derive(Debug, Clone)]
 pub struct FilePathIter<'a> {
     iter: std::slice::Iter<'a, Option<&'a c_char>>,

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -120,8 +120,14 @@ impl ExactSizeIterator for FilePathIter<'_> {
     }
 }
 
-make_thin_wrapper!(FilePathList, ffi::FilePathList, ffi::UnloadDirectoryFiles);
 make_thin_wrapper!(
+    /// Iterable list of file paths.
+    FilePathList,
+    ffi::FilePathList,
+    ffi::UnloadDirectoryFiles
+);
+make_thin_wrapper!(
+    /// Iterable list of paths to files that were dropped.
     DroppedFilePathList,
     ffi::FilePathList,
     ffi::UnloadDroppedFiles

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -2,17 +2,64 @@
 use crate::{core::RaylibHandle, ffi};
 use std::ffi::{CStr, CString, OsString, c_char};
 
-/// Iterator over file paths
+/// # Safety
 ///
-/// Created by [`FilePathList::iter`].
-#[derive(Debug, Clone)]
-pub struct FilePathIter<'a> {
-    iter: std::slice::Iter<'a, Option<&'a c_char>>,
+/// `ptr` must be given by a [`FilePathList`] or [`DroppedFilePathList`]
+fn ptr_to_path_str(&ptr: &*const c_char) -> &str {
+    assert!(!ptr.is_null(), "path within bounds should not be null");
+    // SAFETY: `ptr` is guaranteed non-null and aligned due to coming from a reference.
+    // Given this iterator can only be initialized from Raylib data, `ptr` is guaranteed to be a nul-terminated c-string.
+    unsafe { CStr::from_ptr(ptr) }
+        .to_str()
+        .expect("file path string should be in utf-8") // TODO: Paths aren't necessarily encoded in UTF-8
 }
-impl<'a> FilePathIter<'a> {
-    /// # Safety
-    /// The memory pointed to by `list` must not be mutated for `'a`.
-    /// Every `*mut c_char` in `list` must outlive `'a`.
+
+/// Iterator over file paths
+pub type FilePathIter<'a> =
+    std::iter::Map<std::slice::Iter<'a, *const c_char>, fn(&'a *const c_char) -> &'a str>;
+
+make_thin_wrapper!(
+    /// Iterable list of file paths.
+    FilePathList,
+    ffi::FilePathList,
+    ffi::UnloadDirectoryFiles
+);
+
+make_thin_wrapper!(
+    /// Iterable list of paths to files that were dropped.
+    DroppedFilePathList,
+    ffi::FilePathList,
+    ffi::UnloadDroppedFiles
+);
+
+impl FilePathList {
+    /// Length of the file path list
+    #[inline]
+    #[must_use]
+    pub const fn count(&self) -> u32 {
+        self.0.count
+    }
+
+    /// The amount of files that can be held in this list.
+    #[inline]
+    #[must_use]
+    pub const fn capacity(&self) -> u32 {
+        self.0.capacity
+    }
+
+    /// The paths held in this list.
+    /// This function is NOT constant and the inner array will be copied into the returned Vec every time you call this.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if a path is not compatible with utf-8.
+    //  which happens a lot??? WTF-8 is standard on windows!!
+    #[must_use]
+    pub fn paths(&self) -> Vec<&str> {
+        self.iter().collect()
+    }
+
+    /// An iterator over the paths held in this list.
     ///
     /// ## Examples
     ///
@@ -63,114 +110,16 @@ impl<'a> FilePathIter<'a> {
     /// //          ^^^^ mutable borrow occurs here
     /// assert_eq!(s, Some("apple")); // immutable borrow later used here
     /// ```
-    unsafe fn new(list: *mut *mut c_char, count: u32) -> Self {
-        // No new items are being created that get dropped here, these are just changes in perspective of how to borrow-check the pointers.
-        assert!(!list.is_null(), "file path array cannot be null");
-        assert!(list.is_aligned(), "file path array must be aligned");
-        let list = list.cast::<Option<&'a c_char>>();
-        let iter = unsafe { std::slice::from_raw_parts(list, count as usize) }.iter();
-        Self { iter }
-    }
-    fn func(f: Option<&'a c_char>) -> &'a str {
-        // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
-        let s = std::slice::from_ref(f.expect("file path string cannot be null"));
-        unsafe { CStr::from_ptr(s.as_ptr()) }
-            .to_str()
-            .expect("file path string should be in utf-8") // no???
-    }
-}
-impl<'a> Iterator for FilePathIter<'a> {
-    type Item = &'a str;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().copied().map(Self::func)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
-
-    #[inline]
-    fn count(self) -> usize {
-        self.len()
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        self.iter.last().copied().map(Self::func)
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n).copied().map(Self::func)
-    }
-}
-impl DoubleEndedIterator for FilePathIter<'_> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().copied().map(Self::func)
-    }
-
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth_back(n).copied().map(Self::func)
-    }
-}
-impl ExactSizeIterator for FilePathIter<'_> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.iter.len()
-    }
-}
-
-make_thin_wrapper!(
-    /// Iterable list of file paths.
-    FilePathList,
-    ffi::FilePathList,
-    ffi::UnloadDirectoryFiles
-);
-make_thin_wrapper!(
-    /// Iterable list of paths to files that were dropped.
-    DroppedFilePathList,
-    ffi::FilePathList,
-    ffi::UnloadDroppedFiles
-);
-
-impl FilePathList {
-    /// Length of the file path list
-    #[inline]
-    #[must_use]
-    pub const fn count(&self) -> u32 {
-        self.0.count
-    }
-
-    /// The amount of files that can be held in this list.
-    #[inline]
-    #[must_use]
-    pub const fn capacity(&self) -> u32 {
-        self.0.capacity
-    }
-
-    /// The paths held in this list.
-    /// This function is NOT constant and the inner array will be copied into the returned Vec every time you call this.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if a path is not compatible with utf-8.
-    //  which happens a lot??? WTF-8 is standard on windows!!
-    #[must_use]
-    pub fn paths(&self) -> Vec<&str> {
-        unsafe { std::slice::from_raw_parts(self.0.paths, self.count() as usize) }
-            .iter()
-            .map(|f| {
-                unsafe { CStr::from_ptr(*f) }
-                    .to_str()
-                    .expect("file path string should be in utf-8") // no???
-            })
-            .collect()
-    }
-
-    /// An iterator over the paths held in this list.
-    #[must_use]
     pub fn iter(&self) -> FilePathIter<'_> {
-        unsafe { FilePathIter::new(self.0.paths, self.count()) }
+        (!self.0.paths.is_null())
+            .then(||
+                // SAFETY: Just checked and `list` is both non-null.
+                // FilePathList cannot be constructed outside of the library, and Raylib
+                // guarantees that its count will accurately describe its pointer.
+                unsafe { std::slice::from_raw_parts(self.0.paths.cast(), self.count as usize) })
+            .unwrap_or_default()
+            .iter()
+            .map(ptr_to_path_str)
     }
 }
 
@@ -207,20 +156,20 @@ impl DroppedFilePathList {
     /// This method will panic if a path is not compatible with utf-8.
     #[must_use]
     pub fn paths(&self) -> Vec<&str> {
-        unsafe { std::slice::from_raw_parts(self.0.paths, self.count() as usize) }
-            .iter()
-            .map(|f| {
-                unsafe { CStr::from_ptr(*f) }
-                    .to_str()
-                    .expect("file path string should be in utf-8") // no???
-            })
-            .collect()
+        self.iter().collect()
     }
 
     /// An iterator over the paths held in this list.
-    #[must_use]
     pub fn iter(&self) -> FilePathIter<'_> {
-        unsafe { FilePathIter::new(self.0.paths, self.count()) }
+        (!self.0.paths.is_null())
+            .then(||
+                // SAFETY: Just checked and `list` is both non-null.
+                // FilePathList cannot be constructed outside of the library, and Raylib
+                // guarantees that its count will accurately describe its pointer.
+                unsafe { std::slice::from_raw_parts(self.0.paths.cast(), self.count as usize) })
+            .unwrap_or_default()
+            .iter()
+            .map(ptr_to_path_str)
     }
 }
 
@@ -239,6 +188,8 @@ impl RaylibHandle {
     #[inline]
     #[must_use]
     pub fn is_file_dropped(&self) -> bool {
+        // SOUNDNESS HOLE: IsFileDropped reads a global static without locking.
+        // There is nothing stopping it from being written to on another thread mid-read.
         unsafe { ffi::IsFileDropped() }
     }
 
@@ -258,6 +209,10 @@ impl RaylibHandle {
             .expect("lossy file_name string should not have an internal 0 byte");
         let file_ext = CString::new(file_ext.into().to_string_lossy().as_bytes())
             .expect("lossy file_ext string should not have an internal 0 byte");
+        // SOUNDNESS HOLE: IsFileExtension calls TextSplit, which returns a static buffer
+        // without locking instead of allocating memory. There is nothing stopping another
+        // thread from calling TextSplit and mutating the static buffer while IsFileExtension
+        // holds a reference to it.
         unsafe { ffi::IsFileExtension(file_name.as_ptr(), file_ext.as_ptr()) }
     }
 
@@ -268,6 +223,10 @@ impl RaylibHandle {
     /// This method will panic if the application directory is not compatible with utf-8.
     #[must_use]
     pub fn application_directory(&self) -> String {
+        // SOUNDNESS HOLE: GetApplicationDirectory returns a static buffer without locking
+        // instead of allocating memory. There is nothing stopping another thread from
+        // calling GetApplicationDirectory at the same time and mutating the buffer before
+        // this method finishes copying it.
         let st = unsafe { ffi::GetApplicationDirectory() };
         let c_str = unsafe { CStr::from_ptr(st) };
 

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -1,8 +1,6 @@
-//! File manipulation functions. Should be parity with std::fs except on emscripten
-use crate::ffi;
-
-use crate::core::RaylibHandle;
-use std::ffi::{c_char, CStr, CString, OsString};
+//! File manipulation functions. Should be parity with [`std::fs`] except on emscripten
+use crate::{core::RaylibHandle, ffi};
+use std::ffi::{CStr, CString, OsString, c_char};
 
 #[derive(Debug, Clone)]
 pub struct FilePathIter<'a> {
@@ -70,17 +68,19 @@ impl<'a> FilePathIter<'a> {
         let iter = unsafe { std::slice::from_raw_parts(list, count as usize) }.iter();
         Self { iter }
     }
-    fn func(f: &Option<&'a c_char>) -> &'a str {
+    fn func(f: Option<&'a c_char>) -> &'a str {
         // CStr isn't being "constructed", it's essentially an adapter on &[c_char]
         let s = std::slice::from_ref(f.expect("file path string cannot be null"));
-        unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap()
+        unsafe { CStr::from_ptr(s.as_ptr()) }
+            .to_str()
+            .expect("file path string should be in utf-8") // no???
     }
 }
 impl<'a> Iterator for FilePathIter<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(Self::func)
+        self.iter.next().copied().map(Self::func)
     }
 
     #[inline]
@@ -94,23 +94,23 @@ impl<'a> Iterator for FilePathIter<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.iter.last().map(Self::func)
+        self.iter.last().copied().map(Self::func)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n).map(Self::func)
+        self.iter.nth(n).copied().map(Self::func)
     }
 }
-impl<'a> DoubleEndedIterator for FilePathIter<'a> {
+impl DoubleEndedIterator for FilePathIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Self::func)
+        self.iter.next_back().copied().map(Self::func)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth_back(n).map(Self::func)
+        self.iter.nth_back(n).copied().map(Self::func)
     }
 }
-impl<'a> ExactSizeIterator for FilePathIter<'a> {
+impl ExactSizeIterator for FilePathIter<'_> {
     #[inline]
     fn len(&self) -> usize {
         self.iter.len()
@@ -127,140 +127,213 @@ make_thin_wrapper!(
 impl FilePathList {
     /// Length of the file path list
     #[inline]
+    #[must_use]
     pub const fn count(&self) -> u32 {
         self.0.count
     }
     /// The amount of files that can be held in this list.
     #[inline]
+    #[must_use]
     pub const fn capacity(&self) -> u32 {
         self.0.capacity
     }
     /// The paths held in this list.
     /// This function is NOT constant and the inner array will be copied into the returned Vec every time you call this.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if a path is not compatible with utf-8.
+    //  which happens a lot??? WTF-8 is standard on windows!!
+    #[must_use]
     pub fn paths(&self) -> Vec<&str> {
         unsafe { std::slice::from_raw_parts(self.0.paths, self.count() as usize) }
             .iter()
-            .map(|f| unsafe { CStr::from_ptr(*f) }.to_str().unwrap())
+            .map(|f| {
+                unsafe { CStr::from_ptr(*f) }
+                    .to_str()
+                    .expect("file path string should be in utf-8") // no???
+            })
             .collect()
     }
     /// An iterator over the paths held in this list.
-    pub fn iter<'a>(&'a self) -> FilePathIter<'a> {
+    #[must_use]
+    pub fn iter(&self) -> FilePathIter<'_> {
         unsafe { FilePathIter::new(self.0.paths, self.count()) }
+    }
+}
+
+impl<'a> IntoIterator for &'a FilePathList {
+    type Item = <Self::IntoIter as Iterator>::Item;
+    type IntoIter = FilePathIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 
 impl DroppedFilePathList {
     /// Length of the file path list
     #[inline]
+    #[must_use]
     pub const fn count(&self) -> u32 {
         self.0.count
     }
     /// The amount of files that can be held in this list.
     #[inline]
+    #[must_use]
     pub const fn capacity(&self) -> u32 {
         self.0.capacity
     }
     /// The paths held in this list.
-    /// This function is NOT constant and the inner array will be copied into the returned Vec every time you call this.
+    /// This function is NOT constant and the inner array will be copied into the returned [`Vec`] every time you call this.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if a path is not compatible with utf-8.
+    #[must_use]
     pub fn paths(&self) -> Vec<&str> {
         unsafe { std::slice::from_raw_parts(self.0.paths, self.count() as usize) }
             .iter()
-            .map(|f| unsafe { CStr::from_ptr(*f) }.to_str().unwrap())
+            .map(|f| {
+                unsafe { CStr::from_ptr(*f) }
+                    .to_str()
+                    .expect("file path string should be in utf-8") // no???
+            })
             .collect()
     }
     /// An iterator over the paths held in this list.
-    pub fn iter<'a>(&'a self) -> FilePathIter<'a> {
+    #[must_use]
+    pub fn iter(&self) -> FilePathIter<'_> {
         unsafe { FilePathIter::new(self.0.paths, self.count()) }
+    }
+}
+
+impl<'a> IntoIterator for &'a DroppedFilePathList {
+    type Item = <Self::IntoIter as Iterator>::Item;
+    type IntoIter = FilePathIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 
 impl RaylibHandle {
     /// Checks if a file has been dropped into the window.
     #[inline]
+    #[must_use]
     pub fn is_file_dropped(&self) -> bool {
         unsafe { ffi::IsFileDropped() }
     }
 
     /// Checks a file's extension.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `file_name` or `file_ext`, when converted to a lossy string, has an internal 0 byte.
     #[inline]
-    pub fn is_file_extension<A>(&self, file_name: A, file_ext: A) -> bool
+    #[must_use]
+    pub fn is_file_extension<A, B>(&self, file_name: A, file_ext: B) -> bool
     where
         A: Into<OsString>,
+        B: Into<OsString>,
     {
-        let file_name = CString::new(file_name.into().to_string_lossy().as_bytes()).unwrap();
-        let file_ext = CString::new(file_ext.into().to_string_lossy().as_bytes()).unwrap();
+        let file_name = CString::new(file_name.into().to_string_lossy().as_bytes())
+            .expect("lossy file_name string should not have an internal 0 byte");
+        let file_ext = CString::new(file_ext.into().to_string_lossy().as_bytes())
+            .expect("lossy file_ext string should not have an internal 0 byte");
         unsafe { ffi::IsFileExtension(file_name.as_ptr(), file_ext.as_ptr()) }
     }
     /// Get the directory of the running application.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the application directory is not compatible with utf-8.
+    #[must_use]
     pub fn application_directory(&self) -> String {
-        unsafe {
-            let st = ffi::GetApplicationDirectory();
-            let c_str = CStr::from_ptr(st);
+        let st = unsafe { ffi::GetApplicationDirectory() };
+        let c_str = unsafe { CStr::from_ptr(st) };
 
-            // If this ever errors out, yell at @ioi_xd on Discord,
-            c_str.to_str().unwrap().to_string()
-        }
+        // If this ever errors out, yell at @ioi_xd on Discord,
+        c_str
+            .to_str()
+            .expect("application directory string should be in utf-8") // no???
+            .to_string()
     }
 
     /// Get file length in bytes.
     ///
-    /// # Errors
-    /// This function will return an error if the supplied bytes contain an internal 0 byte. The NulError returned will contain the bytes as well as the position of the nul byte.
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     pub fn get_file_length<A>(&self, filename: A) -> i32
     where
         A: Into<OsString>,
     {
-        let c_str = CString::new(filename.into().to_string_lossy().as_bytes()).unwrap();
+        let c_str = CString::new(filename.into().to_string_lossy().as_bytes())
+            .expect("lossy filename string should not contain an internal 0 byte");
         unsafe { ffi::GetFileLength(c_str.as_ptr()) }
     }
 
     /// Check if a given path is a file or a directory
     ///
-    /// # Errors
-    /// This function will return an error if the supplied bytes contain an internal 0 byte. The NulError returned will contain the bytes as well as the position of the nul byte.
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[must_use]
     pub fn is_path_file<A>(&self, filename: A) -> bool
     where
         A: Into<OsString>,
     {
-        let c_str = CString::new(filename.into().to_string_lossy().as_bytes()).unwrap();
+        let c_str = CString::new(filename.into().to_string_lossy().as_bytes())
+            .expect("lossy filename string should not contain an internal 0 byte");
         unsafe { ffi::IsPathFile(c_str.as_ptr()) }
     }
 
     /// Load directory filepaths
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `dir_path` contains an internal 0 byte.
     pub fn load_directory_files<A>(&self, dir_path: A) -> FilePathList
     where
         A: Into<OsString>,
     {
-        unsafe {
-            let c_str = CString::new(dir_path.into().to_string_lossy().as_bytes()).unwrap(); // .unwrap() is okay here because any nul bytes placed into the actual string should be cleared out by to_string_lossy.
-            FilePathList(ffi::LoadDirectoryFiles(c_str.as_ptr()))
-        }
+        let c_str = CString::new(dir_path.into().to_string_lossy().as_bytes())
+            .expect("lossy dir_path string should not contain an internal 0 byte");
+        FilePathList(unsafe { ffi::LoadDirectoryFiles(c_str.as_ptr()) })
     }
 
     /// Load directory filepaths with extension filtering and recursive directory scan
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `dir_c_str` contains an internal 0 byte
     pub fn load_directory_files_ex<A>(
         &self,
         dir_path: A,
-        filter: String,
+        mut filter: String,
         scan_sub_dirs: bool,
     ) -> FilePathList
     where
         A: Into<OsString>,
     {
-        unsafe {
-            let dir_c_str = CString::new(dir_path.into().to_string_lossy().as_bytes()).unwrap(); // .unwrap() is okay here because any nul bytes placed into the actual string should be cleared out by to_string_lossy.
-            let filter_c_str = CString::new(filter.replace("\0", "").as_bytes()).unwrap();
-            FilePathList(ffi::LoadDirectoryFilesEx(
-                dir_c_str.as_ptr(),
-                filter_c_str.as_ptr(),
-                scan_sub_dirs,
-            ))
+        let dir_c_str = CString::new(dir_path.into().to_string_lossy().as_bytes())
+            .expect("lossy dir_path string should not contain an internal 0 byte");
+        while let Some(pos) = filter.rfind('\0') {
+            filter.remove(pos);
         }
+        let filter_c_str =
+            CString::new(filter.as_bytes()).expect("removing all 0 bytes from the string guarantees there aren't any 0 bytes in the string");
+        FilePathList(unsafe {
+            ffi::LoadDirectoryFilesEx(dir_c_str.as_ptr(), filter_c_str.as_ptr(), scan_sub_dirs)
+        })
     }
 
     /// Check if a file has been dropped into window
     #[inline]
+    #[must_use]
     pub fn load_dropped_files(&self) -> DroppedFilePathList {
         unsafe { DroppedFilePathList(ffi::LoadDroppedFiles()) }
     }
@@ -268,8 +341,8 @@ impl RaylibHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::ManuallyDrop;
     use super::*;
+    use std::mem::ManuallyDrop;
 
     #[test]
     #[should_panic(expected = "file path array cannot be null")]
@@ -314,11 +387,11 @@ mod tests {
     #[test]
     fn test_len() {
         let mut paths = [
-            CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"orange\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"banana\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"mango\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"pineapple\0").unwrap().as_ptr().cast_mut(),
+            c"apple".as_ptr().cast_mut(),
+            c"orange".as_ptr().cast_mut(),
+            c"banana".as_ptr().cast_mut(),
+            c"mango".as_ptr().cast_mut(),
+            c"pineapple".as_ptr().cast_mut(),
         ];
         let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
             capacity: 5,
@@ -343,11 +416,11 @@ mod tests {
     #[test]
     fn test_len_double_ended() {
         let mut paths = [
-            CStr::from_bytes_with_nul(b"apple\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"orange\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"banana\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"mango\0").unwrap().as_ptr().cast_mut(),
-            CStr::from_bytes_with_nul(b"pineapple\0").unwrap().as_ptr().cast_mut(),
+            c"apple".as_ptr().cast_mut(),
+            c"orange".as_ptr().cast_mut(),
+            c"banana".as_ptr().cast_mut(),
+            c"mango".as_ptr().cast_mut(),
+            c"pineapple".as_ptr().cast_mut(),
         ];
         let list = ManuallyDrop::new(FilePathList(ffi::FilePathList {
             capacity: 5,

--- a/raylib/src/core/input.rs
+++ b/raylib/src/core/input.rs
@@ -1,91 +1,75 @@
 //! Keyboard, Controller, and Mouse related functions
-use crate::consts::Gesture;
-use crate::core::math::Vector2;
-use crate::core::RaylibHandle;
-use crate::{ffi, trace_log};
-use raylib_sys::TraceLogLevel;
-
-use std::ffi::c_char;
-use std::ffi::CStr;
+use crate::{
+    consts::{GamepadAxis, GamepadButton, Gesture, KeyboardKey, MouseButton},
+    core::{RaylibHandle, math::Vector2},
+    ffi::{self, TraceLogLevel},
+    trace_log,
+};
+use std::ffi::{CStr, c_char};
 
 impl RaylibHandle {
     /// Detect if a key has been pressed once.
     #[inline]
     #[must_use]
-    pub fn is_key_pressed(&self, key: crate::consts::KeyboardKey) -> bool {
-        unsafe { ffi::IsKeyPressed((key as u32) as i32) }
+    pub fn is_key_pressed(&self, key: KeyboardKey) -> bool {
+        unsafe { ffi::IsKeyPressed(key as i32) }
     }
 
     /// Check if a key has been pressed again
     #[inline]
     #[must_use]
-    pub fn is_key_pressed_repeat(&self, key: crate::consts::KeyboardKey) -> bool {
-        unsafe { ffi::IsKeyPressedRepeat((key as u32) as i32) }
+    pub fn is_key_pressed_repeat(&self, key: KeyboardKey) -> bool {
+        unsafe { ffi::IsKeyPressedRepeat(key as i32) }
     }
 
     /// Detect if a key is being pressed.
     #[inline]
     #[must_use]
-    pub fn is_key_down(&self, key: crate::consts::KeyboardKey) -> bool {
-        unsafe { ffi::IsKeyDown((key as u32) as i32) }
+    pub fn is_key_down(&self, key: KeyboardKey) -> bool {
+        unsafe { ffi::IsKeyDown(key as i32) }
     }
 
     /// Detect if a key has been released once.
     #[inline]
     #[must_use]
-    pub fn is_key_released(&self, key: crate::consts::KeyboardKey) -> bool {
-        unsafe { ffi::IsKeyReleased((key as u32) as i32) }
+    pub fn is_key_released(&self, key: KeyboardKey) -> bool {
+        unsafe { ffi::IsKeyReleased(key as i32) }
     }
 
     /// Detect if a key is NOT being pressed.
     #[inline]
     #[must_use]
-    pub fn is_key_up(&self, key: crate::consts::KeyboardKey) -> bool {
-        unsafe { ffi::IsKeyUp((key as u32) as i32) }
+    pub fn is_key_up(&self, key: KeyboardKey) -> bool {
+        unsafe { ffi::IsKeyUp(key as i32) }
     }
 
     /// Gets latest key pressed.
     #[inline]
     #[must_use]
-    pub fn get_key_pressed(&mut self) -> Option<crate::consts::KeyboardKey> {
-        let key = unsafe { ffi::GetKeyPressed() };
-        if key > 0 {
-            return key_from_i32(key);
-        }
-        None
+    pub fn get_key_pressed(&mut self) -> Option<KeyboardKey> {
+        key_from_i32(unsafe { ffi::GetKeyPressed() })
     }
 
     /// Gets latest key pressed.
     #[inline]
     #[must_use]
     pub fn get_key_pressed_number(&mut self) -> Option<u32> {
-        let key = unsafe { ffi::GetKeyPressed() };
-        if key > 0 {
-            return Some(key as u32);
-        }
-        None
+        u32::try_from(unsafe { ffi::GetKeyPressed() }).ok()
     }
 
     /// Gets latest char (unicode) pressed
     #[inline]
     #[must_use]
     pub fn get_char_pressed(&mut self) -> Option<char> {
-        let char_code = unsafe { ffi::GetCharPressed() };
-        if char_code > 0 {
-            return char::from_u32(char_code as u32);
-        }
-        None
+        u32::try_from(unsafe { ffi::GetCharPressed() })
+            .ok()
+            .and_then(char::from_u32)
     }
 
     /// Sets a custom key to exit program (default is ESC).
-    // #[inline]
-    pub fn set_exit_key(&mut self, key: Option<crate::consts::KeyboardKey>) {
-        unsafe {
-            match key {
-                Some(k) => ffi::SetExitKey((k as u32) as i32),
-                None => ffi::SetExitKey(0),
-            }
-        }
+    #[inline]
+    pub fn set_exit_key(&mut self, key: Option<KeyboardKey>) {
+        unsafe { ffi::SetExitKey(key.map_or(0, |k| k as i32)) }
     }
 
     /// Detect if a gamepad is available.
@@ -96,23 +80,23 @@ impl RaylibHandle {
     }
 
     /// Returns gamepad internal name id.
+    // TODO: Why can't this return &str?
     #[inline]
     #[must_use]
     pub fn get_gamepad_name(&self, gamepad: i32) -> Option<String> {
-        unsafe {
-            let name = ffi::GetGamepadName(gamepad);
-            match name.is_null() {
-                false => match CStr::from_ptr(name).to_str() {
-                    Ok(a) => Some(a.to_owned()),
-                    Err(err) => {
-                        trace_log(
-                            TraceLogLevel::LOG_WARNING,
-                            format!("Result of get_gamepad_name was not valid UTF-8; \"{}\". Returning None.",err).as_str(),
-                        );
-                        None
-                    }
-                },
-                true => None,
+        let name = unsafe { ffi::GetGamepadName(gamepad) };
+        if name.is_null() {
+            None
+        } else {
+            match unsafe { CStr::from_ptr(name) }.to_str() {
+                Ok(a) => Some(a.to_owned()),
+                Err(err) => {
+                    trace_log(
+                        TraceLogLevel::LOG_WARNING,
+                        format!("Result of get_gamepad_name was not valid UTF-8; \"{err}\". Returning None.").as_str(),
+                    );
+                    None
+                }
             }
         }
     }
@@ -120,52 +104,37 @@ impl RaylibHandle {
     /// Detect if a gamepad button has been pressed once.
     #[inline]
     #[must_use]
-    pub fn is_gamepad_button_pressed(
-        &self,
-        gamepad: i32,
-        button: crate::consts::GamepadButton,
-    ) -> bool {
+    pub fn is_gamepad_button_pressed(&self, gamepad: i32, button: GamepadButton) -> bool {
         unsafe { ffi::IsGamepadButtonPressed(gamepad, button as i32) }
     }
 
     /// Detect if a gamepad button is being pressed.
     #[inline]
     #[must_use]
-    pub fn is_gamepad_button_down(
-        &self,
-        gamepad: i32,
-        button: crate::consts::GamepadButton,
-    ) -> bool {
+    pub fn is_gamepad_button_down(&self, gamepad: i32, button: GamepadButton) -> bool {
         unsafe { ffi::IsGamepadButtonDown(gamepad, button as i32) }
     }
 
     /// Detect if a gamepad button has been released once.
     #[inline]
     #[must_use]
-    pub fn is_gamepad_button_released(
-        &self,
-        gamepad: i32,
-        button: crate::consts::GamepadButton,
-    ) -> bool {
+    pub fn is_gamepad_button_released(&self, gamepad: i32, button: GamepadButton) -> bool {
         unsafe { ffi::IsGamepadButtonReleased(gamepad, button as i32) }
     }
 
     /// Detect if a gamepad button is NOT being pressed.
     #[inline]
     #[must_use]
-    pub fn is_gamepad_button_up(&self, gamepad: i32, button: crate::consts::GamepadButton) -> bool {
+    pub fn is_gamepad_button_up(&self, gamepad: i32, button: GamepadButton) -> bool {
         unsafe { ffi::IsGamepadButtonUp(gamepad, button as i32) }
     }
 
     /// Gets the last gamepad button pressed.
     #[inline]
     #[must_use]
-    pub fn get_gamepad_button_pressed(&self) -> Option<crate::consts::GamepadButton> {
+    pub fn get_gamepad_button_pressed(&self) -> Option<GamepadButton> {
         let button = unsafe { ffi::GetGamepadButtonPressed() };
-        if button != raylib_sys::GamepadButton::GAMEPAD_BUTTON_UNKNOWN as i32 {
-            return Some(unsafe { std::mem::transmute(button as u32) });
-        }
-        None
+        gamepad_button_from_i32(button).filter(|b| b != &GamepadButton::GAMEPAD_BUTTON_UNKNOWN)
     }
 
     /// Returns gamepad axis count for a gamepad.
@@ -178,35 +147,35 @@ impl RaylibHandle {
     /// Returns axis movement value for a gamepad axis.
     #[inline]
     #[must_use]
-    pub fn get_gamepad_axis_movement(&self, gamepad: i32, axis: crate::consts::GamepadAxis) -> f32 {
+    pub fn get_gamepad_axis_movement(&self, gamepad: i32, axis: GamepadAxis) -> f32 {
         unsafe { ffi::GetGamepadAxisMovement(gamepad, axis as i32) }
     }
 
     /// Detect if a mouse button has been pressed once.
     #[inline]
     #[must_use]
-    pub fn is_mouse_button_pressed(&self, button: crate::consts::MouseButton) -> bool {
+    pub fn is_mouse_button_pressed(&self, button: MouseButton) -> bool {
         unsafe { ffi::IsMouseButtonPressed(button as i32) }
     }
 
     /// Detect if a mouse button is being pressed.
     #[inline]
     #[must_use]
-    pub fn is_mouse_button_down(&self, button: crate::consts::MouseButton) -> bool {
+    pub fn is_mouse_button_down(&self, button: MouseButton) -> bool {
         unsafe { ffi::IsMouseButtonDown(button as i32) }
     }
 
     /// Detect if a mouse button has been released once.
     #[inline]
     #[must_use]
-    pub fn is_mouse_button_released(&self, button: crate::consts::MouseButton) -> bool {
+    pub fn is_mouse_button_released(&self, button: MouseButton) -> bool {
         unsafe { ffi::IsMouseButtonReleased(button as i32) }
     }
 
     /// Detect if a mouse button is NOT being pressed.
     #[inline]
     #[must_use]
-    pub fn is_mouse_button_up(&self, button: crate::consts::MouseButton) -> bool {
+    pub fn is_mouse_button_up(&self, button: MouseButton) -> bool {
         unsafe { ffi::IsMouseButtonUp(button as i32) }
     }
 
@@ -240,20 +209,40 @@ impl RaylibHandle {
 
     /// Sets mouse position.
     #[inline]
-    pub fn set_mouse_position(&mut self, position: impl Into<Vector2>) {
+    pub fn set_mouse_position_xy(&mut self, x: i32, y: i32) {
         unsafe {
-            let Vector2 { x, y } = position.into();
-            ffi::SetMousePosition(x as i32, y as i32);
+            ffi::SetMousePosition(x, y);
         }
+    }
+
+    /// Sets mouse position.
+    ///
+    /// Call [`Self::set_mouse_position_xy`] for a version that actually matches the namesake
+    /// of this method and doesn't pointlessly request [`f32`]s only to cast to ints.
+    #[inline]
+    #[allow(clippy::cast_possible_truncation, reason = "ig that's the intent")]
+    pub fn set_mouse_position(&mut self, position: impl Into<Vector2>) {
+        let Vector2 { x, y } = position.into();
+        self.set_mouse_position_xy(x as i32, y as i32);
     }
 
     /// Sets mouse offset.
     #[inline]
-    pub fn set_mouse_offset(&mut self, offset: impl Into<Vector2>) {
+    pub fn set_mouse_offset_xy(&mut self, offset_x: i32, offset_y: i32) {
         unsafe {
-            let Vector2 { x, y } = offset.into();
-            ffi::SetMouseOffset(x as i32, y as i32);
+            ffi::SetMouseOffset(offset_x, offset_y);
         }
+    }
+
+    /// Sets mouse offset.
+    ///
+    /// Call [`Self::set_mouse_offset_xy`] for a version that actually matches the namesake
+    /// of this method and doesn't pointlessly request [`f32`]s only to cast to ints.
+    #[inline]
+    #[allow(clippy::cast_possible_truncation, reason = "ig that's the intent")]
+    pub fn set_mouse_offset(&mut self, offset: impl Into<Vector2>) {
+        let Vector2 { x, y } = offset.into();
+        self.set_mouse_offset_xy(x as i32, y as i32);
     }
 
     /// Sets mouse scaling.
@@ -293,21 +282,28 @@ impl RaylibHandle {
     }
 
     /// Returns touch position XY for a touch point index (relative to screen size).
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `index` is greater than [`i32::MAX`].
     #[inline]
     #[must_use]
     pub fn get_touch_position(&self, index: u32) -> Vector2 {
-        unsafe { ffi::GetTouchPosition(index as i32).into() }
+        unsafe {
+            ffi::GetTouchPosition(index.try_into().expect("index should not exceed i32::MAX"))
+                .into()
+        }
     }
 
     /// Enables a set of gestures using flags.
     #[inline]
     pub fn set_gestures_enabled(&self, gesture_flags: u32) {
         unsafe {
-            ffi::SetGesturesEnabled(gesture_flags as u32);
+            ffi::SetGesturesEnabled(gesture_flags);
         }
     }
 
-    /// Set internal gamepad mappings (SDL_GameControllerDB)
+    /// Set internal gamepad mappings (`SDL_GameControllerDB`)
     #[inline]
     #[must_use]
     pub fn set_gamepad_mappings(&self, bind: &[c_char]) -> i32 {
@@ -334,24 +330,39 @@ impl RaylibHandle {
     }
 
     /// Gets latest detected gesture.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if [`ffi::GetGestureDetected()`] returns an unrecognized gesture value.
     #[inline]
     #[must_use]
     pub fn get_gesture_detected(&self) -> Gesture {
-        unsafe { std::mem::transmute(ffi::GetGestureDetected()) }
+        let gesture = unsafe { ffi::GetGestureDetected() };
+        gesture_bitflags_from_i32(gesture).expect("unknown gesture")
     }
 
     /// Get touch point identifier for given index
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `index` is greater than [`i32::MAX`].
     #[inline]
     #[must_use]
     pub fn get_touch_point_id(&self, index: u32) -> i32 {
-        unsafe { ffi::GetTouchPointId(index as i32) }
+        unsafe { ffi::GetTouchPointId(index.try_into().expect("index should not exceed i32::MAX")) }
     }
 
     /// Gets touch points count.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if [`ffi::GetTouchPointCount`] returns a negative count.
     #[inline]
     #[must_use]
     pub fn get_touch_point_count(&self) -> u32 {
-        unsafe { ffi::GetTouchPointCount() as u32 }
+        unsafe { ffi::GetTouchPointCount() }
+            .try_into()
+            .expect("touch point count should not be negative")
     }
 
     /// Gets gesture hold time in seconds.
@@ -391,9 +402,92 @@ impl RaylibHandle {
 }
 
 #[must_use]
-pub fn key_from_i32(key: i32) -> Option<crate::consts::KeyboardKey> {
-    use crate::consts::KeyboardKey::*;
+pub const fn gamepad_button_from_i32(button: i32) -> Option<GamepadButton> {
+    #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+    use GamepadButton::*;
+    match button {
+        0 => Some(GAMEPAD_BUTTON_UNKNOWN),
+        1 => Some(GAMEPAD_BUTTON_LEFT_FACE_UP),
+        2 => Some(GAMEPAD_BUTTON_LEFT_FACE_RIGHT),
+        3 => Some(GAMEPAD_BUTTON_LEFT_FACE_DOWN),
+        4 => Some(GAMEPAD_BUTTON_LEFT_FACE_LEFT),
+        5 => Some(GAMEPAD_BUTTON_RIGHT_FACE_UP),
+        6 => Some(GAMEPAD_BUTTON_RIGHT_FACE_RIGHT),
+        7 => Some(GAMEPAD_BUTTON_RIGHT_FACE_DOWN),
+        8 => Some(GAMEPAD_BUTTON_RIGHT_FACE_LEFT),
+        9 => Some(GAMEPAD_BUTTON_LEFT_TRIGGER_1),
+        10 => Some(GAMEPAD_BUTTON_LEFT_TRIGGER_2),
+        11 => Some(GAMEPAD_BUTTON_RIGHT_TRIGGER_1),
+        12 => Some(GAMEPAD_BUTTON_RIGHT_TRIGGER_2),
+        13 => Some(GAMEPAD_BUTTON_MIDDLE_LEFT),
+        14 => Some(GAMEPAD_BUTTON_MIDDLE),
+        15 => Some(GAMEPAD_BUTTON_MIDDLE_RIGHT),
+        16 => Some(GAMEPAD_BUTTON_LEFT_THUMB),
+        17 => Some(GAMEPAD_BUTTON_RIGHT_THUMB),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub const fn gamepad_axis_from_i32(axis: i32) -> Option<GamepadAxis> {
+    #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+    use GamepadAxis::*;
+    match axis {
+        0 => Some(GAMEPAD_AXIS_LEFT_X),
+        1 => Some(GAMEPAD_AXIS_LEFT_Y),
+        2 => Some(GAMEPAD_AXIS_RIGHT_X),
+        3 => Some(GAMEPAD_AXIS_RIGHT_Y),
+        4 => Some(GAMEPAD_AXIS_LEFT_TRIGGER),
+        5 => Some(GAMEPAD_AXIS_RIGHT_TRIGGER),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub const fn gesture_from_i32(gesture: i32) -> Option<Gesture> {
+    #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+    use Gesture::*;
+    match gesture {
+        0 => Some(GESTURE_NONE),
+        1 => Some(GESTURE_TAP),
+        2 => Some(GESTURE_DOUBLETAP),
+        4 => Some(GESTURE_HOLD),
+        8 => Some(GESTURE_DRAG),
+        16 => Some(GESTURE_SWIPE_RIGHT),
+        32 => Some(GESTURE_SWIPE_LEFT),
+        64 => Some(GESTURE_SWIPE_UP),
+        128 => Some(GESTURE_SWIPE_DOWN),
+        256 => Some(GESTURE_PINCH_IN),
+        512 => Some(GESTURE_PINCH_OUT),
+        _ => None,
+    }
+}
+
+/// Returns [`None`] if any flags fall outside the range of supported bits
+#[must_use]
+pub const fn gesture_bitflags_from_i32(gesture: i32) -> Option<Gesture> {
+    if gesture == (gesture & 1023) {
+        Some(unsafe { std::mem::transmute::<i32, Gesture>(gesture) })
+    } else {
+        None
+    }
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "that's just how many enum variants there are"
+)]
+#[must_use]
+pub const fn key_from_i32(key: i32) -> Option<KeyboardKey> {
+    #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+    use KeyboardKey::*;
     match key {
+        0 => Some(KEY_NULL),
+        4 => Some(KEY_BACK),
+        5 => Some(KEY_MENU),
+        24 => Some(KEY_VOLUME_UP),
+        25 => Some(KEY_VOLUME_DOWN),
+        32 => Some(KEY_SPACE),
         39 => Some(KEY_APOSTROPHE),
         44 => Some(KEY_COMMA),
         45 => Some(KEY_MINUS),
@@ -437,7 +531,10 @@ pub fn key_from_i32(key: i32) -> Option<crate::consts::KeyboardKey> {
         88 => Some(KEY_X),
         89 => Some(KEY_Y),
         90 => Some(KEY_Z),
-        32 => Some(KEY_SPACE),
+        91 => Some(KEY_LEFT_BRACKET),
+        92 => Some(KEY_BACKSLASH),
+        93 => Some(KEY_RIGHT_BRACKET),
+        96 => Some(KEY_GRAVE),
         256 => Some(KEY_ESCAPE),
         257 => Some(KEY_ENTER),
         258 => Some(KEY_TAB),
@@ -478,10 +575,6 @@ pub fn key_from_i32(key: i32) -> Option<crate::consts::KeyboardKey> {
         346 => Some(KEY_RIGHT_ALT),
         347 => Some(KEY_RIGHT_SUPER),
         348 => Some(KEY_KB_MENU),
-        91 => Some(KEY_LEFT_BRACKET),
-        92 => Some(KEY_BACKSLASH),
-        93 => Some(KEY_RIGHT_BRACKET),
-        96 => Some(KEY_GRAVE),
         320 => Some(KEY_KP_0),
         321 => Some(KEY_KP_1),
         322 => Some(KEY_KP_2),

--- a/raylib/src/core/input.rs
+++ b/raylib/src/core/input.rs
@@ -401,6 +401,9 @@ impl RaylibHandle {
     }
 }
 
+/// Safely convert [`i32`] to [`GamepadButton`].
+///
+/// Returns [`None`] if `button` is not a valid discriminant of [`GamepadButton`].
 #[must_use]
 pub const fn gamepad_button_from_i32(button: i32) -> Option<GamepadButton> {
     #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
@@ -428,6 +431,9 @@ pub const fn gamepad_button_from_i32(button: i32) -> Option<GamepadButton> {
     }
 }
 
+/// Safely convert [`i32`] to [`GamepadAxis`].
+///
+/// Returns [`None`] if `axis` is not a valid discriminant of [`GamepadAxis`].
 #[must_use]
 pub const fn gamepad_axis_from_i32(axis: i32) -> Option<GamepadAxis> {
     #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
@@ -443,6 +449,9 @@ pub const fn gamepad_axis_from_i32(axis: i32) -> Option<GamepadAxis> {
     }
 }
 
+/// Safely convert [`i32`] to a single [`Gesture`].
+///
+/// Returns [`None`] if `gesture` is not a valid discriminant of [`Gesture`].
 #[must_use]
 pub const fn gesture_from_i32(gesture: i32) -> Option<Gesture> {
     #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
@@ -463,6 +472,8 @@ pub const fn gesture_from_i32(gesture: i32) -> Option<Gesture> {
     }
 }
 
+/// Convert [`i32`] to a bitmask [`Gesture`].
+///
 /// Returns [`None`] if any flags fall outside the range of supported bits
 #[must_use]
 pub const fn gesture_bitflags_from_i32(gesture: i32) -> Option<Gesture> {
@@ -473,6 +484,9 @@ pub const fn gesture_bitflags_from_i32(gesture: i32) -> Option<Gesture> {
     }
 }
 
+/// Safely convert [`i32`] to a [`KeyboardKey`].
+///
+/// Returns [`None`] if `key` is not a valid discriminant of [`KeyboardKey`].
 #[allow(
     clippy::too_many_lines,
     reason = "that's just how many enum variants there are"

--- a/raylib/src/core/logging.rs
+++ b/raylib/src/core/logging.rs
@@ -1,4 +1,5 @@
-///! Functions to change the behavior of raylib logging.
+//! Functions to change the behavior of raylib logging.
+
 // TODO: refactor this entire thing to use log
 use crate::consts::TraceLogLevel;
 use crate::ffi;
@@ -8,15 +9,19 @@ use std::ffi::CString;
 #[inline]
 pub fn set_trace_log(types: TraceLogLevel) {
     unsafe {
-        ffi::SetTraceLogLevel((types as u32) as i32);
+        ffi::SetTraceLogLevel(types as i32);
     }
 }
 
-/// Writes a trace log message (`Log::INFO`, `Log::WARNING`, `Log::ERROR`, `Log::DEBUG`).
+/// Writes a trace log message ([`LOG_INFO`](TraceLogLevel::LOG_INFO), [`LOG_WARNING`](TraceLogLevel::LOG_WARNING), [`LOG_ERROR`](TraceLogLevel::LOG_ERROR), [`LOG_DEBUG`](TraceLogLevel::LOG_DEBUG)).
+///
+/// # Panics
+///
+/// This function will panic if `text` contains an internal 0 byte.
 #[inline]
 pub fn trace_log(msg_type: TraceLogLevel, text: &str) {
     unsafe {
-        let text = CString::new(text).unwrap();
-        ffi::TraceLog((msg_type as u32) as i32, text.as_ptr());
+        let text = CString::new(text).expect("text should not contain an internal 0 byte");
+        ffi::TraceLog(msg_type as i32, text.as_ptr());
     }
 }

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -25,15 +25,17 @@ macro_rules! make_thin_wrapper {
 
 macro_rules! make_thin_wrapper_lifetime {
     ($(#[$attrs:meta])* $name:ident, $t1:ty, $t2:ty, $dropfunc:expr) => {
-        make_thin_wrapper_lifetime!($name, $t1, $t2, $dropfunc, true);
+        make_thin_wrapper_lifetime!($(#[$attrs])* $name, $t1, $t2, $dropfunc, true);
     };
     ($(#[$attrs:meta])* $name:ident, $t1:ty, $t2:ty,$dropfunc:expr, false) => {
+        $(#[$attrs])*
         #[derive(Debug)]
         pub struct $name<'a>(pub(crate) $t1, &'a $t2);
 
         impl_wrapper!($name, $t1, $dropfunc, 0);
     };
     ($(#[$attrs:meta])* $name:ident, $t1:ty, $t2:ty, $dropfunc:expr, true) => {
+        $(#[$attrs])*
         #[derive(Debug)]
         pub struct $name<'a>(pub(crate) $t1, &'a $t2);
 

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -53,7 +53,7 @@ macro_rules! impl_wrapper {
             /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
             /// and copies must not be used after being unloaded to avoid use-after-free.
             #[must_use]
-            pub unsafe fn unwrap(self) -> $t {
+            pub const unsafe fn unwrap(self) -> $t {
                 let inner = self.$rawfield;
                 std::mem::forget(self);
                 inner
@@ -78,7 +78,7 @@ macro_rules! gen_from_raw_wrapper {
         impl$(<$lifetime>)? $name$(<$lifetime>)? {
             /// Returns the unwrapped raylib-sys object.
             #[must_use]
-            pub fn to_raw(self) -> $t {
+            pub const fn to_raw(self) -> $t {
                 let raw = self.$rawfield;
                 std::mem::forget(self);
                 raw
@@ -92,7 +92,7 @@ macro_rules! gen_from_raw_wrapper {
             /// If there are any aliases to `raw`, they must not be used after this function's return drops,
             /// and Rust's aliasing rules must be ensured by the caller.
             #[must_use]
-            pub unsafe fn from_raw(raw: $t) -> Self {
+            pub const unsafe fn from_raw(raw: $t) -> Self {
                 Self(raw)
             }
         }

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -52,7 +52,7 @@ macro_rules! impl_wrapper {
             /// # Safety
             ///
             /// Must manually free memory by calling the proper unload function.
-            /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+            /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
             /// and copies must not be used after being unloaded to avoid use-after-free.
             #[must_use]
             pub const unsafe fn unwrap(self) -> $t {
@@ -185,5 +185,19 @@ macro_rules! impl_rslice {
                 &mut self.$rawfield
             }
         }
+    };
+}
+
+/// Assert at compiletime that the size and offsets of each field in `$A` matches with the corresponding fields in `$B`.
+/// This macro should guarantee transmutation between safe and ffi versions of the same struct is valid.
+macro_rules! assert_layout_compat {
+    (
+        $A:ty { $($a_fields:ident),* $(,)? },
+        $B:ty { $($b_fields:ident),* $(,)? } $(,)?
+    ) => {
+        const _: () = {
+            assert!(::std::mem::size_of::<$A>() == ::std::mem::size_of::<$B>());
+            $(assert!(::std::mem::offset_of!($A, $a_fields) == ::std::mem::offset_of!($B, $b_fields));)*
+        };
     };
 }

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -45,7 +45,14 @@ macro_rules! make_thin_wrapper_lifetime {
 macro_rules! impl_wrapper {
     ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
         impl$(<$lifetime>)? $name$(<$lifetime>)? {
-            /// Take the raw ffi type. Must manually free memory by calling the proper unload function
+            /// Take the raw ffi type.
+            ///
+            /// # Safety
+            ///
+            /// Must manually free memory by calling the proper unload function.
+            /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+            /// and copies must not be used after being unloaded to avoid use-after-free.
+            #[must_use]
             pub unsafe fn unwrap(self) -> $t {
                 let inner = self.$rawfield;
                 std::mem::forget(self);
@@ -56,29 +63,35 @@ macro_rules! impl_wrapper {
         impl$(<$lifetime>)? Drop for $name$(<$lifetime>)? {
             #[allow(unused_unsafe)]
             fn drop(&mut self) {
+                // SAFETY: `Self` does not implement `Clone`, and `unwrap` takes ownership of `self`.
+                // Taking `self` by mutable reference guarantees it has no aliases.
                 unsafe {
                     ($dropfunc)(self.$rawfield);
                 }
             }
         }
-
-
     };
 }
 
 macro_rules! gen_from_raw_wrapper {
     ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
         impl$(<$lifetime>)? $name$(<$lifetime>)? {
-            /// returns the unwrapped raylib-sys object
+            /// Returns the unwrapped raylib-sys object.
+            #[must_use]
             pub fn to_raw(self) -> $t {
                 let raw = self.$rawfield;
                 std::mem::forget(self);
                 raw
             }
 
-            /// converts raylib-sys object to a "safe"
-            /// version. Make sure to call this function
-            /// from the thread the resource was created.
+            /// Converts raylib-sys object to a "safe" version.
+            ///
+            /// # Safety
+            ///
+            /// Make sure to call this function from the thread the resource was created.
+            /// If there are any aliases to `raw`, they must not be used after this function's return drops,
+            /// and Rust's aliasing rules must be ensured by the caller.
+            #[must_use]
             pub unsafe fn from_raw(raw: $t) -> Self {
                 Self(raw)
             }
@@ -90,13 +103,13 @@ macro_rules! deref_impl_wrapper {
     ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
         impl$(<$lifetime>)? std::convert::AsRef<$t> for $name$(<$lifetime>)? {
             fn as_ref(&self) -> &$t {
-                &self.$rawfield
+                self
             }
         }
 
         impl$(<$lifetime>)? std::convert::AsMut<$t> for $name$(<$lifetime>)? {
             fn as_mut(&mut self) -> &mut $t {
-                &mut self.$rawfield
+                self
             }
         }
 
@@ -116,6 +129,7 @@ macro_rules! deref_impl_wrapper {
         }
     };
 }
+
 macro_rules! make_rslice {
     ($(#[$attrs:meta])* $name:ident, $t:ty, $dropfunc:expr) => {
         $(#[$attrs])*
@@ -132,10 +146,8 @@ macro_rules! impl_rslice {
         impl Drop for $name {
             #[allow(unused_unsafe)]
             fn drop(&mut self) {
-                unsafe {
-                    let inner = std::mem::ManuallyDrop::take(&mut self.0);
-                    ($dropfunc)(std::boxed::Box::leak(inner).as_mut_ptr() as *mut _);
-                }
+                let inner = unsafe { std::mem::ManuallyDrop::take(&mut self.0) };
+                unsafe { ($dropfunc)(std::boxed::Box::leak(inner).as_mut_ptr().cast()) };
             }
         }
 

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -61,7 +61,10 @@ macro_rules! impl_wrapper {
         }
 
         impl$(<$lifetime>)? Drop for $name$(<$lifetime>)? {
-            #[allow(unused_unsafe)]
+            #[allow(
+                unused_unsafe,
+                reason = "$dropfunc is not unsafe in every instance of this macro"
+            )]
             fn drop(&mut self) {
                 // SAFETY: `Self` does not implement `Clone`, and `unwrap` takes ownership of `self`.
                 // Taking `self` by mutable reference guarantees it has no aliases.
@@ -144,7 +147,10 @@ macro_rules! make_rslice {
 macro_rules! impl_rslice {
     ($name:ident, $t:ty, $dropfunc:expr, $rawfield:tt) => {
         impl Drop for $name {
-            #[allow(unused_unsafe)]
+            #[allow(
+                unused_unsafe,
+                reason = "$dropfunc is not unsafe in every instance of this macro"
+            )]
             fn drop(&mut self) {
                 let inner = unsafe { std::mem::ManuallyDrop::take(&mut self.0) };
                 unsafe { ($dropfunc)(std::boxed::Box::leak(inner).as_mut_ptr().cast()) };

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -298,7 +298,7 @@ impl Quaternion {
     /// Returns a normalized version of the current quaternion.
     #[inline]
     #[must_use]
-    #[allow(clippy::similar_names)]
+    #[allow(clippy::similar_names, reason = "consistency with Raylib definition")]
     pub fn normalized(&self) -> Quaternion {
         let mut length = self.length();
         if length == 0.0 {
@@ -427,7 +427,7 @@ impl From<(f32, f32, f32, f32)> for Quaternion {
 
 impl Mul for Quaternion {
     type Output = Quaternion;
-    #[allow(clippy::similar_names)]
+    #[allow(clippy::similar_names, reason = "consistency with Raylib definition")]
     fn mul(self, q: Quaternion) -> Quaternion {
         let qax = self.x;
         let qay = self.y;
@@ -455,7 +455,6 @@ impl MulAssign for Quaternion {
 
 optional_serde_struct! {
     /// Matrix, 4x4 components, column major, OpenGL style, right-handed
-    #[allow(missing_docs)]
     pub struct Matrix {
         // Matrix first row (4 components)
         /// row 1 column 1
@@ -643,7 +642,7 @@ impl Matrix {
 
     /// Returns xyz-rotation matrix (angles in radians)
     #[must_use]
-    #[allow(clippy::similar_names)]
+    #[allow(clippy::similar_names, reason = "consistency with Raylib definition")]
     pub fn rotate_xyz(ang: Vector3) -> Self {
         let mut result = Self::identity();
 

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -153,9 +153,10 @@ impl Quaternion {
             }
         }
     }
+
+    /// Returns a rotation matrix for the current quaternion.
     #[inline]
     #[must_use]
-    /// Returns a rotation matrix for the current quaternion.
     pub fn to_matrix(&self) -> Matrix {
         let x = self.x;
         let y = self.y;
@@ -200,9 +201,10 @@ impl Quaternion {
             m15: 1.0,
         }
     }
+
+    /// Returns a quaternion equivalent to Euler angles.
     #[inline]
     #[must_use]
-    /// Returns a quaternion equivalent to Euler angles.
     pub fn from_euler(pitch: f32, yaw: f32, roll: f32) -> Quaternion {
         let x0 = (pitch * 0.5).cos();
         let x1 = (pitch * 0.5).sin();
@@ -218,9 +220,10 @@ impl Quaternion {
             w: (x0 * y0 * z0) + (x1 * y1 * z1),
         }
     }
+
+    /// Returns a vector containing Euler angles in radians (roll, pitch, yaw), based on the current quaternion.
     #[inline]
     #[must_use]
-    /// Returns a vector containing Euler angles in radians (roll, pitch, yaw), based on the current quaternion.
     pub fn to_euler(&self) -> Vector3 {
         // roll (x-axis rotation)
         let x0 = 2.0 * (self.w * self.x + self.y * self.z);
@@ -241,9 +244,10 @@ impl Quaternion {
             z: z0.atan2(z1),
         }
     }
+
+    /// Returns rotation quaternion for an `axis` and `angle` (in radians).
     #[inline]
     #[must_use]
-    /// Returns rotation quaternion for an `axis` and `angle` (in radians).
     pub fn from_axis_angle(axis: Vector3, angle: f32) -> Quaternion {
         let mut result = Quaternion::identity();
         let mut axis = axis;
@@ -264,9 +268,10 @@ impl Quaternion {
         result.w = cosres;
         result.normalized()
     }
+
+    /// Returns a 2-tuple containing the axis (`Vector3`) and angle (`f32` in radians) for the current quaternion.
     #[inline]
     #[must_use]
-    /// Returns a 2-tuple containing the axis (`Vector3`) and angle (`f32` in radians) for the current quaternion.
     pub fn to_axis_angle(&self) -> (Vector3, f32) {
         let mut q = *self;
         if q.w.abs() > 1.0 {
@@ -315,9 +320,10 @@ impl Quaternion {
             w: self.w * ilength,
         }
     }
+
+    /// Returns an inverted version of the current quaternion.
     #[inline]
     #[must_use]
-    /// Returns an inverted version of the current quaternion.
     pub fn inverted(&self) -> Quaternion {
         let mut result = *self;
         let length = self.length();
@@ -332,10 +338,11 @@ impl Quaternion {
         }
         result
     }
-    #[inline]
-    #[must_use]
+
     /// Calculates linear interpolation between current and `q` quaternions.
     /// Returns an inverted version of the current quaternion.
+    #[inline]
+    #[must_use]
     pub const fn lerp(&self, q: Quaternion, amount: f32) -> Quaternion {
         Quaternion {
             x: self.x + amount * (q.x - self.x),
@@ -671,8 +678,8 @@ impl Matrix {
     }
 
     /// Returns a scaling matrix.
-    #[must_use]
     #[inline]
+    #[must_use]
     #[rustfmt::skip]
     pub const fn scale(x: f32, y: f32, z: f32) -> Matrix {
         Matrix {
@@ -683,8 +690,8 @@ impl Matrix {
         }
     }
 
-    #[must_use]
     /// Returns perspective projection matrix based on frustum parameters.
+    #[must_use]
     pub fn frustum(left: f32, right: f32, bottom: f32, top: f32, near: f32, far: f32) -> Matrix {
         let rl = right - left;
         let tb = top - bottom;
@@ -713,16 +720,16 @@ impl Matrix {
         }
     }
 
-    #[must_use]
     /// Returns perspective projection matrix.
+    #[must_use]
     pub fn perspective(fovy: f32, aspect: f32, near: f32, far: f32) -> Matrix {
         let top = near * (fovy * 0.5).tan();
         let right = top * aspect;
         Matrix::frustum(-right, right, -top, top, near, far)
     }
 
-    #[must_use]
     /// Returns orthographic projection matrix.
+    #[must_use]
     pub fn ortho(left: f32, right: f32, bottom: f32, top: f32, near: f32, far: f32) -> Matrix {
         let rl = right - left;
         let tb = top - bottom;
@@ -748,8 +755,8 @@ impl Matrix {
         }
     }
 
-    #[must_use]
     /// Returns camera look-at matrix (view matrix).
+    #[must_use]
     pub fn look_at(eye: Vector3, target: Vector3, up: Vector3) -> Matrix {
         let z = (eye - target).normalize();
         let x = up.cross(z).normalize();
@@ -776,8 +783,8 @@ impl Matrix {
         .inverted()
     }
 
-    #[must_use]
     /// Calculates the determinant of the current matrix.
+    #[must_use]
     pub const fn determinant(&self) -> f32 {
         let a00 = self.m0;
         let a01 = self.m1;
@@ -819,16 +826,17 @@ impl Matrix {
             - a10 * a01 * a22 * a33
             + a00 * a11 * a22 * a33
     }
-    #[must_use]
-    #[inline]
+
     /// Calculates the trace of the matrix (sum of the values along the diagonal).
+    #[inline]
+    #[must_use]
     pub const fn trace(&self) -> f32 {
         self.m0 + self.m5 + self.m10 + self.m15
     }
 
-    #[must_use]
-    #[inline]
     /// Returns a new `Matrix` transposed from the current one.
+    #[inline]
+    #[must_use]
     pub const fn transposed(&self) -> Matrix {
         Matrix {
             m0: self.m0,
@@ -849,8 +857,9 @@ impl Matrix {
             m15: self.m15,
         }
     }
-    #[must_use]
+
     /// Returns a new `Matrix` inverted from the current one.
+    #[must_use]
     pub const fn inverted(&self) -> Matrix {
         let a00 = self.m0;
         let a01 = self.m1;
@@ -1061,8 +1070,8 @@ impl From<&Ray> for ffi::Ray {
 
 impl Ray {
     /// Construct a [`Ray`] from a start position and direction.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const fn new(position: Vector3, direction: Vector3) -> Self {
         Self {
             position,
@@ -1086,8 +1095,8 @@ optional_serde_struct! {
 
 impl BoundingBox {
     /// Construct a [`BoundingBox`] from its `min` and `max` points.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const fn new(min: Vector3, max: Vector3) -> BoundingBox {
         BoundingBox { min, max }
     }

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -15,15 +15,18 @@ Permission is granted to anyone to use this software for any purpose, including 
 */
 
 use crate::misc::AsF32;
-use crate::{ffi, MintVec3};
+use crate::{MintVec3, ffi};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Range, Sub, SubAssign};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 pub use glam;
+/// Vector2, 2 components
 pub type Vector2 = glam::Vec2;
+/// Vector3, 3 components
 pub type Vector3 = glam::Vec3;
+/// Vector4, 4 components
 pub type Vector4 = glam::Vec4;
 // note(jest): Transform and Matrix do not use glam because of incompat struct alignment so they are manually implemented below
 
@@ -36,14 +39,14 @@ macro_rules! optional_serde_struct {
     };
 }
 
-/// A convenience function for linearly interpolating an `f32`.
+/// A convenience function for linearly interpolating an [`f32`].
 #[inline]
 #[must_use]
 pub const fn lerp(v0: f32, v1: f32, amount: f32) -> f32 {
     v0 + amount * (v1 - v0)
 }
 
-/// A convenience function for making a new `Quaternion`.
+/// A convenience function for making a new [`Quaternion`].
 #[inline]
 #[must_use]
 pub fn rquat<T1: AsF32, T2: AsF32, T3: AsF32, T4: AsF32>(x: T1, y: T2, z: T3, w: T4) -> Quaternion {
@@ -51,6 +54,7 @@ pub fn rquat<T1: AsF32, T2: AsF32, T3: AsF32, T4: AsF32>(x: T1, y: T2, z: T3, w:
 }
 
 optional_serde_struct!(
+    /// Quaternion, 4 components (Vector4 alias)
     pub struct Quaternion {
         x: f32,
         y: f32,
@@ -60,7 +64,7 @@ optional_serde_struct!(
 );
 
 impl Quaternion {
-    /// Returns a new `Quaternion` with specified components.
+    /// Returns a new [`Quaternion`] with specified components.
     #[inline]
     #[must_use]
     pub const fn new(x: f32, y: f32, z: f32, w: f32) -> Quaternion {
@@ -290,9 +294,11 @@ impl Quaternion {
     pub fn length(&self) -> f32 {
         (self.x * self.x + self.y * self.y + self.z * self.z + self.w * self.w).sqrt()
     }
+
+    /// Returns a normalized version of the current quaternion.
     #[inline]
     #[must_use]
-    /// Returns a normalized version of the current quaternion.
+    #[allow(clippy::similar_names)]
     pub fn normalized(&self) -> Quaternion {
         let mut length = self.length();
         if length == 0.0 {
@@ -421,6 +427,7 @@ impl From<(f32, f32, f32, f32)> for Quaternion {
 
 impl Mul for Quaternion {
     type Output = Quaternion;
+    #[allow(clippy::similar_names)]
     fn mul(self, q: Quaternion) -> Quaternion {
         let qax = self.x;
         let qay = self.y;
@@ -448,26 +455,43 @@ impl MulAssign for Quaternion {
 
 optional_serde_struct! {
     /// Matrix, 4x4 components, column major, OpenGL style, right-handed
+    #[allow(missing_docs)]
     pub struct Matrix {
         // Matrix first row (4 components)
+        /// row 1 column 1
         pub m0: f32,
+        /// row 1 column 2
         pub m4: f32,
+        /// row 1 column 3
         pub m8: f32,
+        /// row 1 column 4
         pub m12: f32,
         // Matrix second row (4 components)
+        /// row 2 column 1
         pub m1: f32,
+        /// row 2 column 2
         pub m5: f32,
+        /// row 2 column 3
         pub m9: f32,
+        /// row 2 column 4
         pub m13: f32,
         // Matrix third row (4 components)
+        /// row 3 column 1
         pub m2: f32,
+        /// row 3 column 2
         pub m6: f32,
+        /// row 3 column 3
         pub m10: f32,
+        /// row 3 column 4
         pub m14: f32,
         // Matrix fourth row (4 components)
+        /// row 4 column 1
         pub m3: f32,
+        /// row 4 column 2
         pub m7: f32,
+        /// row 4 column 3
         pub m11: f32,
+        /// row 4 column 4
         pub m15: f32,
     }
 }
@@ -494,72 +518,39 @@ impl Matrix {
     /// Returns the identity matrix.
     #[inline]
     #[must_use]
+    #[rustfmt::skip]
     pub const fn identity() -> Matrix {
         Matrix {
-            m0: 1.0,
-            m4: 0.0,
-            m8: 0.0,
-            m12: 0.0,
-            m1: 0.0,
-            m5: 1.0,
-            m9: 0.0,
-            m13: 0.0,
-            m2: 0.0,
-            m6: 0.0,
-            m10: 1.0,
-            m14: 0.0,
-            m3: 0.0,
-            m7: 0.0,
-            m11: 0.0,
-            m15: 1.0,
+            m0: 1.0, m4: 0.0, m8:  0.0, m12: 0.0,
+            m1: 0.0, m5: 1.0, m9:  0.0, m13: 0.0,
+            m2: 0.0, m6: 0.0, m10: 1.0, m14: 0.0,
+            m3: 0.0, m7: 0.0, m11: 0.0, m15: 1.0,
         }
     }
 
     /// Returns the zero matriz.
     #[inline]
     #[must_use]
+    #[rustfmt::skip]
     pub const fn zero() -> Matrix {
         Matrix {
-            m0: 0.0,
-            m4: 0.0,
-            m8: 0.0,
-            m12: 0.0,
-            m1: 0.0,
-            m5: 0.0,
-            m9: 0.0,
-            m13: 0.0,
-            m2: 0.0,
-            m6: 0.0,
-            m10: 0.0,
-            m14: 0.0,
-            m3: 0.0,
-            m7: 0.0,
-            m11: 0.0,
-            m15: 0.0,
+            m0: 0.0, m4: 0.0, m8:  0.0, m12: 0.0,
+            m1: 0.0, m5: 0.0, m9:  0.0, m13: 0.0,
+            m2: 0.0, m6: 0.0, m10: 0.0, m14: 0.0,
+            m3: 0.0, m7: 0.0, m11: 0.0, m15: 0.0,
         }
     }
 
     /// Returns a translation matrix.
     #[inline]
     #[must_use]
+    #[rustfmt::skip]
     pub const fn translate(x: f32, y: f32, z: f32) -> Matrix {
         Matrix {
-            m0: 1.0,
-            m4: 0.0,
-            m8: 0.0,
-            m12: x,
-            m1: 0.0,
-            m5: 1.0,
-            m9: 0.0,
-            m13: y,
-            m2: 0.0,
-            m6: 0.0,
-            m10: 1.0,
-            m14: z,
-            m3: 0.0,
-            m7: 0.0,
-            m11: 0.0,
-            m15: 1.0,
+            m0: 1.0, m4: 0.0, m8:  0.0, m12:   x,
+            m1: 0.0, m5: 1.0, m9:  0.0, m13:   y,
+            m2: 0.0, m6: 0.0, m10: 1.0, m14:   z,
+            m3: 0.0, m7: 0.0, m11: 0.0, m15: 1.0,
         }
     }
 
@@ -571,7 +562,7 @@ impl Matrix {
         let mut z = axis.z;
         let mut length = (x * x + y * y + z * z).sqrt();
 
-        if (length != 1.0) && (length != 0.0) {
+        if ((length - 1.0).abs() > f32::EPSILON) && (length != 0.0) {
             length = 1.0 / length;
             x *= length;
             y *= length;
@@ -605,8 +596,8 @@ impl Matrix {
         }
     }
 
-    #[must_use]
     /// Returns a translation matrix around the X axis.
+    #[must_use]
     pub fn rotate_x(angle: f32) -> Matrix {
         let mut result = Matrix::identity();
 
@@ -620,8 +611,8 @@ impl Matrix {
         result
     }
 
-    #[must_use]
     /// Returns a translation matrix around the Y axis.
+    #[must_use]
     pub fn rotate_y(angle: f32) -> Matrix {
         let mut result = Matrix::identity();
 
@@ -635,8 +626,8 @@ impl Matrix {
         result
     }
 
-    #[must_use]
     /// Returns a translation matrix around the Z axis.
+    #[must_use]
     pub fn rotate_z(angle: f32) -> Matrix {
         let mut result = Matrix::identity();
 
@@ -650,8 +641,9 @@ impl Matrix {
         result
     }
 
-    #[must_use]
     /// Returns xyz-rotation matrix (angles in radians)
+    #[must_use]
+    #[allow(clippy::similar_names)]
     pub fn rotate_xyz(ang: Vector3) -> Self {
         let mut result = Self::identity();
 
@@ -677,27 +669,16 @@ impl Matrix {
         result
     }
 
-    #[must_use]
     /// Returns a scaling matrix.
+    #[must_use]
     #[inline]
+    #[rustfmt::skip]
     pub const fn scale(x: f32, y: f32, z: f32) -> Matrix {
         Matrix {
-            m0: x,
-            m4: 0.0,
-            m8: 0.0,
-            m12: 0.0,
-            m1: 0.0,
-            m5: y,
-            m9: 0.0,
-            m13: 0.0,
-            m2: 0.0,
-            m6: 0.0,
-            m10: z,
-            m14: 0.0,
-            m3: 0.0,
-            m7: 0.0,
-            m11: 0.0,
-            m15: 1.0,
+            m0:   x, m4: 0.0, m8:  0.0, m12: 0.0,
+            m1: 0.0, m5:   y, m9:  0.0, m13: 0.0,
+            m2: 0.0, m6: 0.0, m10:   z, m14: 0.0,
+            m3: 0.0, m7: 0.0, m11: 0.0, m15: 1.0,
         }
     }
 
@@ -1078,6 +1059,7 @@ impl From<&Ray> for ffi::Ray {
 }
 
 impl Ray {
+    /// Construct a [`Ray`] from a start position and direction.
     #[must_use]
     #[inline]
     pub const fn new(position: Vector3, direction: Vector3) -> Self {
@@ -1088,10 +1070,11 @@ impl Ray {
     }
 }
 
+/// Rectangle, 4 components
 pub type Rectangle = ffi::Rectangle;
 
 optional_serde_struct! {
-    /// BoundingBox
+    /// [`BoundingBox`]
     pub struct BoundingBox {
         /// Minimum vertex box-corner
         pub min: Vector3,
@@ -1101,26 +1084,30 @@ optional_serde_struct! {
 }
 
 impl BoundingBox {
+    /// Construct a [`BoundingBox`] from its `min` and `max` points.
     #[must_use]
     #[inline]
-    pub fn new(min: Vector3, max: Vector3) -> BoundingBox {
+    pub const fn new(min: Vector3, max: Vector3) -> BoundingBox {
         BoundingBox { min, max }
     }
 }
 
 impl From<ffi::BoundingBox> for BoundingBox {
+    #[inline]
     fn from(r: ffi::BoundingBox) -> BoundingBox {
         unsafe { std::mem::transmute(r) }
     }
 }
 
 impl From<BoundingBox> for ffi::BoundingBox {
+    #[inline]
     fn from(v: BoundingBox) -> ffi::BoundingBox {
         unsafe { std::mem::transmute(v) }
     }
 }
 
 impl From<&BoundingBox> for ffi::BoundingBox {
+    #[inline]
     fn from(v: &BoundingBox) -> ffi::BoundingBox {
         unsafe { std::mem::transmute(*v) }
     }
@@ -1154,7 +1141,7 @@ impl BoundingBox {
 }
 
 optional_serde_struct! {
-    /// RayCollision, ray hit information
+    /// [`RayCollision`], ray hit information
     pub struct RayCollision {
         /// Did the ray hit something?
         pub hit: bool,
@@ -1168,18 +1155,21 @@ optional_serde_struct! {
 }
 
 impl From<ffi::RayCollision> for RayCollision {
+    #[inline]
     fn from(r: ffi::RayCollision) -> RayCollision {
         unsafe { std::mem::transmute(r) }
     }
 }
 
 impl From<RayCollision> for ffi::RayCollision {
+    #[inline]
     fn from(v: RayCollision) -> ffi::RayCollision {
         unsafe { std::mem::transmute(v) }
     }
 }
 
 impl From<&RayCollision> for ffi::RayCollision {
+    #[inline]
     fn from(v: &RayCollision) -> ffi::RayCollision {
         unsafe { std::mem::transmute(*v) }
     }
@@ -1221,6 +1211,10 @@ mod math_test {
     use crate::{ffi, math::Matrix};
 
     #[test]
+    #[allow(
+        clippy::float_cmp,
+        reason = "no math operations are being performed, only transmutation"
+    )]
     fn test_into() {
         let v2: ffi::Vector2 = (Vector2 { x: 1.0, y: 2.0 }).into();
         assert!(v2.x == 1.0 && v2.y == 2.0, "bad memory transmutation");

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1,3 +1,5 @@
+//! Structs and functions for game-related math and linear algebra
+
 /* raylib-rs
    raymath.rs - Structs and functions for game-related math and linear algebra
 

--- a/raylib/src/core/misc.rs
+++ b/raylib/src/core/misc.rs
@@ -46,6 +46,7 @@ impl IntoIterator for RandomSequence {
         RandSeqIterator(self, 0)
     }
 }
+
 /// Iterator over [`RandomSequence`] elements.
 pub struct RandSeqIterator(RandomSequence, usize);
 

--- a/raylib/src/core/misc.rs
+++ b/raylib/src/core/misc.rs
@@ -1,99 +1,131 @@
 //! Useful functions that don't fit anywhere else
 
-use crate::core::texture::Image;
-use crate::core::{RaylibHandle, RaylibThread};
-use crate::ffi;
-use std::ffi::CString;
-use std::ops::{Deref, DerefMut, Range};
-use std::usize;
+use crate::{
+    core::{RaylibHandle, RaylibThread, texture::Image},
+    ffi,
+};
+use std::{
+    ffi::CString,
+    ops::{Deref, DerefMut, Range},
+    ptr::NonNull,
+};
 
-/// Struct for holding the result of RaylibHandle::load_random_sequence.
-/// This is a thin wrapper for an array of i32. The reason it exists is because Raylib expects you
+/// Struct for holding the result of [`RaylibHandle::load_random_sequence`].
+/// This is a thin wrapper for an array of [`i32`]. The reason it exists is because Raylib expects you
 /// to unload the sequence it creates manually, and this struct does it for you.
-pub struct RandomSequence<'a>(&'a mut [i32]);
+pub struct RandomSequence(NonNull<[i32]>);
 
-impl<'a> Deref for RandomSequence<'a> {
+impl Deref for RandomSequence {
     type Target = [i32];
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
-        self.0
+        unsafe { self.0.as_ref() }
     }
 }
 
-impl<'a> DerefMut for RandomSequence<'a> {
+impl DerefMut for RandomSequence {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        unsafe { self.0.as_mut() }
     }
 }
 
-impl<'a> Drop for RandomSequence<'a> {
+impl Drop for RandomSequence {
     fn drop(&mut self) {
-        unsafe { ffi::UnloadRandomSequence(self.0.as_mut_ptr()) }
+        unsafe { ffi::UnloadRandomSequence(self.0.as_ptr().cast()) }
     }
 }
 
-impl<'a> IntoIterator for RandomSequence<'a> {
+impl IntoIterator for RandomSequence {
     type Item = i32;
+    type IntoIter = RandSeqIterator;
 
-    type IntoIter = RandSeqIterator<'a>;
-
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         RandSeqIterator(self, 0)
     }
 }
-pub struct RandSeqIterator<'a>(RandomSequence<'a>, usize);
+/// Iterator over [`RandomSequence`] elements.
+pub struct RandSeqIterator(RandomSequence, usize);
 
-impl<'a> Iterator for RandSeqIterator<'a> {
+impl Iterator for RandSeqIterator {
     type Item = i32;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ret = self.0.get(self.1);
-        self.1 += 1;
-        match ret {
-            Some(a) => Some(*a),
-            None => None,
-        }
+        self.1
+            .checked_add(1)
+            .filter(|n| *n < self.0.len())
+            .map(|n| self.0[std::mem::replace(&mut self.1, n)])
     }
 }
 
+impl ExactSizeIterator for RandSeqIterator {
+    fn len(&self) -> usize {
+        self.0.len() - self.1
+    }
+}
+
+impl std::iter::FusedIterator for RandSeqIterator {}
+
 /// Open URL with default system browser (if available)
+///
+/// # Example
 /// ```ignore
 /// use raylib::*;
 /// fn main() {
 ///     open_url("https://google.com");
 /// }
+/// ```
+///
+/// # Panics
+///
+/// This function will panic if `url` contains an internal 0 byte
 pub fn open_url(url: &str) {
-    let s = CString::new(url).expect("Not a string");
+    let s = CString::new(url).expect("url should not contain an internal 0 byte");
     unsafe {
         ffi::OpenURL(s.as_ptr());
     }
 }
 
 impl RaylibHandle {
+    /// Load random values sequence, no values repeated, min and max included
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if [`ffi::LoadRandomSequence`] errors or if `count` is greater than [`usize::MAX`].
+    // This function should definitely return `Option<RandomSequence>` and `num` should be a `RangeInclusive<i32>`
     #[must_use]
-    /// Load random values sequence, no values repeated
-    pub fn load_random_sequence<'a>(&self, num: Range<i32>, count: u32) -> RandomSequence<'a> {
-        unsafe {
-            let ptr = ffi::LoadRandomSequence(count, num.start, num.end.into());
-            RandomSequence(std::slice::from_raw_parts_mut(ptr, count as usize))
-        }
+    pub fn load_random_sequence(&self, num: Range<i32>, count: u32) -> RandomSequence {
+        let ptr = unsafe { ffi::LoadRandomSequence(count, num.start, num.end) };
+        RandomSequence(NonNull::slice_from_raw_parts(
+            NonNull::new(ptr).expect("error occurred in ffi::LoadRandomSequence"),
+            count
+                .try_into()
+                .expect("count should not exceed usize::MAX"),
+        ))
     }
+
+    /// Load pixels from the screen into a CPU image
     #[inline]
     #[must_use]
-    /// Load pixels from the screen into a CPU image
     pub fn load_image_from_screen(&self, _: &RaylibThread) -> Image {
         unsafe { Image(ffi::LoadImageFromScreen()) }
     }
 
     /// Takes a screenshot of current screen (saved a .png)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte
     pub fn take_screenshot(&mut self, _: &RaylibThread, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe {
             ffi::TakeScreenshot(c_filename.as_ptr());
         }
     }
-    #[inline]
-    #[must_use]
+
     /// Returns a random value between min and max (both included)
     /// ```ignore
     /// use raylib::*;
@@ -102,8 +134,10 @@ impl RaylibHandle {
     ///     let r = rl.get_random_value(0, 10);
     ///     println!("random value: {}", r);
     /// }
+    #[inline]
+    #[must_use]
     pub fn get_random_value<T: From<i32>>(&self, num: Range<i32>) -> T {
-        unsafe { (ffi::GetRandomValue(num.start, num.end.into()) as i32).into() }
+        unsafe { (ffi::GetRandomValue(num.start, num.end) as i32).into() }
     }
 
     /// Set the seed for random number generation
@@ -114,25 +148,25 @@ impl RaylibHandle {
     }
 }
 
-// lossy conversion to an f32
+/// Lossy conversion to an [`f32`]
 pub trait AsF32: Copy {
+    /// Convert `self` to [`f32`] using `as`.
     fn as_f32(self) -> f32;
 }
 
-macro_rules! as_f32 {
-    ($ty:ty) => {
-        impl AsF32 for $ty {
+macro_rules! impl_as_f32 {
+    ($($Ty:ty),* $(,)?) => {$(
+        impl AsF32 for $Ty {
+            #[allow(
+                clippy::cast_lossless,
+                clippy::cast_precision_loss,
+                reason = "AsF32 is meant to replicate the `as` keyword"
+            )]
             fn as_f32(self) -> f32 {
                 self as f32
             }
         }
-    };
+    )*};
 }
 
-as_f32!(u8);
-as_f32!(u16);
-as_f32!(u32);
-as_f32!(i8);
-as_f32!(i16);
-as_f32!(i32);
-as_f32!(f32);
+impl_as_f32!(u8, u16, u32, i8, i16, i32, f32);

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -33,6 +33,9 @@ use crate::ffi;
 use std::ffi::CString;
 use std::marker::PhantomData;
 
+#[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+use crate::consts::ConfigFlags::*;
+
 // shamelessly stolen from imgui
 #[macro_export]
 macro_rules! rstr {
@@ -68,106 +71,102 @@ pub struct RaylibHandle(()); // inner field is private, preventing manual constr
 
 impl Drop for RaylibHandle {
     fn drop(&mut self) {
-        unsafe {
-            if ffi::IsWindowReady() {
+        if unsafe { ffi::IsWindowReady() } {
+            unsafe {
                 ffi::CloseWindow();
-                // NOTE(IOI_XD): If imgui is enabled, we don't call the destructor here because we're using a context that Rust expects to free, and the only other thing in that function is the free'ing of FontTexture...an action which causes a segfault.
-                // It then gets successfully replaced if rlImGuiReloadFonts is called, so we'll take it.
             }
+            // NOTE(IOI_XD): If imgui is enabled, we don't call the destructor here because we're using a context that Rust expects to free, and the only other thing in that function is the free'ing of FontTexture...an action which causes a segfault.
+            // It then gets successfully replaced if rlImGuiReloadFonts is called, so we'll take it.
         }
     }
 }
 
 /// A builder that allows more customization of the game window shown to the user before the `RaylibHandle` is created.
 #[derive(Debug, Default)]
-pub struct RaylibBuilder {
-    fullscreen_mode: bool,
-    window_resizable: bool,
-    window_undecorated: bool,
-    window_transparent: bool,
-    msaa_4x_hint: bool,
-    vsync_hint: bool,
+pub struct RaylibBuilder<'a> {
+    flags: u32,
     log_level: TraceLogLevel,
     width: i32,
     height: i32,
-    title: String,
+    title: &'a str,
 }
+
 #[inline]
 #[must_use]
 /// Creates a `RaylibBuilder` for choosing window options before initialization.
-pub fn init() -> RaylibBuilder {
+pub fn init<'a>() -> RaylibBuilder<'a> {
     RaylibBuilder {
         width: 640,
         height: 480,
-        title: "raylib-rs".to_string(),
+        title: "raylib-rs",
         ..Default::default()
     }
 }
 
-impl RaylibBuilder {
+impl<'a> RaylibBuilder<'a> {
     /// Sets the window to be fullscreen.
-    pub fn fullscreen(&mut self) -> &mut Self {
-        self.fullscreen_mode = true;
+    pub const fn fullscreen(&mut self) -> &mut Self {
+        self.flags |= FLAG_FULLSCREEN_MODE as u32;
         self
     }
 
     /// Set the builder's log level.
-    pub fn log_level(&mut self, level: TraceLogLevel) -> &mut Self {
+    pub const fn log_level(&mut self, level: TraceLogLevel) -> &mut Self {
         self.log_level = level;
         self
     }
     /// Sets the window to be resizable.
-    pub fn resizable(&mut self) -> &mut Self {
-        self.window_resizable = true;
+    pub const fn resizable(&mut self) -> &mut Self {
+        self.flags |= FLAG_WINDOW_RESIZABLE as u32;
         self
     }
 
     /// Sets the window to be undecorated (without a border).
-    pub fn undecorated(&mut self) -> &mut Self {
-        self.window_undecorated = true;
+    pub const fn undecorated(&mut self) -> &mut Self {
+        self.flags |= FLAG_WINDOW_UNDECORATED as u32;
         self
     }
 
     /// Sets the window to be transparent.
-    pub fn transparent(&mut self) -> &mut Self {
-        self.window_transparent = true;
+    pub const fn transparent(&mut self) -> &mut Self {
+        self.flags |= FLAG_WINDOW_TRANSPARENT as u32;
         self
     }
 
     /// Hints that 4x MSAA (anti-aliasing) should be enabled. The system's graphics drivers may override this setting.
-    pub fn msaa_4x(&mut self) -> &mut Self {
-        self.msaa_4x_hint = true;
+    pub const fn msaa_4x(&mut self) -> &mut Self {
+        self.flags |= FLAG_MSAA_4X_HINT as u32;
         self
     }
 
-    /// Hints that vertical sync (VSync) should be enabled. The system's graphics drivers may override this setting.
-    pub fn vsync(&mut self) -> &mut Self {
-        self.vsync_hint = true;
+    /// Hints that vertical sync (Vsync) should be enabled. The system's graphics drivers may override this setting.
+    pub const fn vsync(&mut self) -> &mut Self {
+        self.flags |= FLAG_VSYNC_HINT as u32;
         self
     }
 
     /// Sets the window's width.
-    pub fn width(&mut self, w: i32) -> &mut Self {
+    pub const fn width(&mut self, w: i32) -> &mut Self {
         self.width = w;
         self
     }
 
     /// Sets the window's height.
-    pub fn height(&mut self, h: i32) -> &mut Self {
+    pub const fn height(&mut self, h: i32) -> &mut Self {
         self.height = h;
         self
     }
 
     /// Sets the window's width and height.
-    pub fn size(&mut self, w: i32, h: i32) -> &mut Self {
+    pub const fn size(&mut self, w: i32, h: i32) -> &mut Self {
         self.width = w;
         self.height = h;
         self
     }
 
     /// Sets the window title.
-    pub fn title(&mut self, text: &str) -> &mut Self {
-        self.title = text.to_string();
+    pub const fn title(&mut self, text: &'a str) -> &mut Self {
+        self.title = text;
         self
     }
 
@@ -176,37 +175,17 @@ impl RaylibBuilder {
     /// # Panics
     ///
     /// Attempting to initialize Raylib more than once will result in a panic.
+    #[must_use]
     pub fn build(&self) -> (RaylibHandle, RaylibThread) {
-        use crate::consts::ConfigFlags::*;
-        let mut flags = 0u32;
-        if self.fullscreen_mode {
-            flags |= FLAG_FULLSCREEN_MODE as u32;
-        }
-        if self.window_resizable {
-            flags |= FLAG_WINDOW_RESIZABLE as u32;
-        }
-        if self.window_undecorated {
-            flags |= FLAG_WINDOW_UNDECORATED as u32;
-        }
-        if self.window_transparent {
-            flags |= FLAG_WINDOW_TRANSPARENT as u32;
-        }
-        if self.msaa_4x_hint {
-            flags |= FLAG_MSAA_4X_HINT as u32;
-        }
-        if self.vsync_hint {
-            flags |= FLAG_VSYNC_HINT as u32;
-        }
-
         unsafe {
-            ffi::SetConfigFlags(flags as u32);
+            ffi::SetConfigFlags(self.flags);
         }
 
         unsafe {
             ffi::SetTraceLogLevel(self.log_level as i32);
         }
 
-        let rl = init_window(self.width, self.height, &self.title);
+        let rl = init_window(self.width, self.height, self.title);
 
         (rl, RaylibThread(PhantomData))
     }
@@ -217,18 +196,21 @@ impl RaylibBuilder {
 /// # Panics
 ///
 /// Attempting to initialize Raylib more than once will result in a panic.
+///
+/// This function will panic if `title` contains an internal 0 byte.
 fn init_window(width: i32, height: i32, title: &str) -> RaylibHandle {
-    if unsafe { ffi::IsWindowReady() } {
-        panic!("Attempted to initialize raylib-rs more than once!");
-    } else {
-        unsafe {
-            let c_title = CString::new(title).unwrap();
-            ffi::InitWindow(width, height, c_title.as_ptr());
-        }
-        if !unsafe { ffi::IsWindowReady() } {
-            panic!("Attempting to create window failed!");
-        }
-
-        RaylibHandle(())
+    assert!(
+        !unsafe { ffi::IsWindowReady() },
+        "Attempted to initialize raylib-rs more than once!"
+    );
+    unsafe {
+        let c_title = CString::new(title).expect("title should not contain an internal 0 byte");
+        ffi::InitWindow(width, height, c_title.as_ptr());
     }
+    assert!(
+        unsafe { ffi::IsWindowReady() },
+        "Attempting to create window failed!",
+    );
+
+    RaylibHandle(())
 }

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -1,3 +1,5 @@
+//! Raylib core features and functionality
+
 #[macro_use]
 mod macros;
 
@@ -7,7 +9,7 @@ pub mod callbacks;
 pub mod camera;
 pub mod collision;
 pub mod color {
-    #[allow(unused_imports)]
+    //! Color
     pub use crate::ffi::Color;
 }
 pub mod data;
@@ -36,6 +38,7 @@ use std::marker::PhantomData;
 #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
 use crate::consts::ConfigFlags::*;
 
+/// Construct a cstring as you would a Rust string
 // shamelessly stolen from imgui
 #[macro_export]
 macro_rules! rstr {

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -94,9 +94,9 @@ pub struct RaylibBuilder<'a> {
     title: &'a str,
 }
 
+/// Creates a `RaylibBuilder` for choosing window options before initialization.
 #[inline]
 #[must_use]
-/// Creates a `RaylibBuilder` for choosing window options before initialization.
 pub fn init<'a>() -> RaylibBuilder<'a> {
     RaylibBuilder {
         width: 640,
@@ -118,6 +118,7 @@ impl<'a> RaylibBuilder<'a> {
         self.log_level = level;
         self
     }
+
     /// Sets the window to be resizable.
     pub const fn resizable(&mut self) -> &mut Self {
         self.flags |= FLAG_WINDOW_RESIZABLE as u32;

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -14,7 +14,6 @@ use crate::{
     ffi,
 };
 use std::ffi::CString;
-use std::os::raw::c_void;
 
 fn no_drop<T>(_thing: T) {}
 make_thin_wrapper!(
@@ -23,21 +22,36 @@ make_thin_wrapper!(
     ffi::Model,
     ffi::UnloadModel
 );
-make_thin_wrapper!(WeakModel, ffi::Model, no_drop);
+make_thin_wrapper!(
+    /// Unowned version of [`Model`] that does not free the resource when dropped
+    WeakModel,
+    ffi::Model,
+    no_drop
+);
 make_thin_wrapper!(
     /// Mesh, vertex data and vao/vbo
     Mesh,
     ffi::Mesh,
     |mesh: ffi::Mesh| ffi::UnloadMesh(mesh)
 );
-make_thin_wrapper!(WeakMesh, ffi::Mesh, no_drop);
+make_thin_wrapper!(
+    /// Unowned version of [`Mesh`] that does not free the resource when dropped
+    WeakMesh,
+    ffi::Mesh,
+    no_drop
+);
 make_thin_wrapper!(
     /// Material, includes shader and maps
     Material,
     ffi::Material,
     ffi::UnloadMaterial
 );
-make_thin_wrapper!(WeakMaterial, ffi::Material, no_drop);
+make_thin_wrapper!(
+    /// Unowned version of [`Material`] that does not free the resource when dropped
+    WeakMaterial,
+    ffi::Material,
+    no_drop
+);
 make_thin_wrapper!(
     /// Bone, skeletal animation bone
     BoneInfo,
@@ -45,14 +59,19 @@ make_thin_wrapper!(
     no_drop
 );
 make_thin_wrapper!(
-    /// ModelAnimation
+    /// [`ModelAnimation`]
     ModelAnimation,
     ffi::ModelAnimation,
     ffi::UnloadModelAnimation
 );
-make_thin_wrapper!(WeakModelAnimation, ffi::ModelAnimation, no_drop);
 make_thin_wrapper!(
-    /// MaterialMap
+    /// Unowned version of [`ModelAnimation`] that does not free the resource when dropped
+    WeakModelAnimation,
+    ffi::ModelAnimation,
+    no_drop
+);
+make_thin_wrapper!(
+    /// [`MaterialMap`]
     MaterialMap,
     ffi::MaterialMap,
     no_drop
@@ -86,16 +105,88 @@ impl Clone for WeakModelAnimation {
     }
 }
 
+mod sealed {
+    use super::{Mesh, WeakMesh};
+    /// Convertible to weak version of `Self`
+    pub trait MakeWeak {
+        /// The weak form of `Self`
+        type Weak;
+        /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+        /// that it is only unloaded once, manually.
+        ///
+        /// # Safety
+        ///
+        /// Must manually free memory by calling the proper unload function.
+        /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+        /// and copies must not be used after being unloaded to avoid use-after-free.
+        #[must_use]
+        unsafe fn make_weak(self) -> Self::Weak;
+    }
+    /// Convertible from weak version of `Self`
+    pub trait FromWeak<T> {
+        /// Converts weak to a "safe" version.
+        ///
+        /// # Safety
+        ///
+        /// Make sure to call this function from the thread the resource was created.
+        /// If there are any aliases to `val`, they must not be used after this function's return drops,
+        /// and Rust's aliasing rules must be ensured by the caller.
+        #[must_use]
+        unsafe fn from_weak(val: T) -> Self;
+    }
+    macro_rules! imlp_make_weak {
+        ($($Ty:ident -> $Weak:ident;)*) => {$(
+            impl MakeWeak for $Ty {
+                type Weak = $Weak;
+                #[inline]
+                unsafe fn make_weak(self) -> Self::Weak {
+                    unsafe { self.make_weak() }
+                }
+            }
+            impl MakeWeak for $Weak {
+                type Weak = $Weak;
+                #[inline]
+                unsafe fn make_weak(self) -> Self::Weak {
+                    self
+                }
+            }
+            impl FromWeak<$Weak> for $Ty {
+                #[inline]
+                unsafe fn from_weak(val: $Weak) -> Self {
+                    unsafe { $Ty::from_raw(val.to_raw()) }
+                }
+            }
+            impl FromWeak<$Ty> for $Ty {
+                #[inline]
+                unsafe fn from_weak(val: $Ty) -> Self {
+                    val
+                }
+            }
+        )*};
+    }
+    imlp_make_weak! {
+        Mesh -> WeakMesh;
+    }
+}
+pub use sealed::{FromWeak, MakeWeak};
+
 impl RaylibHandle {
-    #[must_use]
-    /// Loads model from files (mesh and material).
-    // #[inline]
+    /// Loads model from files ([`Mesh`] and [`Material`]).
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`LoadModelError::LoadFromFileFailed`] if the model returned by [`ffi::LoadModel`] contains null
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte
     pub fn load_model(
         &mut self,
         _: &RaylibThread,
         filename: &str,
     ) -> Result<Model, LoadModelError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let m = unsafe { ffi::LoadModel(c_filename.as_ptr()) };
         if m.meshes.is_null() && m.materials.is_null() && m.bones.is_null() && m.bindPose.is_null()
         {
@@ -107,14 +198,18 @@ impl RaylibHandle {
         Ok(Model(m))
     }
 
-    #[must_use]
-    /// Loads model from a generated mesh
+    /// Loads model from a generated [`Mesh`]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadModelError::LoadFromMeshFailed`] if the model returned by [`ffi::LoadModelFromMesh`] contains null
     pub fn load_model_from_mesh(
         &mut self,
         _: &RaylibThread,
-        mesh: WeakMesh,
+        mesh: impl MakeWeak<Weak = WeakMesh>,
     ) -> Result<Model, LoadModelError> {
-        let m = unsafe { ffi::LoadModelFromMesh(mesh.0) };
+        let weak_mesh = unsafe { mesh.make_weak() };
+        let m = unsafe { ffi::LoadModelFromMesh(weak_mesh.0) };
 
         if m.meshes.is_null() || m.materials.is_null() {
             return Err(LoadModelError::LoadFromMeshFailed);
@@ -123,31 +218,36 @@ impl RaylibHandle {
         Ok(Model(m))
     }
 
-    #[must_use]
     /// Load model animations from file
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadModelAnimError::NoAnimationsLoaded`] if [`ffi::LoadModelAnimations`] assigns `m_size` with a value <= 0.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     pub fn load_model_animations(
         &mut self,
         _: &RaylibThread,
         filename: &str,
     ) -> Result<Vec<ModelAnimation>, LoadModelAnimError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain internal 0 byte");
         let mut m_size = 0;
-        let m_ptr = unsafe { ffi::LoadModelAnimations(c_filename.as_ptr(), &mut m_size) };
-        if m_size <= 0 {
-            return Err(LoadModelAnimError::NoAnimationsLoaded {
-                path: filename.into(),
-            });
-        }
-        let mut m_vec = Vec::with_capacity(m_size as usize);
-        for i in 0..m_size {
+        let m_ptr = unsafe { ffi::LoadModelAnimations(c_filename.as_ptr(), &raw mut m_size) };
+        if let Ok(m_size @ 1..) = usize::try_from(m_size) {
+            let m_arr = unsafe { std::slice::from_raw_parts_mut(m_ptr, m_size) };
+            let m_vec = m_arr.iter().copied().map(ModelAnimation).collect();
             unsafe {
-                m_vec.push(ModelAnimation(*m_ptr.offset(i as isize)));
+                ffi::MemFree(m_ptr.cast());
             }
+            Ok(m_vec)
+        } else {
+            Err(LoadModelAnimError::NoAnimationsLoaded {
+                path: filename.into(),
+            })
         }
-        unsafe {
-            ffi::MemFree(m_ptr as *mut ::std::os::raw::c_void);
-        }
-        Ok(m_vec)
     }
 
     /// Update model animation pose (CPU)
@@ -183,149 +283,227 @@ impl RaylibModel for WeakModel {}
 impl RaylibModel for Model {}
 
 impl Model {
-    pub unsafe fn make_weak(self) -> WeakModel {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
+    #[must_use]
+    #[inline]
+    pub const unsafe fn make_weak(self) -> WeakModel {
         let m = WeakModel(self.0);
         std::mem::forget(self);
         m
     }
 }
 
-pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
+/// [`Model`] accessors and helper methods.
+pub trait RaylibModel {
+    /// Local transform matrix
     #[inline]
     #[must_use]
-    /// Local transform matrix
-    fn transform(&self) -> &Matrix {
-        unsafe { std::mem::transmute(&self.as_ref().transform) }
+    fn transform(&self) -> &Matrix
+    where
+        Self: AsRef<ffi::Model>,
+    {
+        unsafe { &*(std::ptr::from_ref(&self.as_ref().transform).cast()) }
     }
 
+    /// Set the local transformation matrix
     #[inline]
-    fn set_transform(&mut self, mat: &Matrix) {
+    fn set_transform(&mut self, mat: &Matrix)
+    where
+        Self: AsMut<ffi::Model>,
+    {
         self.as_mut().transform = (*mat).into();
     }
 
     /// Meshes array
     #[inline]
     #[must_use]
-    fn meshes(&self) -> &[WeakMesh] {
+    fn meshes(&self) -> &[WeakMesh]
+    where
+        Self: AsRef<ffi::Model>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().meshes as *const WeakMesh,
-                self.as_ref().meshCount as usize,
+                self.as_ref().meshes.cast(),
+                self.as_ref()
+                    .meshCount
+                    .try_into()
+                    .expect("meshCount should not be negative"),
             )
         }
     }
-    // Meshes array
+    /// Meshes array
     #[inline]
     #[must_use]
-    fn meshes_mut(&mut self) -> &mut [WeakMesh] {
+    fn meshes_mut(&mut self) -> &mut [WeakMesh]
+    where
+        Self: AsMut<ffi::Model>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().meshes as *mut WeakMesh,
-                self.as_mut().meshCount as usize,
+                self.as_mut().meshes.cast(),
+                self.as_mut()
+                    .meshCount
+                    .try_into()
+                    .expect("meshCount should not be negative"),
             )
         }
     }
     /// Materials array
     #[inline]
     #[must_use]
-    fn materials(&self) -> &[WeakMaterial] {
+    fn materials(&self) -> &[WeakMaterial]
+    where
+        Self: AsRef<ffi::Model>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().materials as *const WeakMaterial,
-                self.as_ref().materialCount as usize,
+                self.as_ref().materials.cast(),
+                self.as_ref()
+                    .materialCount
+                    .try_into()
+                    .expect("materialCount should not be negative"),
             )
         }
     }
     /// Materials array
     #[inline]
     #[must_use]
-    fn materials_mut(&mut self) -> &mut [WeakMaterial] {
+    fn materials_mut(&mut self) -> &mut [WeakMaterial]
+    where
+        Self: AsMut<ffi::Model>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().materials as *mut WeakMaterial,
-                self.as_mut().materialCount as usize,
+                self.as_mut().materials.cast(),
+                self.as_mut()
+                    .materialCount
+                    .try_into()
+                    .expect("materialCount should not be negative"),
             )
         }
     }
+    /// Bones information (skeleton)
     #[inline]
     #[must_use]
-    /// Bones information (skeleton)
-    fn bones(&self) -> Option<&[BoneInfo]> {
+    fn bones(&self) -> Option<&[BoneInfo]>
+    where
+        Self: AsRef<ffi::Model>,
+    {
         if self.as_ref().bones.is_null() {
             return None;
         }
 
         Some(unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().bones as *const BoneInfo,
-                self.as_ref().boneCount as usize,
+                self.as_ref().bones.cast(),
+                self.as_ref()
+                    .boneCount
+                    .try_into()
+                    .expect("boneCount should not be negative"),
             )
         })
     }
+    /// Bones information (skeleton)
     #[inline]
     #[must_use]
-    /// Bones information (skeleton)
-    fn bones_mut(&mut self) -> Option<&mut [BoneInfo]> {
-        if self.as_ref().bones.is_null() {
+    fn bones_mut(&mut self) -> Option<&mut [BoneInfo]>
+    where
+        Self: AsMut<ffi::Model>,
+    {
+        if self.as_mut().bones.is_null() {
             return None;
         }
 
         Some(unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().bones as *mut BoneInfo,
-                self.as_mut().boneCount as usize,
+                self.as_mut().bones.cast(),
+                self.as_mut()
+                    .boneCount
+                    .try_into()
+                    .expect("boneCount should not be negative"),
             )
         })
     }
+    /// Bones base transformation (pose)
     #[inline]
     #[must_use]
-    /// Bones base transformation (pose)
-    fn bind_pose(&self) -> Option<&Transform> {
+    fn bind_pose(&self) -> Option<&Transform>
+    where
+        Self: AsRef<ffi::Model>,
+    {
         if self.as_ref().bindPose.is_null() {
             return None;
         }
-        Some(unsafe { std::mem::transmute(self.as_ref().bindPose) })
+        Some(unsafe { &*(self.as_ref().bindPose.cast()) })
     }
+    /// Bones base transformation (pose)
     #[inline]
     #[must_use]
-    /// Bones base transformation (pose)
-    fn bind_pose_mut(&mut self) -> Option<&mut Transform> {
-        if self.as_ref().bindPose.is_null() {
+    fn bind_pose_mut(&mut self) -> Option<&mut Transform>
+    where
+        Self: AsMut<ffi::Model>,
+    {
+        if self.as_mut().bindPose.is_null() {
             return None;
         }
-        Some(unsafe { std::mem::transmute(self.as_mut().bindPose) })
+        Some(unsafe { &mut *(self.as_mut().bindPose.cast()) })
     }
-    #[inline]
-    #[must_use]
     /// Check model animation skeleton match
-    fn is_model_animation_valid(&self, anim: &ModelAnimation) -> bool {
+    #[inline]
+    #[must_use]
+    fn is_model_animation_valid(&self, anim: &ModelAnimation) -> bool
+    where
+        Self: AsRef<ffi::Model>,
+    {
         unsafe { ffi::IsModelAnimationValid(*self.as_ref(), anim.0) }
     }
 
     /// Check if a model is ready
     #[inline]
     #[must_use]
-    fn is_model_valid(&self) -> bool {
+    fn is_model_valid(&self) -> bool
+    where
+        Self: AsRef<ffi::Model>,
+    {
         unsafe { ffi::IsModelValid(*self.as_ref()) }
     }
 
     /// Compute model bounding box limits (considers all meshes)
     #[inline]
     #[must_use]
-    fn get_model_bounding_box(&self) -> BoundingBox {
+    fn get_model_bounding_box(&self) -> BoundingBox
+    where
+        Self: AsRef<ffi::Model>,
+    {
         unsafe { BoundingBox::from(ffi::GetModelBoundingBox(*self.as_ref())) }
     }
-    #[inline]
+
     /// Set material for a mesh
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`SetMaterialError::MeshIdOutOfBounds`] if `mesh_id` is greater than `meshCount`,
+    /// or [`SetMaterialError::MaterialIdOutOfBounds`] if `material_id` is greater than `materialCount`.
+    #[inline]
     fn set_model_mesh_material(
         &mut self,
         mesh_id: i32,
         material_id: i32,
-    ) -> Result<(), SetMaterialError> {
+    ) -> Result<(), SetMaterialError>
+    where
+        Self: AsMut<ffi::Model>,
+    {
         // should this be an assertion?
-        if mesh_id >= self.as_ref().meshCount {
+        if mesh_id >= self.as_mut().meshCount {
             Err(SetMaterialError::MeshIdOutOfBounds)
-        } else if material_id >= self.as_ref().materialCount {
+        } else if material_id >= self.as_mut().materialCount {
             Err(SetMaterialError::MaterialIdOutOfBounds)
         } else {
             unsafe { ffi::SetModelMeshMaterial(self.as_mut(), mesh_id, material_id) };
@@ -338,138 +516,268 @@ impl RaylibMesh for WeakMesh {}
 impl RaylibMesh for Mesh {}
 
 impl Mesh {
-    pub unsafe fn make_weak(self) -> WeakMesh {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
+    #[must_use]
+    #[inline]
+    pub const unsafe fn make_weak(self) -> WeakMesh {
         let m = WeakMesh(self.0);
         std::mem::forget(self);
         m
     }
 }
-pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
+
+/// [`Mesh`] accessors and helper methods.
+pub trait RaylibMesh {
     /// Upload mesh vertex data in GPU and provide VAO/VBO ids
     #[inline]
-    unsafe fn upload(&mut self, dynamic: bool) {
-        unsafe { ffi::UploadMesh(self.as_mut(), dynamic) };
+    unsafe fn upload(&mut self, dynamic: bool)
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
+        unsafe {
+            ffi::UploadMesh(self.as_mut(), dynamic);
+        }
     }
     /// Update mesh vertex data in GPU for a specific buffer index
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `data` has a length greater than [`i32::MAX`].
     #[inline]
-    unsafe fn update_buffer<A>(&mut self, index: i32, data: &[u8], offset: i32) {
+    unsafe fn update_buffer<A>(&mut self, index: i32, data: &[u8], offset: i32)
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe {
             ffi::UpdateMeshBuffer(
                 *self.as_ref(),
                 index,
-                data.as_ptr() as *const c_void,
-                data.len() as i32,
+                data.as_ptr().cast(),
+                data.len()
+                    .try_into()
+                    .expect("data should not exceed i32::MAX elements"),
                 offset,
-            )
-        };
+            );
+        }
     }
     /// Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn vertices(&self) -> &[Vector3] {
+    fn vertices(&self) -> &[Vector3]
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().vertices as *const Vector3,
-                self.as_ref().vertexCount as usize,
+                self.as_ref().vertices.cast(),
+                self.as_ref()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn vertices_mut(&mut self) -> &mut [Vector3] {
+    fn vertices_mut(&mut self) -> &mut [Vector3]
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().vertices as *mut Vector3,
-                self.as_mut().vertexCount as usize,
+                self.as_mut().vertices.cast(),
+                self.as_mut()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn normals(&self) -> &[Vector3] {
+    fn normals(&self) -> &[Vector3]
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().normals as *const Vector3,
-                self.as_ref().vertexCount as usize,
+                self.as_ref().normals.cast(),
+                self.as_ref()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn normals_mut(&mut self) -> &mut [Vector3] {
+    fn normals_mut(&mut self) -> &mut [Vector3]
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().normals as *mut Vector3,
-                self.as_mut().vertexCount as usize,
+                self.as_mut().normals.cast(),
+                self.as_mut()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn tangents(&self) -> &[Vector3] {
+    fn tangents(&self) -> &[Vector3]
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().tangents as *const Vector3,
-                self.as_ref().vertexCount as usize,
+                self.as_ref().tangents.cast(),
+                self.as_ref()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn tangents_mut(&mut self) -> &mut [Vector3] {
+    fn tangents_mut(&mut self) -> &mut [Vector3]
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().tangents as *mut Vector3,
-                self.as_mut().vertexCount as usize,
+                self.as_mut().tangents.cast(),
+                self.as_mut()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn colors(&self) -> &[Color] {
+    fn colors(&self) -> &[Color]
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().colors as *const Color,
-                self.as_ref().vertexCount as usize,
+                self.as_ref().colors.cast(),
+                self.as_ref()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vertexCount` is negative
     #[inline]
     #[must_use]
-    fn colors_mut(&mut self) -> &mut [Color] {
+    fn colors_mut(&mut self) -> &mut [Color]
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().colors as *mut Color,
-                self.as_mut().vertexCount as usize,
+                self.as_mut().colors.cast(),
+                self.as_mut()
+                    .vertexCount
+                    .try_into()
+                    .expect("vertexCount should not be negative"),
             )
         }
     }
     /// Vertex indices (in case vertex data comes indexed)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `triangleCount * 3` is negative or would overflow
     #[inline]
     #[must_use]
-    fn indices(&self) -> &[u16] {
+    fn indices(&self) -> &[u16]
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().indices as *const u16,
-                self.as_ref().vertexCount as usize,
+                self.as_ref().indices.cast(),
+                self.as_ref()
+                    .triangleCount
+                    .try_into()
+                    .ok()
+                    .and_then(|n: usize| n.checked_mul(3))
+                    .expect("triangleCount*3 should not be negative or overflow"),
             )
         }
     }
     /// Vertex indices (in case vertex data comes indexed)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `triangleCount * 3` is negative or would overflow
     #[inline]
     #[must_use]
-    fn indices_mut(&mut self) -> &mut [u16] {
+    fn indices_mut(&mut self) -> &mut [u16]
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().indices as *mut u16,
-                self.as_mut().vertexCount as usize,
+                self.as_mut().indices.cast(),
+                self.as_mut()
+                    .triangleCount
+                    .try_into()
+                    .ok()
+                    .and_then(|n: usize| n.checked_mul(3))
+                    .expect("triangleCount*3 should not be negative or overflow"),
             )
         }
     }
@@ -558,32 +866,54 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     /// Computes mesh bounding box limits.
     #[inline]
     #[must_use]
-    fn get_mesh_bounding_box(&self) -> BoundingBox {
+    fn get_mesh_bounding_box(&self) -> BoundingBox
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
         unsafe { ffi::GetMeshBoundingBox(*self.as_ref()).into() }
     }
 
     /// Computes mesh tangents.
     // NOTE: New VBO for tangents is generated at default location and also binded to mesh VAO
     #[inline]
-    fn gen_mesh_tangents(&mut self, _: &RaylibThread) {
+    fn gen_mesh_tangents(&mut self, _: &RaylibThread)
+    where
+        Self: AsMut<ffi::Mesh>,
+    {
         unsafe {
             ffi::GenMeshTangents(self.as_mut());
         }
     }
 
     /// Exports mesh as an OBJ file.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
-    fn export(&self, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+    fn export(&self, filename: &str)
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe {
             ffi::ExportMesh(*self.as_ref(), c_filename.as_ptr());
         }
     }
 
     /// Export mesh as code file (.h) defining multiple arrays of vertex attributes
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
-    fn export_as_code(&self, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+    fn export_as_code(&self, filename: &str)
+    where
+        Self: AsRef<ffi::Mesh>,
+    {
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe {
             ffi::ExportMeshAsCode(*self.as_ref(), c_filename.as_ptr());
         }
@@ -591,97 +921,129 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
 }
 
 impl Material {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[must_use]
     #[inline]
-    pub unsafe fn make_weak(self) -> WeakMaterial {
+    pub const unsafe fn make_weak(self) -> WeakMaterial {
         let m = WeakMaterial(self.0);
         std::mem::forget(self);
         m
     }
 
     /// Load materials from model file
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadMaterialError::NoneLoaded`] if [`ffi::LoadMaterials`] outputs a size smaller than 0.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     pub fn load_materials(filename: &str) -> Result<Vec<Material>, LoadMaterialError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain internal 0 byte");
         let mut m_size = 0;
-        let m_ptr = unsafe { ffi::LoadMaterials(c_filename.as_ptr(), &mut m_size) };
-        if m_size <= 0 {
-            return Err(LoadMaterialError::NoneLoaded {
-                path: filename.into(),
-            });
-        }
-        let mut m_vec = Vec::with_capacity(m_size as usize);
-        for i in 0..m_size {
+        let m_ptr = unsafe { ffi::LoadMaterials(c_filename.as_ptr(), &raw mut m_size) };
+        if let Ok(m_size @ 1..) = usize::try_from(m_size) {
+            let m_arr = unsafe { std::slice::from_raw_parts_mut(m_ptr, m_size) };
+            let m_vec = m_arr.iter().copied().map(Material).collect();
             unsafe {
-                m_vec.push(Material(*m_ptr.offset(i as isize)));
+                ffi::MemFree(m_ptr.cast());
             }
+            Ok(m_vec)
+        } else {
+            Err(LoadMaterialError::NoneLoaded {
+                path: filename.into(),
+            })
         }
-        unsafe {
-            ffi::MemFree(m_ptr as *mut ::std::os::raw::c_void);
-        }
-        Ok(m_vec)
     }
 }
 
 impl RaylibMaterial for WeakMaterial {}
 impl RaylibMaterial for Material {}
 
-pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
+/// [`Material`] accessors and helper methods.
+pub trait RaylibMaterial {
     /// Material shader
     #[must_use]
     #[inline]
-    fn shader(&self) -> &crate::shaders::WeakShader {
-        unsafe { std::mem::transmute(&self.as_ref().shader) }
+    fn shader(&self) -> &crate::shaders::WeakShader
+    where
+        Self: AsRef<ffi::Material>,
+    {
+        unsafe { &*std::ptr::from_ref(&self.as_ref().shader).cast() }
     }
-    #[must_use]
-    #[inline]
     /// Material shader
-    fn shader_mut(&mut self) -> &mut crate::shaders::WeakShader {
-        unsafe { std::mem::transmute(&mut self.as_mut().shader) }
-    }
     #[must_use]
     #[inline]
-    /// Material maps array (MAX_MATERIAL_MAPS)
-    fn maps(&self) -> &[MaterialMap] {
+    fn shader_mut(&mut self) -> &mut crate::shaders::WeakShader
+    where
+        Self: AsMut<ffi::Material>,
+    {
+        unsafe { &mut *std::ptr::from_mut(&mut self.as_mut().shader).cast() }
+    }
+    /// Material maps array ([`consts::MAX_MATERIAL_MAPS`])
+    #[must_use]
+    #[inline]
+    fn maps(&self) -> &[MaterialMap]
+    where
+        Self: AsRef<ffi::Material>,
+    {
         unsafe {
             std::slice::from_raw_parts(
-                self.as_ref().maps as *const MaterialMap,
+                self.as_ref().maps.cast(),
                 consts::MAX_MATERIAL_MAPS as usize,
             )
         }
     }
     #[must_use]
     #[inline]
-    /// Material maps array (MAX_MATERIAL_MAPS)
-    fn maps_mut(&mut self) -> &mut [MaterialMap] {
+    /// Material maps array ([`consts::MAX_MATERIAL_MAPS`])
+    fn maps_mut(&mut self) -> &mut [MaterialMap]
+    where
+        Self: AsMut<ffi::Material>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().maps as *mut MaterialMap,
+                self.as_mut().maps.cast(),
                 consts::MAX_MATERIAL_MAPS as usize,
             )
         }
     }
 
-    /// Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
+    /// Set texture for a material map type (`MATERIAL_MAP_DIFFUSE`, `MATERIAL_MAP_SPECULAR`...)
     #[inline]
     fn set_material_texture(
         &mut self,
         map_type: crate::consts::MaterialMapIndex,
         texture: impl AsRef<ffi::Texture2D>,
-    ) {
-        unsafe {
-            ffi::SetMaterialTexture(self.as_mut(), (map_type as u32) as i32, *texture.as_ref())
-        }
+    ) where
+        Self: AsMut<ffi::Material>,
+    {
+        unsafe { ffi::SetMaterialTexture(self.as_mut(), map_type as i32, *texture.as_ref()) }
     }
 
     /// Check if a material is valid (shader assigned, map textures loaded in GPU)
     #[inline]
     #[must_use]
-    fn is_material_valid(&mut self) -> bool {
+    fn is_material_valid(&mut self) -> bool
+    where
+        Self: AsRef<ffi::Material>,
+    {
         unsafe { ffi::IsMaterialValid(*self.as_ref()) }
     }
 }
 
+/// Iterator over frame pose references
+///
+/// Returned by [`RaylibModelAnimation::frame_poses_iter`].
 #[derive(Debug, Clone)]
 pub struct FramePoseIter<'a> {
     iter: std::slice::Iter<'a, Option<&'a [Transform]>>,
@@ -701,7 +1063,7 @@ impl<'a> FramePoseIter<'a> {
         let iter = unsafe { std::slice::from_raw_parts(frame_poses, frame_count) }.iter();
         Self { iter, bone_count }
     }
-    fn func(tf: &Option<&'a [Transform]>, bone_count: usize) -> &'a [Transform] {
+    const fn func(tf: Option<&'a [Transform]>, bone_count: usize) -> &'a [Transform] {
         unsafe {
             std::slice::from_raw_parts(
                 tf.expect("frame pose transform cannot be null").as_ptr(),
@@ -715,7 +1077,10 @@ impl<'a> Iterator for FramePoseIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let bone_count = self.bone_count;
-        self.iter.next().map(move |tf| Self::func(tf, bone_count))
+        self.iter
+            .next()
+            .copied()
+            .map(move |tf| Self::func(tf, bone_count))
     }
 
     #[inline]
@@ -730,19 +1095,26 @@ impl<'a> Iterator for FramePoseIter<'a> {
 
     fn last(self) -> Option<Self::Item> {
         let bone_count = self.bone_count;
-        self.iter.last().map(move |tf| Self::func(tf, bone_count))
+        self.iter
+            .last()
+            .copied()
+            .map(move |tf| Self::func(tf, bone_count))
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let bone_count = self.bone_count;
-        self.iter.nth(n).map(move |tf| Self::func(tf, bone_count))
+        self.iter
+            .nth(n)
+            .copied()
+            .map(move |tf| Self::func(tf, bone_count))
     }
 }
-impl<'a> DoubleEndedIterator for FramePoseIter<'a> {
+impl DoubleEndedIterator for FramePoseIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let bone_count = self.bone_count;
         self.iter
             .next_back()
+            .copied()
             .map(move |tf| Self::func(tf, bone_count))
     }
 
@@ -750,15 +1122,19 @@ impl<'a> DoubleEndedIterator for FramePoseIter<'a> {
         let bone_count = self.bone_count;
         self.iter
             .nth_back(n)
+            .copied()
             .map(move |tf| Self::func(tf, bone_count))
     }
 }
-impl<'a> ExactSizeIterator for FramePoseIter<'a> {
+impl ExactSizeIterator for FramePoseIter<'_> {
     #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
+/// Iterator over mutable frame pose references
+///
+/// Returned by [`RaylibModelAnimation::frame_poses_iter`].
 #[derive(Debug)]
 pub struct FramePoseIterMut<'a> {
     iter: std::slice::IterMut<'a, Option<&'a mut [Transform]>>,
@@ -777,7 +1153,7 @@ impl<'a> FramePoseIterMut<'a> {
         let iter = unsafe { std::slice::from_raw_parts_mut(frame_poses, frame_count) }.iter_mut();
         Self { iter, bone_count }
     }
-    fn func(tf: &mut Option<&'a mut [Transform]>, bone_count: usize) -> &'a mut [Transform] {
+    const fn func(tf: &mut Option<&'a mut [Transform]>, bone_count: usize) -> &'a mut [Transform] {
         unsafe {
             std::slice::from_raw_parts_mut(
                 tf.as_mut()
@@ -816,7 +1192,7 @@ impl<'a> Iterator for FramePoseIterMut<'a> {
         self.iter.nth(n).map(move |tf| Self::func(tf, bone_count))
     }
 }
-impl<'a> DoubleEndedIterator for FramePoseIterMut<'a> {
+impl DoubleEndedIterator for FramePoseIterMut<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let bone_count = self.bone_count;
         self.iter
@@ -831,7 +1207,7 @@ impl<'a> DoubleEndedIterator for FramePoseIterMut<'a> {
             .map(move |tf| Self::func(tf, bone_count))
     }
 }
-impl<'a> ExactSizeIterator for FramePoseIterMut<'a> {
+impl ExactSizeIterator for FramePoseIterMut<'_> {
     #[inline]
     fn len(&self) -> usize {
         self.iter.len()
@@ -842,94 +1218,171 @@ impl RaylibModelAnimation for ModelAnimation {}
 impl RaylibModelAnimation for WeakModelAnimation {}
 
 impl ModelAnimation {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
-    pub unsafe fn make_weak(self) -> WeakModelAnimation {
+    pub const unsafe fn make_weak(self) -> WeakModelAnimation {
         let m = WeakModelAnimation(self.0);
         std::mem::forget(self);
         m
     }
 }
 
-pub trait RaylibModelAnimation: AsRef<ffi::ModelAnimation> + AsMut<ffi::ModelAnimation> {
+/// [`ModelAnimation`] accessors and helper methods.
+pub trait RaylibModelAnimation {
     /// Bones information (skeleton)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `boneCount` is negative
     #[inline]
     #[must_use]
-    fn bones(&self) -> &[BoneInfo] {
+    fn bones(&self) -> &[BoneInfo]
+    where
+        Self: AsRef<ffi::ModelAnimation>,
+    {
         unsafe {
             std::slice::from_raw_parts(
                 self.as_ref().bones as *const BoneInfo,
-                self.as_ref().boneCount as usize,
+                self.as_ref()
+                    .boneCount
+                    .try_into()
+                    .expect("boneCount should not be negative"),
             )
         }
     }
 
     /// Bones information (skeleton)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `boneCount` is negative
     #[inline]
     #[must_use]
-    fn bones_mut(&mut self) -> &mut [BoneInfo] {
+    fn bones_mut(&mut self) -> &mut [BoneInfo]
+    where
+        Self: AsMut<ffi::ModelAnimation>,
+    {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().bones as *mut BoneInfo,
-                self.as_mut().boneCount as usize,
+                self.as_mut().bones.cast(),
+                self.as_mut()
+                    .boneCount
+                    .try_into()
+                    .expect("boneCount should not be negative"),
             )
         }
     }
 
-    #[must_use]
     /// Poses array by frame
-    fn frame_poses(&self) -> Vec<&[Transform]> {
-        let anim = self.as_ref();
-        let mut top = Vec::with_capacity(anim.frameCount as usize);
-
-        for i in 0..anim.frameCount {
-            top.push(unsafe {
-                std::slice::from_raw_parts(
-                    *(anim.framePoses.offset(i as isize) as *const *const Transform),
-                    anim.boneCount as usize,
-                )
-            });
-        }
-
-        top
-    }
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `frameCount` or `boneCount` is negative
     #[must_use]
-    fn frame_poses_iter<'a>(&'a self) -> FramePoseIter<'a> {
+    fn frame_poses(&self) -> Vec<&[Transform]>
+    where
+        Self: AsRef<ffi::ModelAnimation>,
+    {
+        let anim = self.as_ref();
+        let bone_count = anim
+            .boneCount
+            .try_into()
+            .expect("boneCount should not be negative");
+
+        unsafe {
+            std::slice::from_raw_parts(
+                anim.framePoses.cast::<*const Transform>(),
+                anim.frameCount
+                    .try_into()
+                    .expect("frameCount should not be negative"),
+            )
+        }
+        .iter()
+        .copied()
+        .map(|frame_pose| unsafe { std::slice::from_raw_parts(frame_pose, bone_count) })
+        .collect()
+    }
+    /// Iterator over poses array by frame
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `frameCount` or `boneCount` is negative
+    #[must_use]
+    fn frame_poses_iter(&self) -> FramePoseIter<'_>
+    where
+        Self: AsRef<ffi::ModelAnimation>,
+    {
         let anim = self.as_ref();
         unsafe {
             FramePoseIter::new(
                 anim.framePoses,
-                anim.frameCount as usize,
-                anim.boneCount as usize,
+                anim.frameCount
+                    .try_into()
+                    .expect("frameCount should not be negative"),
+                anim.boneCount
+                    .try_into()
+                    .expect("boneCount should not be negative"),
             )
         }
     }
 
-    #[must_use]
     /// Poses array by frame
-    fn frame_poses_mut(&mut self) -> Vec<&mut [Transform]> {
-        let anim = self.as_ref();
-        let mut top = Vec::with_capacity(anim.frameCount as usize);
-
-        for i in 0..anim.frameCount {
-            top.push(unsafe {
-                std::slice::from_raw_parts_mut(
-                    *(anim.framePoses.offset(i as isize) as *mut *mut Transform),
-                    anim.boneCount as usize,
-                )
-            });
-        }
-
-        top
-    }
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `frameCount` or `boneCount` is negative
     #[must_use]
-    fn frame_poses_iter_mut<'a>(&'a mut self) -> FramePoseIterMut<'a> {
-        let anim = self.as_ref();
+    fn frame_poses_mut(&mut self) -> Vec<&mut [Transform]>
+    where
+        Self: AsMut<ffi::ModelAnimation>,
+    {
+        let anim = self.as_mut();
+        let bone_count = anim
+            .boneCount
+            .try_into()
+            .expect("boneCount should not be negative");
+
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                anim.framePoses.cast::<*mut Transform>(),
+                anim.frameCount
+                    .try_into()
+                    .expect("frameCount should not be negative"),
+            )
+        }
+        .iter()
+        .copied()
+        .map(|frame_pose| unsafe { std::slice::from_raw_parts_mut(frame_pose, bone_count) })
+        .collect()
+    }
+    /// Iterator over poses array by frame
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `frameCount` or `boneCount` is negative
+    #[must_use]
+    fn frame_poses_iter_mut(&mut self) -> FramePoseIterMut<'_>
+    where
+        Self: AsMut<ffi::ModelAnimation>,
+    {
+        let anim = self.as_mut();
         unsafe {
             FramePoseIterMut::new(
                 anim.framePoses,
-                anim.frameCount as usize,
-                anim.boneCount as usize,
+                anim.frameCount
+                    .try_into()
+                    .expect("frameCount should not be negative"),
+                anim.boneCount
+                    .try_into()
+                    .expect("boneCount should not be negative"),
             )
         }
     }
@@ -939,80 +1392,107 @@ impl MaterialMap {
     /// Material map texture
     #[inline]
     #[must_use]
-    pub fn texture(&self) -> &crate::texture::WeakTexture2D {
-        unsafe { std::mem::transmute(&self.0.texture) }
+    pub const fn texture(&self) -> &crate::texture::WeakTexture2D {
+        unsafe { &*std::ptr::from_ref(&self.0.texture).cast() }
     }
     /// Material map texture
     #[inline]
     #[must_use]
-    pub fn texture_mut(&mut self) -> &mut crate::texture::WeakTexture2D {
-        unsafe { std::mem::transmute(&mut self.0.texture) }
+    pub const fn texture_mut(&mut self) -> &mut crate::texture::WeakTexture2D {
+        unsafe { &mut *std::ptr::from_mut(&mut self.0.texture).cast() }
     }
 
     /// Material map color
     #[inline]
     #[must_use]
-    pub fn color(&self) -> &Color {
-        unsafe { std::mem::transmute(&self.0.color) }
+    pub const fn color(&self) -> &Color {
+        unsafe { &*std::ptr::from_ref(&self.0.color).cast() }
     }
     /// Material map color
     #[inline]
     #[must_use]
-    pub fn color_mut(&mut self) -> &mut Color {
-        unsafe { std::mem::transmute(&mut self.0.color) }
+    pub const fn color_mut(&mut self) -> &mut Color {
+        unsafe { &mut *std::ptr::from_mut(&mut self.0.color).cast() }
     }
 
     /// Material map value
     #[inline]
     #[must_use]
-    pub fn value(&self) -> &f32 {
-        unsafe { std::mem::transmute(&self.0.value) }
+    pub const fn value(&self) -> &f32 {
+        unsafe { &*std::ptr::from_ref(&self.0.value).cast() }
     }
     /// Material map value
     #[inline]
     #[must_use]
-    pub fn value_mut(&mut self) -> &mut f32 {
-        unsafe { std::mem::transmute(&mut self.0.value) }
+    pub const fn value_mut(&mut self) -> &mut f32 {
+        unsafe { &mut *std::ptr::from_mut(&mut self.0.value).cast() }
     }
 }
 
 impl RaylibHandle {
-    /// Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
+    /// Load default material (Supports: `DIFFUSE`, `SPECULAR`, `NORMAL` maps)
     #[inline]
     #[must_use]
     pub fn load_material_default(&self, _: &RaylibThread) -> WeakMaterial {
         WeakMaterial(unsafe { ffi::LoadMaterialDefault() })
     }
 
-    /// Weak materials will leak memory if they are not unlaoded
     /// Unload material from GPU memory (VRAM)
+    ///
+    /// Weak materials will leak memory if they are not unlaoded
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `material`.
+    /// The caller must ensure that `material` has not yet been unloaded, and that no copies
+    /// of `material` are accessed or unloaded after this method returns.
     #[inline]
     pub unsafe fn unload_material(&mut self, _: &RaylibThread, material: WeakMaterial) {
-        unsafe { ffi::UnloadMaterial(*material.as_ref()) }
+        unsafe { ffi::UnloadMaterial(material.to_raw()) }
     }
 
-    /// Weak models will leak memory if they are not unlaoded
     /// Unload model from GPU memory (VRAM)
+    ///
+    /// Weak models will leak memory if they are not unlaoded
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `model`.
+    /// The caller must ensure that `model` has not yet been unloaded, and that no copies
+    /// of `model` are accessed or unloaded after this method returns.
     #[inline]
     pub unsafe fn unload_model(&mut self, _: &RaylibThread, model: WeakModel) {
-        unsafe { ffi::UnloadModel(*model.as_ref()) }
+        unsafe { ffi::UnloadModel(model.to_raw()) }
     }
 
-    /// Weak model_animations will leak memory if they are not unlaoded
-    /// Unload model_animation from GPU memory (VRAM)
+    /// Weak model animations will leak memory if they are not unlaoded
+    /// Unload model animation from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `model_animation`.
+    /// The caller must ensure that `model_animation` has not yet been unloaded, and that no copies
+    /// of `model_animation` are accessed or unloaded after this method returns.
     #[inline]
     pub unsafe fn unload_model_animation(
         &mut self,
         _: &RaylibThread,
         model_animation: WeakModelAnimation,
     ) {
-        unsafe { ffi::UnloadModelAnimation(*model_animation.as_ref()) }
+        unsafe { ffi::UnloadModelAnimation(model_animation.to_raw()) }
     }
 
-    /// Weak meshs will leak memory if they are not unlaoded
     /// Unload mesh from GPU memory (VRAM)
+    ///
+    /// Weak meshes will leak memory if they are not unlaoded
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `mesh`.
+    /// The caller must ensure that `mesh` has not yet been unloaded, and that no copies
+    /// of `mesh` are accessed or unloaded after this method returns.
     #[inline]
     pub unsafe fn unload_mesh(&mut self, _: &RaylibThread, mesh: WeakMesh) {
-        unsafe { ffi::UnloadMesh(*mesh.as_ref()) }
+        unsafe { ffi::UnloadMesh(mesh.to_raw()) }
     }
 }

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -117,11 +117,12 @@ mod sealed {
         /// # Safety
         ///
         /// Must manually free memory by calling the proper unload function.
-        /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+        /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
         /// and copies must not be used after being unloaded to avoid use-after-free.
         #[must_use]
         unsafe fn make_weak(self) -> Self::Weak;
     }
+
     /// Convertible from weak version of `Self`
     pub trait FromWeak<T> {
         /// Converts weak to a "safe" version.
@@ -289,10 +290,10 @@ impl Model {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const unsafe fn make_weak(self) -> WeakModel {
         let m = WeakModel(self.0);
         std::mem::forget(self);
@@ -338,6 +339,7 @@ pub trait RaylibModel {
             )
         }
     }
+
     /// Meshes array
     #[inline]
     #[must_use]
@@ -355,6 +357,7 @@ pub trait RaylibModel {
             )
         }
     }
+
     /// Materials array
     #[inline]
     #[must_use]
@@ -372,6 +375,7 @@ pub trait RaylibModel {
             )
         }
     }
+
     /// Materials array
     #[inline]
     #[must_use]
@@ -389,6 +393,7 @@ pub trait RaylibModel {
             )
         }
     }
+
     /// Bones information (skeleton)
     #[inline]
     #[must_use]
@@ -410,6 +415,7 @@ pub trait RaylibModel {
             )
         })
     }
+
     /// Bones information (skeleton)
     #[inline]
     #[must_use]
@@ -431,6 +437,7 @@ pub trait RaylibModel {
             )
         })
     }
+
     /// Bones base transformation (pose)
     #[inline]
     #[must_use]
@@ -443,6 +450,7 @@ pub trait RaylibModel {
         }
         Some(unsafe { &*(self.as_ref().bindPose.cast()) })
     }
+
     /// Bones base transformation (pose)
     #[inline]
     #[must_use]
@@ -455,6 +463,7 @@ pub trait RaylibModel {
         }
         Some(unsafe { &mut *(self.as_mut().bindPose.cast()) })
     }
+
     /// Check model animation skeleton match
     #[inline]
     #[must_use]
@@ -522,10 +531,10 @@ impl Mesh {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const unsafe fn make_weak(self) -> WeakMesh {
         let m = WeakMesh(self.0);
         std::mem::forget(self);
@@ -545,6 +554,7 @@ pub trait RaylibMesh {
             ffi::UploadMesh(self.as_mut(), dynamic);
         }
     }
+
     /// Update mesh vertex data in GPU for a specific buffer index
     ///
     /// # Panics
@@ -567,6 +577,7 @@ pub trait RaylibMesh {
             );
         }
     }
+
     /// Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
     ///
     /// # Panics
@@ -588,6 +599,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
     ///
     /// # Panics
@@ -609,6 +621,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
     ///
     /// # Panics
@@ -630,6 +643,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
     ///
     /// # Panics
@@ -651,6 +665,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
     ///
     /// # Panics
@@ -672,6 +687,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
     ///
     /// # Panics
@@ -693,6 +709,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
     ///
     /// # Panics
@@ -714,6 +731,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
     ///
     /// # Panics
@@ -735,6 +753,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex indices (in case vertex data comes indexed)
     ///
     /// # Panics
@@ -758,6 +777,7 @@ pub trait RaylibMesh {
             )
         }
     }
+
     /// Vertex indices (in case vertex data comes indexed)
     ///
     /// # Panics
@@ -927,10 +947,10 @@ impl Material {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const unsafe fn make_weak(self) -> WeakMaterial {
         let m = WeakMaterial(self.0);
         std::mem::forget(self);
@@ -972,26 +992,28 @@ impl RaylibMaterial for Material {}
 /// [`Material`] accessors and helper methods.
 pub trait RaylibMaterial {
     /// Material shader
-    #[must_use]
     #[inline]
+    #[must_use]
     fn shader(&self) -> &crate::shaders::WeakShader
     where
         Self: AsRef<ffi::Material>,
     {
         unsafe { &*std::ptr::from_ref(&self.as_ref().shader).cast() }
     }
+
     /// Material shader
-    #[must_use]
     #[inline]
+    #[must_use]
     fn shader_mut(&mut self) -> &mut crate::shaders::WeakShader
     where
         Self: AsMut<ffi::Material>,
     {
         unsafe { &mut *std::ptr::from_mut(&mut self.as_mut().shader).cast() }
     }
+
     /// Material maps array ([`consts::MAX_MATERIAL_MAPS`])
-    #[must_use]
     #[inline]
+    #[must_use]
     fn maps(&self) -> &[MaterialMap]
     where
         Self: AsRef<ffi::Material>,
@@ -1003,9 +1025,10 @@ pub trait RaylibMaterial {
             )
         }
     }
-    #[must_use]
-    #[inline]
+
     /// Material maps array ([`consts::MAX_MATERIAL_MAPS`])
+    #[inline]
+    #[must_use]
     fn maps_mut(&mut self) -> &mut [MaterialMap]
     where
         Self: AsMut<ffi::Material>,
@@ -1132,6 +1155,7 @@ impl ExactSizeIterator for FramePoseIter<'_> {
         self.iter.len()
     }
 }
+
 /// Iterator over mutable frame pose references
 ///
 /// Returned by [`RaylibModelAnimation::frame_poses_iter`].
@@ -1224,7 +1248,7 @@ impl ModelAnimation {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
@@ -1310,6 +1334,7 @@ pub trait RaylibModelAnimation {
         .map(|frame_pose| unsafe { std::slice::from_raw_parts(frame_pose, bone_count) })
         .collect()
     }
+
     /// Iterator over poses array by frame
     ///
     /// # Panics
@@ -1363,6 +1388,7 @@ pub trait RaylibModelAnimation {
         .map(|frame_pose| unsafe { std::slice::from_raw_parts_mut(frame_pose, bone_count) })
         .collect()
     }
+
     /// Iterator over poses array by frame
     ///
     /// # Panics
@@ -1395,6 +1421,7 @@ impl MaterialMap {
     pub const fn texture(&self) -> &crate::texture::WeakTexture2D {
         unsafe { &*std::ptr::from_ref(&self.0.texture).cast() }
     }
+
     /// Material map texture
     #[inline]
     #[must_use]
@@ -1408,6 +1435,7 @@ impl MaterialMap {
     pub const fn color(&self) -> &Color {
         unsafe { &*std::ptr::from_ref(&self.0.color).cast() }
     }
+
     /// Material map color
     #[inline]
     #[must_use]
@@ -1421,6 +1449,7 @@ impl MaterialMap {
     pub const fn value(&self) -> &f32 {
         unsafe { &*std::ptr::from_ref(&self.0.value).cast() }
     }
+
     /// Material map value
     #[inline]
     #[must_use]

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -4,13 +4,27 @@ use crate::consts::ShaderUniformDataType;
 use crate::core::math::Matrix;
 use crate::core::math::{Vector2, Vector3, Vector4};
 use crate::core::{RaylibHandle, RaylibThread};
-use crate::{ffi, MintMatrix};
+use crate::{MintMatrix, ffi};
 use std::ffi::CString;
 use std::os::raw::c_void;
 
+/// Maximum number of shader locations supported
+/// (normally set by `config.h`, 32 by default)
+pub const RL_MAX_SHADER_LOCATIONS: usize = 32;
+
 fn no_drop<T>(_thing: T) {}
-make_thin_wrapper!(Shader, ffi::Shader, ffi::UnloadShader);
-make_thin_wrapper!(WeakShader, ffi::Shader, no_drop);
+make_thin_wrapper!(
+    /// Shader
+    Shader,
+    ffi::Shader,
+    ffi::UnloadShader
+);
+make_thin_wrapper!(
+    /// Unowned version of [`Shader`] that does not free the resource when dropped
+    WeakShader,
+    ffi::Shader,
+    no_drop
+);
 
 // #[cfg(feature = "nightly")]
 // impl !Send for Shader {}
@@ -18,42 +32,54 @@ make_thin_wrapper!(WeakShader, ffi::Shader, no_drop);
 // unsafe impl Sync for Shader {}
 
 impl RaylibHandle {
-    #[must_use]
     /// Loads a custom shader and binds default locations.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vs_filename` or `fs_filename` contains an internal 0 byte.
+    #[must_use]
     pub fn load_shader(
         &mut self,
         _: &RaylibThread,
         vs_filename: Option<&str>,
         fs_filename: Option<&str>,
     ) -> Shader {
-        let c_vs_filename = vs_filename.map(|f| CString::new(f).unwrap());
-        let c_fs_filename = fs_filename.map(|f| CString::new(f).unwrap());
+        let vs_c_filename = vs_filename
+            .map(|f| CString::new(f).expect("vs_filename should not contain an internal 0 byte"));
+        let fs_c_filename = fs_filename
+            .map(|f| CString::new(f).expect("fs_filename should not contain an internal 0 byte"));
 
-        let vs = c_vs_filename
+        let vs = vs_c_filename
             .as_ref()
             .map_or_else(std::ptr::null, |s| s.as_ptr());
-        let fs = c_fs_filename
+        let fs = fs_c_filename
             .as_ref()
             .map_or_else(std::ptr::null, |s| s.as_ptr());
 
         Shader(unsafe { ffi::LoadShader(vs, fs) })
     }
 
-    #[must_use]
     /// Loads shader from code strings and binds default locations.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vs_filename` or `fs_filename` contains an internal 0 byte.
+    #[must_use]
     pub fn load_shader_from_memory(
         &mut self,
         _: &RaylibThread,
         vs_code: Option<&str>,
         fs_code: Option<&str>,
     ) -> Shader {
-        let c_vs_code = vs_code.map(|f| CString::new(f).unwrap());
-        let c_fs_code = fs_code.map(|f| CString::new(f).unwrap());
+        let vs_c_code = vs_code
+            .map(|f| CString::new(f).expect("vs_code should not contain an internal 0 byte"));
+        let fs_c_code = fs_code
+            .map(|f| CString::new(f).expect("fs_code should not contain an internal 0 byte"));
 
-        let vs = c_vs_code
+        let vs = vs_c_code
             .as_ref()
             .map_or_else(std::ptr::null, |s| s.as_ptr());
-        let fs = c_fs_code
+        let fs = fs_c_code
             .as_ref()
             .map_or_else(std::ptr::null, |s| s.as_ptr());
 
@@ -89,124 +115,154 @@ impl RaylibHandle {
     pub fn get_matrix_projection(&self) -> Matrix {
         unsafe { ffi::rlGetMatrixProjection().into() }
     }
+    /// Get default shader. Modifying it modifies everything that uses that shader
     #[inline]
     #[must_use]
-    /// Get default shader. Modifying it modifies everything that uses that shader
     pub fn get_shader_default() -> WeakShader {
-        unsafe {
-            WeakShader(ffi::Shader {
-                id: ffi::rlGetShaderIdDefault(),
-                locs: ffi::rlGetShaderLocsDefault(),
-            })
-        }
+        WeakShader(ffi::Shader {
+            id: unsafe { ffi::rlGetShaderIdDefault() },
+            locs: unsafe { ffi::rlGetShaderLocsDefault() },
+        })
     }
 }
 
-pub trait ShaderV {
+/// Types that can be sent to the GPU as uniform values for shaders.
+///
+/// # Safety
+///
+/// The implementor must ensure that [`ShaderV::UNIFORM_TYPE`] accurately describes how
+/// `Self` should be interpreted by the GPU.
+pub unsafe trait ShaderV: Copy {
+    /// Enumerator describing the format [`ShaderV::value`]'s return can/should be interpreted by the GPU.
+    /// This involves the size, alignment, and information stored by the type.
     const UNIFORM_TYPE: ShaderUniformDataType;
-    unsafe fn value(&self) -> *const c_void;
-}
 
-impl ShaderV for f32 {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_FLOAT;
+    /// Convert a reference to `self` into a void pointer that will have its data sent to the GPU.
+    fn value(&self) -> &c_void;
+}
+#[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+use ShaderUniformDataType::*;
+
+unsafe impl ShaderV for f32 {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_FLOAT;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self as *const f32 as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*std::ptr::from_ref(self).cast() }
     }
 }
 
-impl ShaderV for Vector2 {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_VEC2;
+unsafe impl ShaderV for Vector2 {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_VEC2;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self as *const Vector2 as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*std::ptr::from_ref(self).cast() }
     }
 }
 
-impl ShaderV for Vector3 {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_VEC3;
+unsafe impl ShaderV for Vector3 {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_VEC3;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self as *const Vector3 as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*std::ptr::from_ref(self).cast() }
     }
 }
 
-impl ShaderV for Vector4 {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_VEC4;
+unsafe impl ShaderV for Vector4 {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_VEC4;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self as *const Vector4 as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*std::ptr::from_ref(self).cast() }
     }
 }
 
-impl ShaderV for i32 {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_INT;
+unsafe impl ShaderV for i32 {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_INT;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self as *const i32 as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*std::ptr::from_ref(self).cast() }
     }
 }
 
-impl ShaderV for [i32; 2] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_IVEC2;
+unsafe impl ShaderV for [i32; 2] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_IVEC2;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
-impl ShaderV for [i32; 3] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_IVEC3;
+unsafe impl ShaderV for [i32; 3] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_IVEC3;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
-impl ShaderV for [i32; 4] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_IVEC4;
+unsafe impl ShaderV for [i32; 4] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_IVEC4;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
-impl ShaderV for [f32; 2] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_VEC2;
+unsafe impl ShaderV for [f32; 2] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_VEC2;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
-impl ShaderV for [f32; 3] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_VEC3;
+unsafe impl ShaderV for [f32; 3] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_VEC3;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
-impl ShaderV for [f32; 4] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_VEC4;
+unsafe impl ShaderV for [f32; 4] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_VEC4;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
-impl ShaderV for &[i32] {
-    const UNIFORM_TYPE: ShaderUniformDataType = ShaderUniformDataType::SHADER_UNIFORM_SAMPLER2D;
+unsafe impl ShaderV for &[i32] {
+    const UNIFORM_TYPE: ShaderUniformDataType = SHADER_UNIFORM_SAMPLER2D;
     #[inline]
-    unsafe fn value(&self) -> *const c_void {
-        self.as_ptr() as *const c_void
+    fn value(&self) -> &c_void {
+        // SAFETY: A reference cast to a pointer is still a reference
+        unsafe { &*self.as_ptr().cast() }
     }
 }
 
 impl Shader {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
-    pub unsafe fn make_weak(self) -> WeakShader {
+    pub const unsafe fn make_weak(self) -> WeakShader {
         let m = WeakShader(self.0);
         std::mem::forget(self);
         m
@@ -226,22 +282,29 @@ impl Shader {
             ffi::SetShaderValue(
                 self.0,
                 uniform_loc,
-                value.value(),
-                (S::UNIFORM_TYPE as u32) as i32,
+                std::ptr::from_ref(value.value()),
+                S::UNIFORM_TYPE as i32,
             );
         }
     }
 
     /// Set shader uniform value vector
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `value` has a length greater than [`i32::MAX`].
     #[inline]
     pub fn set_shader_value_v<S: ShaderV>(&mut self, uniform_loc: i32, value: &[S]) {
         unsafe {
             ffi::SetShaderValueV(
                 self.0,
                 uniform_loc,
-                value.as_ptr() as *const ::std::os::raw::c_void,
-                (S::UNIFORM_TYPE as u32) as i32,
-                value.len() as i32,
+                value.as_ptr().cast(),
+                S::UNIFORM_TYPE as i32,
+                value
+                    .len()
+                    .try_into()
+                    .expect("value should not exceed i32::MAX elements"),
             );
         }
     }
@@ -270,67 +333,106 @@ impl Shader {
 impl RaylibShader for WeakShader {}
 impl RaylibShader for Shader {}
 
-pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
-    /// Shader locations array (RL_MAX_SHADER_LOCATIONS)
+/// [`Shader`] accessors and helper methods.
+pub trait RaylibShader {
+    /// Shader locations array ([`RL_MAX_SHADER_LOCATIONS`])
     #[inline]
     #[must_use]
-    fn locs(&self) -> &[i32] {
-        unsafe { std::slice::from_raw_parts(self.as_ref().locs, 32) }
+    fn locs(&self) -> &[i32; RL_MAX_SHADER_LOCATIONS]
+    where
+        Self: AsRef<ffi::Shader>,
+    {
+        unsafe { &*self.as_ref().locs.cast() }
     }
 
-    /// Shader locations array (RL_MAX_SHADER_LOCATIONS)
+    /// Shader locations array ([`RL_MAX_SHADER_LOCATIONS`])
     #[inline]
     #[must_use]
-    fn locs_mut(&mut self) -> &mut [i32] {
-        unsafe { std::slice::from_raw_parts_mut(self.as_mut().locs, 32) }
+    fn locs_mut(&mut self) -> &mut [i32; RL_MAX_SHADER_LOCATIONS]
+    where
+        Self: AsMut<ffi::Shader>,
+    {
+        unsafe { &mut *self.as_mut().locs.cast() }
     }
 
     /// Gets shader uniform location by name.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `uniform_name` contains an internal 0 byte.
     #[inline]
     #[must_use]
-    fn get_shader_location(&self, uniform_name: &str) -> i32 {
-        let c_uniform_name = CString::new(uniform_name).unwrap();
+    fn get_shader_location(&self, uniform_name: &str) -> i32
+    where
+        Self: AsRef<ffi::Shader>,
+    {
+        let c_uniform_name =
+            CString::new(uniform_name).expect("uniform_name should not contain an internal 0 byte");
         unsafe { ffi::GetShaderLocation(*self.as_ref(), c_uniform_name.as_ptr()) }
     }
 
     /// Gets shader attribute location by name.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `attribute_name` contains an internal 0 byte.
     #[inline]
     #[must_use]
-    fn get_shader_location_attribute(&self, attribute_name: &str) -> i32 {
-        let c_attribute_name = CString::new(attribute_name).unwrap();
+    fn get_shader_location_attribute(&self, attribute_name: &str) -> i32
+    where
+        Self: AsRef<ffi::Shader>,
+    {
+        let c_attribute_name = CString::new(attribute_name)
+            .expect("attribute_name should not contain an internal 0 byte");
         unsafe { ffi::GetShaderLocationAttrib(*self.as_ref(), c_attribute_name.as_ptr()) }
     }
 
     /// Sets shader uniform value
     #[inline]
-    fn set_shader_value<S: ShaderV>(&mut self, uniform_loc: i32, value: S) {
+    fn set_shader_value<S: ShaderV>(&mut self, uniform_loc: i32, value: S)
+    where
+        Self: AsMut<ffi::Shader>,
+    {
         unsafe {
             ffi::SetShaderValue(
                 *self.as_mut(),
                 uniform_loc,
                 value.value(),
-                (S::UNIFORM_TYPE as u32) as i32,
+                S::UNIFORM_TYPE as i32,
             );
         }
     }
 
     /// Set shader uniform value vector
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `value` has a length greater than [`i32::MAX`].
     #[inline]
-    fn set_shader_value_v<S: ShaderV>(&mut self, uniform_loc: i32, value: &[S]) {
+    fn set_shader_value_v<S: ShaderV>(&mut self, uniform_loc: i32, value: &[S])
+    where
+        Self: AsMut<ffi::Shader>,
+    {
         unsafe {
             ffi::SetShaderValueV(
                 *self.as_mut(),
                 uniform_loc,
-                value.as_ptr() as *const ::std::os::raw::c_void,
-                (S::UNIFORM_TYPE as u32) as i32,
-                value.len() as i32,
+                value.as_ptr().cast(),
+                S::UNIFORM_TYPE as i32,
+                value
+                    .len()
+                    .try_into()
+                    .expect("value should not exceed i32::MAX elements"),
             );
         }
     }
 
     /// Sets shader uniform value (matrix 4x4).
     #[inline]
-    fn set_shader_value_matrix(&mut self, uniform_loc: i32, mat: impl Into<MintMatrix>) {
+    fn set_shader_value_matrix(&mut self, uniform_loc: i32, mat: impl Into<MintMatrix>)
+    where
+        Self: AsMut<ffi::Shader>,
+    {
         unsafe {
             ffi::SetShaderValueMatrix(*self.as_mut(), uniform_loc, mat.into());
         }
@@ -338,7 +440,10 @@ pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
 
     /// Sets shader uniform value (matrix 4x4).
     #[inline]
-    fn set_shader_value_texture(&mut self, uniform_loc: i32, texture: impl AsRef<ffi::Texture2D>) {
+    fn set_shader_value_texture(&mut self, uniform_loc: i32, texture: impl AsRef<ffi::Texture2D>)
+    where
+        Self: AsMut<ffi::Shader>,
+    {
         unsafe {
             ffi::SetShaderValueTexture(*self.as_mut(), uniform_loc, *texture.as_ref());
         }

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -103,8 +103,8 @@ impl RaylibHandle {
     }
 
     /// Gets internal modelview matrix.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn get_matrix_modelview(&self) -> Matrix {
         unsafe { ffi::rlGetMatrixModelview().into() }
     }
@@ -115,6 +115,7 @@ impl RaylibHandle {
     pub fn get_matrix_projection(&self) -> Matrix {
         unsafe { ffi::rlGetMatrixProjection().into() }
     }
+
     /// Get default shader. Modifying it modifies everything that uses that shader
     #[inline]
     #[must_use]
@@ -258,7 +259,7 @@ impl Shader {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -1,10 +1,12 @@
 //! Text and Font related functions
-//! Text manipulation functions are super unsafe so use rust String functions
+//!
+//! Text manipulation functions are super unsafe, so use Rust's [`String`] functions
 
 use crate::core::math::Vector2;
 use crate::core::texture::{Image, Texture2D};
 use crate::core::{RaylibHandle, RaylibThread};
-use crate::error::LoadFontError;
+use crate::databuf::DataBuf;
+use crate::error::{AllocationError, LoadFontError};
 use crate::ffi;
 use crate::ffi::Rectangle;
 
@@ -14,44 +16,51 @@ use std::mem::ManuallyDrop;
 
 fn no_drop<T>(_thing: T) {}
 make_thin_wrapper!(
-    /// Font, font texture and GlyphInfo array data
+    /// Font, font texture and [`GlyphInfo`] array data
     Font,
     ffi::Font,
     ffi::UnloadFont
 );
-make_thin_wrapper!(WeakFont, ffi::Font, no_drop);
 make_thin_wrapper!(
-    /// GlyphInfo, font characters glyphs info
+    /// Unowned version of [`Font`] that does not free the resource when dropped
+    WeakFont,
+    ffi::Font,
+    no_drop
+);
+make_thin_wrapper!(
+    /// [`GlyphInfo`], font characters glyphs info
     GlyphInfo,
     ffi::GlyphInfo,
     no_drop
 );
 
+/// An owned slice of [`GlyphInfo`]s that will be freed by Raylib.
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct RSliceGlyphInfo(pub(crate) std::mem::ManuallyDrop<std::boxed::Box<[GlyphInfo]>>);
+pub struct RSliceGlyphInfo(pub(crate) std::mem::ManuallyDrop<Box<[GlyphInfo]>>);
 
 impl Drop for RSliceGlyphInfo {
-    #[allow(unused_unsafe)]
     fn drop(&mut self) {
+        let inner = unsafe { std::mem::ManuallyDrop::take(&mut self.0) };
+        let len = inner.len();
         unsafe {
-            let inner = std::mem::ManuallyDrop::take(&mut self.0);
-            let len = inner.len();
             ffi::UnloadFontData(
-                std::boxed::Box::leak(inner).as_mut_ptr() as *mut _,
-                len as i32,
+                Box::leak(inner).as_mut_ptr().cast(),
+                len.try_into().expect("len should not exceed i32::MAX"),
             );
         }
     }
 }
 
-impl std::convert::AsRef<Box<[GlyphInfo]>> for RSliceGlyphInfo {
+impl AsRef<Box<[GlyphInfo]>> for RSliceGlyphInfo {
+    #[inline]
     fn as_ref(&self) -> &Box<[GlyphInfo]> {
         &self.0
     }
 }
 
-impl std::convert::AsMut<Box<[GlyphInfo]>> for RSliceGlyphInfo {
+impl AsMut<Box<[GlyphInfo]>> for RSliceGlyphInfo {
+    #[inline]
     fn as_mut(&mut self) -> &mut Box<[GlyphInfo]> {
         &mut self.0
     }
@@ -82,14 +91,16 @@ impl std::ops::DerefMut for RSliceGlyphInfo {
 // unsafe impl Sync for WeakFont {}
 
 impl AsRef<ffi::Texture2D> for Font {
+    #[inline]
     fn as_ref(&self) -> &ffi::Texture2D {
-        return &self.0.texture;
+        &self.0.texture
     }
 }
 
 impl AsRef<ffi::Texture2D> for WeakFont {
+    #[inline]
     fn as_ref(&self) -> &ffi::Texture2D {
-        return &self.0.texture;
+        &self.0.texture
     }
 }
 
@@ -106,39 +117,69 @@ impl Drop for Codepoints {
 const TOO_MANY_CODEPOINTS: &str = "fonts exceeding 2,147,483,647 characters are not supported; at most 1,112,064 characters can possibly be encoded in utf-8.";
 
 impl RaylibHandle {
-    #[must_use]
     /// Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
-    pub(crate) fn load_codepoints(&mut self, text: &str) -> Codepoints {
-        let ptr = CString::new(text).unwrap();
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte, or if [`ffi::LoadCodepoints`] assigns a negative len.
+    #[must_use]
+    pub(crate) fn load_codepoints(text: &str) -> Codepoints {
+        let ptr = CString::new(text).expect("text should not contain an internal 0 byte");
         let mut len = 0;
-        let u = unsafe { ffi::LoadCodepoints(ptr.as_ptr(), &mut len) };
+        // SAFETY: `ptr` is a valid c-string, and `len` is non-null and safe to dereference for writing.
+        // `LoadCodepoints` is pure and does not require Raylib to be initialized.
+        let u = unsafe { ffi::LoadCodepoints(ptr.as_ptr(), &raw mut len) };
 
-        unsafe {
-            Codepoints(std::mem::ManuallyDrop::new(Box::from_raw(
-                std::slice::from_raw_parts_mut(u, len.try_into().expect("codepoint count should never be negative")),
-            )))
-        }
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(
+                u,
+                len.try_into()
+                    .expect("codepoint count should never be negative"),
+            )
+        };
+        Codepoints(std::mem::ManuallyDrop::new(unsafe { Box::from_raw(data) }))
     }
 
+    /// Get total number of codepoints in a UTF-8 encoded string
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[must_use]
     #[inline]
-    /// Get total number of codepoints in a UTF-8 encoded string
     pub fn get_codepoint_count(text: &str) -> i32 {
-        let ptr = CString::new(text).unwrap();
+        let ptr = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GetCodepointCount(ptr.as_ptr()) }
     }
 
     /// Unload font from GPU memory (VRAM)
+    ///
+    /// Weak fonts will leak memory if they are not unlaoded
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `font`.
+    /// The caller must ensure that `font` has not yet been unloaded, and that no copies
+    /// of `font` are accessed or unloaded after this method returns.
     #[inline]
-    pub fn unload_font(&mut self, font: WeakFont) {
-        unsafe { ffi::UnloadFont(font.0) };
+    pub unsafe fn unload_font(&mut self, font: WeakFont) {
+        unsafe { ffi::UnloadFont(font.to_raw()) };
     }
 
     /// Loads font from file into GPU memory (VRAM).
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadFontError::LoadFromFileFailed`] if [`ffi::LoadFont`] returns
+    /// a font whose glyphs are null or texture id is 0.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
-    #[must_use]
     pub fn load_font(&mut self, _: &RaylibThread, filename: &str) -> Result<Font, LoadFontError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let f = unsafe { ffi::LoadFont(c_filename.as_ptr()) };
         if f.glyphs.is_null() || f.texture.id == 0 {
             return Err(LoadFontError::LoadFromFileFailed {
@@ -149,9 +190,19 @@ impl RaylibHandle {
     }
 
     /// Loads font from file with extended parameters.
-    /// Supplying None for chars loads the entire character set.
+    ///
+    /// Supplying [`None`] for chars loads the entire character set.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadFontError::LoadFromFileFailed`] if [`ffi::LoadFontEx`] returns
+    /// a font whose glyphs are null or texture id is 0.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte, or if the codepoints loaded from `chars`
+    /// exceed [`i32::MAX`] elements.
     #[inline]
-    #[must_use]
     pub fn load_font_ex(
         &mut self,
         _: &RaylibThread,
@@ -159,21 +210,20 @@ impl RaylibHandle {
         font_size: i32,
         chars: Option<&str>,
     ) -> Result<Font, LoadFontError> {
-        let c_filename = CString::new(filename).unwrap();
-        let f = unsafe {
-            match chars {
-                Some(c) => {
-                    let mut co = self.load_codepoints(c);
-                    ffi::LoadFontEx(
-                        c_filename.as_ptr(),
-                        font_size,
-                        co.0.as_mut_ptr(),
-                        co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
-                    )
-                }
-                None => ffi::LoadFontEx(c_filename.as_ptr(), font_size, std::ptr::null_mut(), 0),
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
+        let mut co;
+        let (co_ptr, co_len) = match chars {
+            Some(c) => {
+                co = Self::load_codepoints(c);
+                (
+                    co.0.as_mut_ptr(),
+                    co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
+                )
             }
+            None => (std::ptr::null_mut(), 0),
         };
+        let f = unsafe { ffi::LoadFontEx(c_filename.as_ptr(), font_size, co_ptr, co_len) };
         if f.glyphs.is_null() || f.texture.id == 0 {
             return Err(LoadFontError::LoadFromFileFailed {
                 path: filename.into(),
@@ -183,26 +233,40 @@ impl RaylibHandle {
     }
 
     /// Load font from Image (XNA style)
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadFontError::LoadFromImageFailed`] if [`ffi::LoadFontFromImage`] returns
+    /// a font whose glyphs are null or texture id is 0.
     #[inline]
-    #[must_use]
     pub fn load_font_from_image(
         &mut self,
         _: &RaylibThread,
         image: &Image,
         key: impl Into<ffi::Color>,
-        first_char: i32,
+        first_char: char,
     ) -> Result<Font, LoadFontError> {
-        let f = unsafe { ffi::LoadFontFromImage(image.0, key.into(), first_char) };
-        if f.glyphs.is_null() {
-            return Err(LoadFontError::LoadFromImageFailed);
+        let f = unsafe { ffi::LoadFontFromImage(image.0, key.into(), first_char as i32) };
+        if f.glyphs.is_null() || f.texture.id == 0 {
+            Err(LoadFontError::LoadFromImageFailed)
+        } else {
+            Ok(Font(f))
         }
-        Ok(Font(f))
     }
     /// Load font data from a given memory buffer.
     /// `file_type` refers to the extension, e.g. ".ttf".
-    /// You can pass Some(...) to chars to get the desired characters, or None to get the whole set.
+    /// You can pass [`Some`] to chars to get the desired characters, or None to get the whole set.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadFontError::LoadFromMemoryFailed`] if [`ffi::LoadFontFromMemory`] returns
+    /// a font whose glyphs are null or texture id is 0.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte, or if either `file_data`
+    /// or the codepoints loaded from `chars` exceed [`i32::MAX`] elements.
     #[inline]
-    #[must_use]
     pub fn load_font_from_memory(
         &mut self,
         _: &RaylibThread,
@@ -211,29 +275,31 @@ impl RaylibHandle {
         font_size: i32,
         chars: Option<&str>,
     ) -> Result<Font, LoadFontError> {
-        let c_file_type = CString::new(file_type).unwrap();
-        let f = unsafe {
-            match chars {
-                Some(c) => {
-                    let mut co = self.load_codepoints(c);
-                    ffi::LoadFontFromMemory(
-                        c_file_type.as_ptr(),
-                        file_data.as_ptr(),
-                        file_data.len() as i32,
-                        font_size,
-                        co.0.as_mut_ptr(),
-                        co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
-                    )
-                }
-                None => ffi::LoadFontFromMemory(
-                    c_file_type.as_ptr(),
-                    file_data.as_ptr(),
-                    file_data.len() as i32,
-                    font_size,
-                    std::ptr::null_mut(),
-                    0,
-                ),
+        let c_file_type =
+            CString::new(file_type).expect("file_type should not contain an internal 0 byte");
+        let mut co;
+        let (co_ptr, co_len) = match chars {
+            Some(c) => {
+                co = Self::load_codepoints(c);
+                (
+                    co.0.as_mut_ptr(),
+                    co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
+                )
             }
+            None => (std::ptr::null_mut(), 0),
+        };
+        let f = unsafe {
+            ffi::LoadFontFromMemory(
+                c_file_type.as_ptr(),
+                file_data.as_ptr(),
+                file_data
+                    .len()
+                    .try_into()
+                    .expect("file_data should not exceed i32::MAX elements"),
+                font_size,
+                co_ptr,
+                co_len,
+            )
         };
         if f.glyphs.is_null() || f.texture.id == 0 {
             return Err(LoadFontError::LoadFromMemoryFailed);
@@ -242,6 +308,13 @@ impl RaylibHandle {
     }
     /// Loads font data for further use (see also `Font::from_data`).
     /// Now supports .tiff
+    ///
+    /// Returns [`None`] if [`ffi::LoadFontData`] returns null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte, or if either `file_data`
+    /// or the codepoints loaded from `chars` exceed [`i32::MAX`] elements.
     #[inline]
     pub fn load_font_data(
         &mut self,
@@ -250,83 +323,96 @@ impl RaylibHandle {
         chars: Option<&str>,
         sdf: i32,
     ) -> Option<RSliceGlyphInfo> {
-        unsafe {
-            let ci_arr_ptr = match chars {
-                Some(c) => {
-                    let mut co = self.load_codepoints(c);
-                    ffi::LoadFontData(
-                        data.as_ptr(),
-                        data.len() as i32,
-                        font_size,
-                        co.0.as_mut_ptr(),
-                        co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
-                        sdf,
-                    )
-                }
-                None => ffi::LoadFontData(
-                    data.as_ptr(),
-                    data.len() as i32,
-                    font_size,
-                    std::ptr::null_mut(),
-                    0,
-                    sdf,
-                ),
-            };
-            let ci_size = if let Some(c) = chars { c.len() } else { 95 }; // raylib assumes 95 if none given
-            if ci_arr_ptr.is_null() {
-                None
-            } else {
-                Some(RSliceGlyphInfo(std::mem::ManuallyDrop::new(Box::from_raw(
-                    std::slice::from_raw_parts_mut(ci_arr_ptr as *mut _, ci_size),
-                ))))
+        let mut co;
+        let (co_ptr, co_len) = match chars {
+            Some(c) => {
+                co = Self::load_codepoints(c);
+                (
+                    co.0.as_mut_ptr(),
+                    co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
+                )
             }
-        }
+            None => (std::ptr::null_mut(), 0),
+        };
+        let ci_arr_ptr = unsafe {
+            ffi::LoadFontData(
+                data.as_ptr(),
+                data.len()
+                    .try_into()
+                    .expect("data should not exceed i32::MAX elements"),
+                font_size,
+                co_ptr,
+                co_len,
+                sdf,
+            )
+        };
+        let ci_size = chars.map_or(95, str::len); // raylib assumes 95 if none given
+        (!ci_arr_ptr.is_null()).then(|| {
+            let data = unsafe { std::slice::from_raw_parts_mut(ci_arr_ptr.cast(), ci_size) };
+            RSliceGlyphInfo(std::mem::ManuallyDrop::new(unsafe { Box::from_raw(data) }))
+        })
     }
 }
 
 impl RaylibFont for WeakFont {}
 impl RaylibFont for Font {}
 
-pub trait RaylibFont: AsRef<ffi::Font> + AsMut<ffi::Font> {
+/// [`Font`] accessors and helper methods.
+pub trait RaylibFont {
     /// Base size (default chars height)
     #[inline]
     #[must_use]
-    fn base_size(&self) -> i32 {
+    fn base_size(&self) -> i32
+    where
+        Self: AsRef<ffi::Font>,
+    {
         self.as_ref().baseSize
     }
     /// Texture atlas containing the glyphs
     #[inline]
     #[must_use]
-    fn texture(&self) -> &Texture2D {
-        unsafe { std::mem::transmute(&self.as_ref().texture) }
+    fn texture(&self) -> &Texture2D
+    where
+        Self: AsRef<ffi::Font>,
+    {
+        unsafe { &*std::ptr::from_ref(&self.as_ref().texture).cast() }
     }
     /// Glyphs info data
     #[inline]
     #[must_use]
-    fn chars(&self) -> &[GlyphInfo] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.as_ref().glyphs as *const GlyphInfo,
-                self.as_ref().glyphCount as usize,
-            )
-        }
+    fn chars(&self) -> &[GlyphInfo]
+    where
+        Self: AsRef<ffi::Font>,
+    {
+        let glyph_count = self
+            .as_ref()
+            .glyphCount
+            .try_into()
+            .expect("glyphCount should not be negative");
+        unsafe { std::slice::from_raw_parts(self.as_ref().glyphs.cast(), glyph_count) }
     }
     /// Glyphs info data
     #[inline]
     #[must_use]
-    fn chars_mut(&mut self) -> &mut [GlyphInfo] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().glyphs as *mut GlyphInfo,
-                self.as_ref().glyphCount as usize,
-            )
-        }
+    fn chars_mut(&mut self) -> &mut [GlyphInfo]
+    where
+        Self: AsMut<ffi::Font>,
+    {
+        let glyph_count = self
+            .as_mut()
+            .glyphCount
+            .try_into()
+            .expect("glyphCount should not be negative");
+        unsafe { std::slice::from_raw_parts_mut(self.as_mut().glyphs.cast(), glyph_count) }
     }
 
     /// Check if a font is valid
     #[inline]
     #[must_use]
-    fn is_font_valid(&self) -> bool {
+    fn is_font_valid(&self) -> bool
+    where
+        Self: AsRef<ffi::Font>,
+    {
         unsafe { ffi::IsFontValid(*self.as_ref()) }
     }
 
@@ -334,96 +420,121 @@ pub trait RaylibFont: AsRef<ffi::Font> + AsMut<ffi::Font> {
     #[must_use]
     fn export_font_as_code<A>(&self, filename: A) -> bool
     where
+        Self: AsRef<ffi::Font>,
         A: Into<OsString>,
     {
-        let c_str = CString::new(filename.into().to_string_lossy().as_bytes()).unwrap();
+        let c_str = CString::new(filename.into().to_string_lossy().as_bytes())
+            .expect("lossy filename string should not contain an internal 0 byte");
         unsafe { ffi::ExportFontAsCode(*self.as_ref(), c_str.as_ptr()) }
     }
 
     /// Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
     #[inline]
     #[must_use]
-    fn get_glyph_info(&self, codepoint: char) -> GlyphInfo {
+    fn get_glyph_info(&self, codepoint: char) -> GlyphInfo
+    where
+        Self: AsRef<ffi::Font>,
+    {
         unsafe { GlyphInfo(ffi::GetGlyphInfo(*self.as_ref(), codepoint as i32)) }
     }
 
     /// Gets index position for a unicode character on `font`.
     #[inline]
     #[must_use]
-    fn get_glyph_index(&self, codepoint: char) -> i32 {
+    fn get_glyph_index(&self, codepoint: char) -> i32
+    where
+        Self: AsRef<ffi::Font>,
+    {
         unsafe { ffi::GetGlyphIndex(*self.as_ref(), codepoint as i32) }
     }
 
     /// Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
     #[inline]
     #[must_use]
-    fn get_glyph_atlas_rec(&self, codepoint: char) -> Rectangle {
-        unsafe { ffi::GetGlyphAtlasRec(*self.as_ref(), codepoint as i32).into() }
+    fn get_glyph_atlas_rec(&self, codepoint: char) -> Rectangle
+    where
+        Self: AsRef<ffi::Font>,
+    {
+        unsafe { ffi::GetGlyphAtlasRec(*self.as_ref(), codepoint as i32) }
     }
 
     /// Measures string width in pixels for `font`.
     #[must_use]
-    fn measure_text(&self, text: &str, font_size: f32, spacing: f32) -> Vector2 {
-        let c_text = CString::new(text).unwrap();
+    fn measure_text(&self, text: &str, font_size: f32, spacing: f32) -> Vector2
+    where
+        Self: AsRef<ffi::Font>,
+    {
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::MeasureTextEx(*self.as_ref(), c_text.as_ptr(), font_size, spacing).into() }
     }
 }
 
 impl Font {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
-    pub fn make_weak(self) -> WeakFont {
+    pub const fn make_weak(self) -> WeakFont {
         let w = WeakFont(self.0);
         std::mem::forget(self);
-        return w;
+        w
     }
-    /// Returns a new `Font` using provided `GlyphInfo` data and parameters.
-    #[must_use]
+    /// Returns a new [`Font`] using provided [`GlyphInfo`] data and parameters.
     fn from_data(
         chars: &[ffi::GlyphInfo],
         base_size: i32,
         padding: i32,
         pack_method: i32,
     ) -> Result<Font, LoadFontError> {
-        let f = unsafe {
-            let mut f = std::mem::zeroed::<Font>();
-            f.baseSize = base_size;
-            f.set_chars(chars);
+        let mut f = unsafe { std::mem::zeroed::<Font>() };
+        f.baseSize = base_size;
+        f.set_chars(chars)
+            .expect("should be able to allocate memory for chars");
 
-            let atlas = ffi::GenImageFontAtlas(
+        let atlas = unsafe {
+            ffi::GenImageFontAtlas(
                 f.glyphs,
-                &mut f.0.recs,
+                &raw mut f.0.recs,
                 f.baseSize,
                 f.glyphCount,
                 padding,
                 pack_method,
-            );
-            f.texture = ffi::LoadTextureFromImage(atlas);
-            ffi::UnloadImage(atlas);
-            f
+            )
         };
+        f.texture = unsafe { ffi::LoadTextureFromImage(atlas) };
+        unsafe {
+            ffi::UnloadImage(atlas);
+        }
         if f.0.glyphs.is_null() || f.0.texture.id == 0 {
             return Err(LoadFontError::LoadFromImageFailed);
         }
         Ok(f)
     }
 
-    /// Sets the character data on the current Font.
-    fn set_chars(&mut self, chars: &[ffi::GlyphInfo]) {
-        unsafe {
-            self.glyphCount = chars.len() as i32;
-            let data_size = self.glyphCount as usize * std::mem::size_of::<ffi::GlyphInfo>();
-            let ci_arr_ptr = ffi::MemAlloc(data_size.try_into().unwrap()); // raylib frees this data in UnloadFont
-            std::ptr::copy(
-                chars.as_ptr(),
-                ci_arr_ptr as *mut ffi::GlyphInfo,
-                chars.len(),
-            );
-            self.glyphs = ci_arr_ptr as *mut ffi::GlyphInfo;
-        }
+    /// Sets the character data on the current [`Font`].
+    fn set_chars(&mut self, chars: &[ffi::GlyphInfo]) -> Result<(), AllocationError> {
+        let glyph_count = chars
+            .len()
+            .try_into()
+            .expect("chars should not exceed i32::MAX elements");
+        // raylib frees this data in UnloadFont
+        let glyphs = DataBuf::<[ffi::GlyphInfo]>::alloc_from_copy(chars)?
+            .into_inner()
+            .into_inner()
+            .as_ptr()
+            .cast();
+        self.glyphCount = glyph_count;
+        self.glyphs = glyphs;
+        Ok(())
     }
 
-    /// Sets the texture on the current Font, and takes ownership of `tex`.
+    /// Sets the texture on the current [`Font`], and takes ownership of `tex`.
     fn set_texture(&mut self, tex: Texture2D) {
         self.texture = tex.0;
         std::mem::forget(tex); // UnloadFont will also unload the texture
@@ -431,36 +542,40 @@ impl Font {
 }
 
 /// Generates image font atlas using `chars` info.
-/// Sets a pointer to an array of rectangles raylib allocated that MUST manually be freed.
-/// Good luck freeing it safely though ;)
+///
+/// # Panics
+///
+/// This function will panic if `chars` has a length greater than [`i32::MAX`],
+/// or if [`ffi::GenImageFontAtlas`] does not assign a value to `glyphRecs`.
 #[inline]
-#[must_use]
 pub fn gen_image_font_atlas(
     _: &RaylibThread,
     chars: &mut [ffi::GlyphInfo],
     font_size: i32,
     padding: i32,
     pack_method: i32,
-) -> (Image, Vec<ffi::Rectangle>) {
-    unsafe {
-        let mut ptr = std::ptr::null_mut();
+) -> (Image, DataBuf<[ffi::Rectangle]>) {
+    let mut ptr = std::ptr::null_mut();
+    let glyph_count = chars
+        .len()
+        .try_into()
+        .expect("chars must not exceed i32::MAX elements");
 
-        let img = Image(ffi::GenImageFontAtlas(
+    let img = Image(unsafe {
+        ffi::GenImageFontAtlas(
             chars.as_mut_ptr(),
-            &mut ptr,
+            &raw mut ptr,
+            glyph_count,
             font_size,
-            chars.len() as i32,
             padding,
             pack_method,
-        ));
+        )
+    });
 
-        let mut recs = Vec::with_capacity(chars.len());
-        #[allow(clippy::uninit_vec)]
-        recs.set_len(chars.len());
-        std::ptr::copy(ptr, recs.as_mut_ptr(), chars.len());
-        ffi::MemFree(ptr as *mut ::std::os::raw::c_void);
-        return (img, recs);
-    }
+    let recs = unsafe { DataBuf::slice_from_raw(ptr, std::mem::MaybeUninit::new(glyph_count)) }
+        .expect("ptr should not be null");
+
+    (img, recs)
 }
 
 impl RaylibHandle {
@@ -471,9 +586,13 @@ impl RaylibHandle {
         WeakFont(unsafe { ffi::GetFontDefault() })
     }
     /// Measures string width in pixels for default font.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[must_use]
     pub fn measure_text(&self, text: &str, font_size: i32) -> i32 {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::MeasureText(c_text.as_ptr(), font_size) }
     }
 

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -145,8 +145,8 @@ impl RaylibHandle {
     /// # Panics
     ///
     /// This method will panic if `text` contains an internal 0 byte.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn get_codepoint_count(text: &str) -> i32 {
         let ptr = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GetCodepointCount(ptr.as_ptr()) }
@@ -253,6 +253,7 @@ impl RaylibHandle {
             Ok(Font(f))
         }
     }
+
     /// Load font data from a given memory buffer.
     /// `file_type` refers to the extension, e.g. ".ttf".
     /// You can pass [`Some`] to chars to get the desired characters, or None to get the whole set.
@@ -306,6 +307,7 @@ impl RaylibHandle {
         }
         Ok(Font(f))
     }
+
     /// Loads font data for further use (see also `Font::from_data`).
     /// Now supports .tiff
     ///
@@ -368,6 +370,7 @@ pub trait RaylibFont {
     {
         self.as_ref().baseSize
     }
+
     /// Texture atlas containing the glyphs
     #[inline]
     #[must_use]
@@ -377,6 +380,7 @@ pub trait RaylibFont {
     {
         unsafe { &*std::ptr::from_ref(&self.as_ref().texture).cast() }
     }
+
     /// Glyphs info data
     #[inline]
     #[must_use]
@@ -391,6 +395,7 @@ pub trait RaylibFont {
             .expect("glyphCount should not be negative");
         unsafe { std::slice::from_raw_parts(self.as_ref().glyphs.cast(), glyph_count) }
     }
+
     /// Glyphs info data
     #[inline]
     #[must_use]
@@ -476,7 +481,7 @@ impl Font {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
@@ -485,6 +490,7 @@ impl Font {
         std::mem::forget(self);
         w
     }
+
     /// Returns a new [`Font`] using provided [`GlyphInfo`] data and parameters.
     fn from_data(
         chars: &[ffi::GlyphInfo],
@@ -585,6 +591,7 @@ impl RaylibHandle {
     pub fn get_font_default(&self) -> WeakFont {
         WeakFont(unsafe { ffi::GetFontDefault() })
     }
+
     /// Measures string width in pixels for default font.
     ///
     /// # Panics

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -7,16 +7,25 @@ use crate::ffi;
 use std::convert::TryInto;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
-use std::ptr::null_mut;
 
 use super::error::{InvalidImageError, LoadTextureError, UpdateTextureError};
 
-make_rslice!(ImagePalette, Color, ffi::UnloadImagePalette);
-make_rslice!(ImageColors, Color, ffi::UnloadImageColors);
+make_rslice!(
+    /// Raylib-managed slice of [`Color`]s unloaded by [`ffi::UnloadImagePalette`]
+    ImagePalette,
+    Color,
+    ffi::UnloadImagePalette
+);
+make_rslice!(
+    /// Raylib-managed slice of [`Color`]s unloaded by [`ffi::UnloadImageColors`]
+    ImageColors,
+    Color,
+    ffi::UnloadImageColors
+);
 
-/// NPatchInfo, n-patch layout info
+/// [`NPatchInfo`], n-patch layout info
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct NPatchInfo {
     /// Texture source rectangle
     pub source: Rectangle,
@@ -33,27 +42,23 @@ pub struct NPatchInfo {
 }
 
 impl From<ffi::NPatchInfo> for NPatchInfo {
+    #[inline]
     fn from(v: ffi::NPatchInfo) -> NPatchInfo {
         unsafe { std::mem::transmute(v) }
     }
 }
 
-impl Into<ffi::NPatchInfo> for NPatchInfo {
-    fn into(self) -> ffi::NPatchInfo {
-        unsafe { std::mem::transmute(self) }
+impl From<NPatchInfo> for ffi::NPatchInfo {
+    #[inline]
+    fn from(v: NPatchInfo) -> Self {
+        unsafe { std::mem::transmute(v) }
     }
 }
 
-impl Into<ffi::NPatchInfo> for &NPatchInfo {
-    fn into(self) -> ffi::NPatchInfo {
-        ffi::NPatchInfo {
-            source: self.source.into(),
-            left: self.left,
-            top: self.top,
-            right: self.right,
-            bottom: self.bottom,
-            layout: (self.layout as u32) as i32,
-        }
+impl From<&NPatchInfo> for ffi::NPatchInfo {
+    #[inline]
+    fn from(v: &NPatchInfo) -> Self {
+        unsafe { std::mem::transmute(*v) }
     }
 }
 
@@ -70,33 +75,26 @@ make_thin_wrapper!(
     ffi::Texture2D,
     ffi::UnloadTexture
 );
-make_thin_wrapper!(WeakTexture2D, ffi::Texture2D, no_drop);
-impl Default for WeakTexture2D {
-    fn default() -> Self {
-        Self(ffi::Texture::default())
-    }
-}
 make_thin_wrapper!(
-    /// RenderTexture, fbo for texture rendering
+    /// Unowned version of [`Texture2D`] that does not free the resource when dropped
+    #[derive(Default, Clone)]
+    WeakTexture2D,
+    ffi::Texture2D,
+    no_drop
+);
+make_thin_wrapper!(
+    /// [`RenderTexture`], fbo for texture rendering
     RenderTexture2D,
     ffi::RenderTexture2D,
     ffi::UnloadRenderTexture
 );
-make_thin_wrapper!(WeakRenderTexture2D, ffi::RenderTexture2D, no_drop);
-
-// Weak things can be clone
-impl Clone for WeakTexture2D {
-    fn clone(&self) -> WeakTexture2D {
-        WeakTexture2D(self.0)
-    }
-}
-
-// Weak things can be clone
-impl Clone for WeakRenderTexture2D {
-    fn clone(&self) -> WeakRenderTexture2D {
-        WeakRenderTexture2D(self.0)
-    }
-}
+make_thin_wrapper!(
+    /// Unowned version of [`RenderTexture2D`] that does not free the resource when dropped
+    #[derive(Clone)]
+    WeakRenderTexture2D,
+    ffi::RenderTexture2D,
+    no_drop
+);
 
 impl RaylibRenderTexture2D for WeakRenderTexture2D {}
 impl RaylibRenderTexture2D for RenderTexture2D {}
@@ -130,9 +128,17 @@ impl AsMut<ffi::Texture2D> for WeakRenderTexture2D {
 }
 
 impl RenderTexture2D {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
-    pub unsafe fn make_weak(self) -> WeakRenderTexture2D {
+    pub const unsafe fn make_weak(self) -> WeakRenderTexture2D {
         let m = WeakRenderTexture2D(self.0);
         std::mem::forget(self);
         m
@@ -146,33 +152,45 @@ impl RenderTexture2D {
     }
 }
 
-pub trait RaylibRenderTexture2D: AsRef<ffi::RenderTexture2D> + AsMut<ffi::RenderTexture2D> {
+/// [`RenderTexture2D`] accessors and helper methods.
+pub trait RaylibRenderTexture2D {
     /// OpenGL framebuffer object id
     #[inline]
     #[must_use]
-    fn id(&self) -> u32 {
+    fn id(&self) -> u32
+    where
+        Self: AsRef<ffi::RenderTexture2D>,
+    {
         self.as_ref().id
     }
 
     /// Color buffer attachment texture
     #[inline]
     #[must_use]
-    fn texture(&self) -> &WeakTexture2D {
-        unsafe { std::mem::transmute(&self.as_ref().texture) }
+    fn texture(&self) -> &WeakTexture2D
+    where
+        Self: AsRef<ffi::RenderTexture2D>,
+    {
+        unsafe { &*std::ptr::from_ref(&self.as_ref().texture).cast() }
     }
 
     /// Color buffer attachment texture
     #[inline]
     #[must_use]
-    fn texture_mut(&mut self) -> &mut WeakTexture2D {
-        unsafe { std::mem::transmute(&mut self.as_mut().texture) }
+    fn texture_mut(&mut self) -> &mut WeakTexture2D
+    where
+        Self: AsMut<ffi::RenderTexture2D>,
+    {
+        unsafe { &mut *std::ptr::from_mut(&mut self.as_mut().texture).cast() }
     }
 }
 
 impl Clone for Image {
     /// Create an image duplicate (useful for transformations)
     fn clone(&self) -> Image {
-        unsafe { Image(ffi::ImageCopy(self.0)) }
+        let copy = unsafe { Image(ffi::ImageCopy(self.0)) };
+        assert_eq!(&copy.0, &self.0, "ImageCopy failed to produce a copy");
+        copy
     }
 }
 
@@ -180,25 +198,31 @@ impl Image {
     /// Image base width
     #[inline]
     #[must_use]
-    pub fn width(&self) -> i32 {
+    pub const fn width(&self) -> i32 {
         self.0.width
     }
     /// Image base height
     #[inline]
     #[must_use]
-    pub fn height(&self) -> i32 {
+    pub const fn height(&self) -> i32 {
         self.0.height
     }
     /// Mipmap levels, 1 by default
     #[inline]
     #[must_use]
-    pub fn mipmaps(&self) -> i32 {
+    pub const fn mipmaps(&self) -> i32 {
         self.0.mipmaps
     }
     /// Image raw data
     #[inline]
     #[must_use]
-    pub unsafe fn data(&self) -> *mut ::std::os::raw::c_void {
+    pub const fn data(&self) -> *const ::std::os::raw::c_void {
+        self.0.data
+    }
+    /// Image raw data
+    #[inline]
+    #[must_use]
+    pub const fn data_mut(&mut self) -> *mut ::std::os::raw::c_void {
         self.0.data
     }
 
@@ -216,12 +240,12 @@ impl Image {
     #[inline]
     #[must_use]
     pub fn get_color(&self, x: i32, y: i32) -> Color {
-        Color::from(unsafe { ffi::GetImageColor(self.0, x, y) })
+        unsafe { ffi::GetImageColor(self.0, x, y) }
     }
     /// Draw circle outline within an image
     #[inline]
     pub fn draw_circle_lines(&mut self, center_x: i32, center_y: i32, radius: i32, color: Color) {
-        unsafe { ffi::ImageDrawCircleLines(&mut self.0, center_x, center_y, radius, color.into()) }
+        unsafe { ffi::ImageDrawCircleLines(&mut self.0, center_x, center_y, radius, color) }
     }
     /// Draw circle outline within an image (Vector version)
     #[inline]
@@ -231,15 +255,14 @@ impl Image {
         center_y: i32,
         color: Color,
     ) {
-        unsafe { ffi::ImageDrawCircleLinesV(&mut self.0, center.into(), center_y, color.into()) }
+        unsafe { ffi::ImageDrawCircleLinesV(&mut self.0, center.into(), center_y, color) }
     }
 
-    /// Data format (PixelFormat type)
+    /// Data format ([`PixelFormat`](crate::consts::PixelFormat) type)
     #[inline]
     #[must_use]
     pub fn format(&self) -> crate::consts::PixelFormat {
-        let i: u32 = self.format as u32;
-        unsafe { std::mem::transmute(i) }
+        unsafe { std::mem::transmute(self.format) }
     }
 
     /// Create an image from another image piece
@@ -256,46 +279,74 @@ impl Image {
         unsafe { Image(ffi::ImageFromChannel(self.0, selected_channel)) }
     }
     /// Exports image as a PNG file.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
     pub fn export_image(&self, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe {
             ffi::ExportImage(self.0, c_filename.as_ptr());
         }
     }
 
     /// Exports image as a PNG file.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
     pub fn export_image_as_code(&self, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe {
             ffi::ExportImageAsCode(self.0, c_filename.as_ptr());
         }
     }
 
     /// Get pixel data size in bytes (image or texture)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if [`ffi::GetPixelDataSize`] returns a negative number (possibly due to overflowing).
     #[inline]
     #[must_use]
     pub fn get_pixel_data_size(&self) -> usize {
-        unsafe { ffi::GetPixelDataSize(self.width(), self.height(), self.format() as i32) as usize }
-    }
-
-    /// Gets pixel data from `image` as a Vec of Color structs.
-    #[must_use]
-    pub fn get_image_data(&self) -> ImageColors {
         unsafe {
-            let image_data = ffi::LoadImageColors(self.0);
-            let image_data_len = (self.width * self.height) as usize;
-            ImageColors(ManuallyDrop::new(Box::from_raw(
-                std::slice::from_raw_parts_mut(image_data as *mut _, image_data_len),
-            )))
+            ffi::GetPixelDataSize(self.width(), self.height(), self.format() as i32)
+                .try_into()
+                .expect("ffi::GetPixelDataSize should return a positive number")
         }
     }
 
-    /// Gets pixel data from `image` as a Vec of Color structs.
+    /// Gets pixel data from `self` as an slice of [`Color`]s.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if `width` or `height` is negative.
+    #[must_use]
+    pub fn get_image_data(&self) -> ImageColors {
+        let image_data_len = usize::try_from(self.width).expect("width should not be negative")
+            * usize::try_from(self.height).expect("height should not be negative");
+        let image_data = unsafe { ffi::LoadImageColors(self.0) };
+        let data = unsafe { std::slice::from_raw_parts_mut(image_data.cast(), image_data_len) };
+        ImageColors(ManuallyDrop::new(unsafe { Box::from_raw(data) }))
+    }
+
+    /// Gets pixel data from `self` as a Vec of Color structs.
+    ///
+    /// `flip` - Reverse the image vertically
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if `width` or `height` is negative.
     #[must_use]
     pub fn get_image_data_u8(&self, flip: bool) -> Vec<u8> {
-        let image_data_len = (self.width * self.height * 4) as usize;
+        let image_data_len = 4
+            * usize::try_from(self.width).expect("width should not be negative")
+            * usize::try_from(self.height).expect("height should not be negative");
         let mut res = Vec::with_capacity(image_data_len);
         if flip {
             for y in (0..self.height).rev() {
@@ -321,20 +372,36 @@ impl Image {
         res
     }
     /// Extract color palette from image to maximum size
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `max_palette_size` is greater than [`i32::MAX`]
+    /// or if [`ffi::LoadImagePalette`] outputs a negative `colorCount`
     #[inline]
     #[must_use]
     pub fn extract_palette(&self, max_palette_size: u32) -> ImagePalette {
-        unsafe {
-            let mut palette_len = 0;
-            let image_data =
-                ffi::LoadImagePalette(self.0, max_palette_size as i32, &mut palette_len);
-            ImagePalette(ManuallyDrop::new(Box::from_raw(
-                std::slice::from_raw_parts_mut(image_data as *mut _, palette_len as usize),
-            )))
-        }
+        let mut palette_len = 0;
+        let image_data = unsafe {
+            ffi::LoadImagePalette(
+                self.0,
+                max_palette_size
+                    .try_into()
+                    .expect("max_palette_size should not exceed i32::MAX"),
+                &mut palette_len,
+            )
+        };
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(
+                image_data.cast(),
+                palette_len
+                    .try_into()
+                    .expect("palette_len should not be negative"),
+            )
+        };
+        ImagePalette(ManuallyDrop::new(unsafe { Box::from_raw(data) }))
     }
 
-    /// Converts `image` to POT (power-of-two).
+    /// Converts `self` to POT (power-of-two).
     #[inline]
     pub fn to_pot(&mut self, fill_color: impl Into<ffi::Color>) {
         unsafe {
@@ -342,15 +409,15 @@ impl Image {
         }
     }
 
-    /// Converts `image` data to desired pixel format.
+    /// Converts `self` data to desired pixel format.
     #[inline]
     pub fn set_format(&mut self, new_format: crate::consts::PixelFormat) {
         unsafe {
-            ffi::ImageFormat(&mut self.0, (new_format as u32) as i32);
+            ffi::ImageFormat(&mut self.0, new_format as i32);
         }
     }
 
-    /// Applies alpha mask to `image`.
+    /// Applies alpha mask to `self`.
     /// Alpha mask must be same size as the image. If alpha mask is not greyscale
     /// Ensure the colors are white (255, 255, 255, 255) or black (0, 0, 0, 0)
     #[inline]
@@ -360,7 +427,7 @@ impl Image {
         }
     }
 
-    /// Clears alpha channel on `image` to desired color.
+    /// Clears alpha channel on `self` to desired color.
     #[inline]
     pub fn alpha_clear(&mut self, color: impl Into<ffi::Color>, threshold: f32) {
         unsafe {
@@ -368,7 +435,7 @@ impl Image {
         }
     }
 
-    /// Crops `image` depending on alpha value.
+    /// Crops `self` depending on alpha value.
     #[inline]
     pub fn alpha_crop(&mut self, threshold: f32) {
         unsafe {
@@ -376,7 +443,7 @@ impl Image {
         }
     }
 
-    /// Premultiplies alpha channel on `image`.
+    /// Premultiplies alpha channel on `self`.
     #[inline]
     pub fn alpha_premultiply(&mut self) {
         unsafe {
@@ -384,7 +451,7 @@ impl Image {
         }
     }
 
-    /// Crops `image` to a defined rectangle.
+    /// Crops `self` to a defined rectangle.
     #[inline]
     pub fn crop(&mut self, crop: impl Into<ffi::Rectangle>) {
         unsafe {
@@ -392,7 +459,7 @@ impl Image {
         }
     }
 
-    /// Resizes `image` (bilinear filtering).
+    /// Resizes `self` (bilinear filtering).
     #[inline]
     pub fn resize(&mut self, new_width: i32, new_height: i32) {
         unsafe {
@@ -400,7 +467,7 @@ impl Image {
         }
     }
 
-    /// Resizes `image` (nearest-neighbor scaling).
+    /// Resizes `self` (nearest-neighbor scaling).
     #[inline]
     pub fn resize_nn(&mut self, new_width: i32, new_height: i32) {
         unsafe {
@@ -408,7 +475,7 @@ impl Image {
         }
     }
 
-    /// Resizes `image` canvas and fills with `color`.
+    /// Resizes `self` canvas and fills with `color`.
     #[inline]
     pub fn resize_canvas(
         &mut self,
@@ -430,7 +497,7 @@ impl Image {
         }
     }
 
-    /// Generates all mipmap levels for a provided `image`.
+    /// Generates all mipmap levels for a provided `self`.
     #[inline]
     pub fn gen_mipmaps(&mut self) {
         unsafe {
@@ -438,7 +505,7 @@ impl Image {
         }
     }
 
-    /// Dithers `image` data to 16bpp or lower (Floyd-Steinberg dithering).
+    /// Dithers `self` data to 16bpp or lower (Floyd-Steinberg dithering).
     #[inline]
     pub fn dither(&mut self, r_bpp: i32, g_bpp: i32, b_bpp: i32, a_bpp: i32) {
         unsafe {
@@ -448,8 +515,9 @@ impl Image {
 
     /// Get image alpha border rectangle
     #[inline]
+    #[must_use]
     pub fn get_image_alpha_border(&self, threshold: f32) -> Rectangle {
-        unsafe { ffi::GetImageAlphaBorder(self.0, threshold).into() }
+        unsafe { ffi::GetImageAlphaBorder(self.0, threshold) }
     }
 
     /// Clear image background with given color
@@ -468,13 +536,7 @@ impl Image {
         tint: impl Into<ffi::Color>,
     ) {
         unsafe {
-            ffi::ImageDraw(
-                &mut self.0,
-                src.0,
-                src_rec.into(),
-                dst_rec.into(),
-                tint.into(),
-            );
+            ffi::ImageDraw(&mut self.0, src.0, src_rec, dst_rec, tint.into());
         }
     }
 
@@ -508,7 +570,7 @@ impl Image {
                 end_pos_x,
                 end_pos_y,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -528,7 +590,7 @@ impl Image {
                 end_pos.into(),
                 thick,
                 color.into(),
-            )
+            );
         }
     }
 
@@ -553,7 +615,7 @@ impl Image {
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
-            ffi::ImageDrawTriangle(&mut self.0, v1.into(), v2.into(), v3.into(), color.into())
+            ffi::ImageDrawTriangle(&mut self.0, v1.into(), v2.into(), v3.into(), color.into());
         }
     }
 
@@ -577,7 +639,7 @@ impl Image {
                 c1.into(),
                 c2.into(),
                 c3.into(),
-            )
+            );
         }
     }
 
@@ -591,11 +653,15 @@ impl Image {
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
-            ffi::ImageDrawTriangleLines(&mut self.0, v1.into(), v2.into(), v3.into(), color.into())
+            ffi::ImageDrawTriangleLines(&mut self.0, v1.into(), v2.into(), v3.into(), color.into());
         }
     }
 
     /// Draw a triangle fan defined by points within an image (first vertex is the center)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `points` has a length greater than [`i32::MAX`].
     pub fn draw_triangle_fan(
         &mut self,
         points: &mut [crate::math::Vector2],
@@ -604,14 +670,21 @@ impl Image {
         unsafe {
             ffi::ImageDrawTriangleFan(
                 &mut self.0,
-                points.as_ptr() as *mut MintVec2,
-                points.len() as i32,
+                points.as_mut_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 color.into(),
-            )
+            );
         }
     }
 
     /// Draw a triangle strip defined by points within an image
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `points` has a length greater than [`i32::MAX`].
     pub fn draw_triangle_strip(
         &mut self,
         points: &mut [crate::math::Vector2],
@@ -620,10 +693,13 @@ impl Image {
         unsafe {
             ffi::ImageDrawTriangleStrip(
                 &mut self.0,
-                points.as_ptr() as *mut MintVec2,
-                points.len() as i32,
+                points.as_mut_ptr().cast(),
+                points
+                    .len()
+                    .try_into()
+                    .expect("points should not exceed i32::MAX elements"),
                 color.into(),
-            )
+            );
         }
     }
 
@@ -699,11 +775,15 @@ impl Image {
         color: impl Into<ffi::Color>,
     ) {
         unsafe {
-            ffi::ImageDrawRectangleLines(&mut self.0, rec.into(), thickness, color.into());
+            ffi::ImageDrawRectangleLines(&mut self.0, rec, thickness, color.into());
         }
     }
 
     /// Draws text (default font) within an image (destination).
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[inline]
     pub fn draw_text(
         &mut self,
@@ -713,7 +793,7 @@ impl Image {
         font_size: i32,
         color: impl Into<ffi::Color>,
     ) {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             ffi::ImageDrawText(
                 &mut self.0,
@@ -727,6 +807,10 @@ impl Image {
     }
 
     /// Draws text (default font) within an image (destination).
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[inline]
     pub fn draw_text_ex(
         &mut self,
@@ -737,7 +821,7 @@ impl Image {
         spacing: f32,
         color: impl Into<ffi::Color>,
     ) {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             ffi::ImageDrawTextEx(
                 &mut self.0,
@@ -751,7 +835,7 @@ impl Image {
         }
     }
 
-    /// Flips `image` vertically.
+    /// Flips `self` vertically.
     #[inline]
     pub fn flip_vertical(&mut self) {
         unsafe {
@@ -759,7 +843,7 @@ impl Image {
         }
     }
 
-    /// Flips `image` horizontally.
+    /// Flips `self` horizontally.
     #[inline]
     pub fn flip_horizontal(&mut self) {
         unsafe {
@@ -767,7 +851,7 @@ impl Image {
         }
     }
 
-    /// Rotates `image` clockwise by 90 degrees (PI/2 radians).
+    /// Rotates `self` clockwise by 90 degrees (PI/2 radians).
     #[inline]
     pub fn rotate_cw(&mut self) {
         unsafe {
@@ -775,7 +859,7 @@ impl Image {
         }
     }
 
-    /// Rotates `image` counterclockwise by 90 degrees (PI/2 radians).
+    /// Rotates `self` counterclockwise by 90 degrees (PI/2 radians).
     #[inline]
     pub fn rotate_ccw(&mut self) {
         unsafe {
@@ -783,7 +867,7 @@ impl Image {
         }
     }
 
-    /// Tints colors in `image` using specified `color`.
+    /// Tints colors in `self` using specified `color`.
     #[inline]
     pub fn color_tint(&mut self, color: impl Into<ffi::Color>) {
         unsafe {
@@ -791,7 +875,7 @@ impl Image {
         }
     }
 
-    /// Inverts the colors in `image`.
+    /// Inverts the colors in `self`.
     #[inline]
     pub fn color_invert(&mut self) {
         unsafe {
@@ -799,7 +883,7 @@ impl Image {
         }
     }
 
-    /// Converts `image color to grayscale.
+    /// Converts `self` color to grayscale.
     #[inline]
     pub fn color_grayscale(&mut self) {
         unsafe {
@@ -807,7 +891,7 @@ impl Image {
         }
     }
 
-    /// Adjusts the contrast of `image`.
+    /// Adjusts the contrast of `self`.
     #[inline]
     pub fn color_contrast(&mut self, contrast: f32) {
         unsafe {
@@ -815,7 +899,7 @@ impl Image {
         }
     }
 
-    /// Adjusts the brightness of `image`.
+    /// Adjusts the brightness of `self`.
     #[inline]
     pub fn color_brightness(&mut self, brightness: i32) {
         unsafe {
@@ -823,7 +907,7 @@ impl Image {
         }
     }
 
-    /// Searches `image` for all occurrences of `color` and replaces them with `replace` color.
+    /// Searches `self` for all occurrences of `color` and replaces them with `replace` color.
     #[inline]
     pub fn color_replace(&mut self, color: impl Into<ffi::Color>, replace: impl Into<ffi::Color>) {
         unsafe {
@@ -832,7 +916,15 @@ impl Image {
     }
 
     /// Export image to memory buffer.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// See [`InvalidImageError`]
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `file_type` contains an internal 0 byte or if [`ffi::ExportImageToMemory`]
+    /// outputs a negative `fileSize`.
     pub fn export_image_to_memory(&self, file_type: &str) -> Result<&[u8], InvalidImageError> {
         if self.width == 0 {
             return Err(InvalidImageError::ZeroWidth);
@@ -840,25 +932,42 @@ impl Image {
         if self.height == 0 {
             return Err(InvalidImageError::ZeroHeight);
         }
-        if self.data == null_mut() {
+        if self.data.is_null() {
             return Err(InvalidImageError::NullData);
         }
 
-        let c_filetype = CString::new(file_type).unwrap();
-        let data_size: &mut i32 = &mut 0;
-        let data = unsafe { ffi::ExportImageToMemory(self.0, c_filetype.as_ptr(), data_size) };
+        let c_filetype =
+            CString::new(file_type).expect("file_type should not contain an internal 0 byte");
+        let mut data_size = 0;
+        let data =
+            unsafe { ffi::ExportImageToMemory(self.0, c_filetype.as_ptr(), &raw mut data_size) };
 
         // The actual function returns null if the code for converting to a file type never goes off.
-        if data == null_mut() {
+        if data.is_null() {
             return Err(InvalidImageError::UnsupportedFormat);
         }
 
-        Ok(unsafe { std::slice::from_raw_parts(data as *const u8, *data_size as usize) })
+        Ok(unsafe {
+            std::slice::from_raw_parts(
+                data.cast_const(),
+                data_size
+                    .try_into()
+                    .expect("data_size should not be negative"),
+            )
+        })
     }
 
     /// Apply custom square convolution kernel to image
+    ///
     /// NOTE: The convolution kernel matrix is expected to be square
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// See [`InvalidImageError`]
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `kernel` has a length greater than [`i32::MAX`]
     pub fn kernel_convolution(&mut self, kernel: &[f32]) -> Result<(), InvalidImageError> {
         if self.width == 0 {
             return Err(InvalidImageError::ZeroWidth);
@@ -866,17 +975,26 @@ impl Image {
         if self.height == 0 {
             return Err(InvalidImageError::ZeroHeight);
         }
-        if self.data == null_mut() {
+        if self.data.is_null() {
             return Err(InvalidImageError::NullData);
         }
 
-        let kernel_width = (kernel.len() as f32).sqrt() as i32;
+        let kernel_width = kernel.len().isqrt();
 
-        if (kernel_width * kernel_width) as usize != kernel.len() {
+        if (kernel_width * kernel_width) != kernel.len() {
             return Err(InvalidImageError::NonSquareKernel);
         }
 
-        unsafe { ffi::ImageKernelConvolution(&mut self.0, kernel.as_ptr(), kernel.len() as i32) }
+        unsafe {
+            ffi::ImageKernelConvolution(
+                &mut self.0,
+                kernel.as_ptr(),
+                kernel
+                    .len()
+                    .try_into()
+                    .expect("kernel should not exceed i32::MAX elements"),
+            );
+        }
 
         Ok(())
     }
@@ -888,6 +1006,8 @@ impl Image {
         unsafe { Image(ffi::GenImageColor(width, height, color.into())) }
     }
     /// Generate image: perlin noise
+    #[inline]
+    #[must_use]
     pub fn gen_image_perlin_noise(
         &self,
         width: i32,
@@ -956,18 +1076,14 @@ impl Image {
     ) -> Image {
         unsafe {
             Image(ffi::GenImageGradientLinear(
-                width,
-                height,
-                direction,
-                start.into(),
-                end.into(),
+                width, height, direction, start, end,
             ))
         }
     }
+    /// Generate images an image with a square gradient
+    /// For best results, `density` should be `0.0..=1.0`
     #[must_use]
     #[inline]
-    /// Generate images an image with a square gradient
-    /// For best results, `density` should be `0.0..1.0``
     pub fn gen_image_gradient_square(
         width: i32,
         height: i32,
@@ -977,19 +1093,19 @@ impl Image {
     ) -> Image {
         unsafe {
             Image(ffi::GenImageGradientSquare(
-                width,
-                height,
-                density,
-                start.into(),
-                end.into(),
+                width, height, density, start, end,
             ))
         }
     }
 
-    // Generates an image with text
+    /// Generates an image with text
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[must_use]
     pub fn gen_image_text(width: i32, height: i32, text: &str) -> Image {
-        let c_str = CString::new(text).unwrap();
+        let c_str = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { Image(ffi::GenImageText(width, height, c_str.as_ptr())) }
     }
 
@@ -1009,21 +1125,37 @@ impl Image {
 
     /// Get clipboard image.
     ///
-    /// NOTE: Only available on Windows. Do not use if you plan to compile to other platforms.
-    #[cfg(target_os = "windows")]
-    #[must_use]
+    /// NOTE: Only available on Windows.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`InvalidImageError::NullData`] if [`ffi::GetClipboardImage()`] returns
+    /// an image whose `data` is null, or if the platform is not Windows.
     pub fn get_clipboard_image(&mut self) -> Result<Image, InvalidImageError> {
-        let i = unsafe { ffi::GetClipboardImage() };
-        if i.data.is_null() {
-            return Err(InvalidImageError::NullData);
+        if cfg!(target_os = "windows") {
+            let i = unsafe { ffi::GetClipboardImage() };
+            if i.data.is_null() {
+                return Err(InvalidImageError::NullData);
+            }
+            Ok(Image(i))
+        } else {
+            Err(InvalidImageError::NullData)
         }
-        Ok(Image(i))
     }
 
     /// Loads image from file into CPU memory (RAM).
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`InvalidImageError::NullDataFromFile`] if [`ffi::LoadImage`] returns
+    /// an image whose `data` is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     pub fn load_image(filename: &str) -> Result<Image, InvalidImageError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let i = unsafe { ffi::LoadImage(c_filename.as_ptr()) };
         if i.data.is_null() {
             return Err(InvalidImageError::NullDataFromFile);
@@ -1032,51 +1164,90 @@ impl Image {
     }
 
     /// Loads image from a given memory buffer
+    ///
     /// The input data is expected to be in a supported file format such as png. Which formats are
     /// supported depend on the build flags used for the raylib (C) library.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`InvalidImageError::InvalidFile`] if `bytes` is empty, or
+    /// [`InvalidImageError::NullDataFromMemory`] if [`ffi::LoadImageFromMemory`] returns an image
+    /// whose `data` is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filetype` contains an internal 0 byte, or if `bytes` has a length
+    /// greater than [`i32::MAX`].
     pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, InvalidImageError> {
-        let c_filetype = CString::new(filetype).unwrap();
-        let data_size = bytes.len().try_into().unwrap();
+        let c_filetype =
+            CString::new(filetype).expect("filetype should not contain an internal 0 byte");
+        let data_size = bytes
+            .len()
+            .try_into()
+            .expect("bytes should not exceed i32::MAX elements");
         if data_size == 0 {
             return Err(InvalidImageError::InvalidFile);
         }
         let i = unsafe { ffi::LoadImageFromMemory(c_filetype.as_ptr(), bytes.as_ptr(), data_size) };
         if i.data.is_null() {
-            return Err(InvalidImageError::NullDataFromMemory);
-        };
-        Ok(Image(i))
+            Err(InvalidImageError::NullDataFromMemory)
+        } else {
+            Ok(Image(i))
+        }
     }
 
-    /// Load image sequence from file, with the number of frames loaded saved to frame_num.
-    /// Image.data buffer includes all frames.
+    /// Load image sequence from file, with the number of frames loaded saved to `frame_num`.
+    ///
+    /// `Image.data` buffer includes all frames.
     /// All frames returned are in RGBA format.
     /// Frames delay data is discarded
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[must_use]
     pub fn load_image_anim(filename: &str, frame_num: &mut i32) -> Self {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
 
         unsafe { Image(ffi::LoadImageAnim(c_filename.as_ptr(), frame_num)) }
     }
 
-    /// Load image from memory buffer, with the number of frames loaded saved to frame_num.
-    /// fileType refers to extension: i.e. ".png". File extension must be provided in lower-case
+    /// Load image from memory buffer, with the number of frames loaded saved to `frame_num`.
+    ///
+    /// `fileType` refers to extension: i.e. ".png". File extension must be provided in lower-case
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte, or if `data` has a length
+    /// greater than [`i32::MAX`].
     #[must_use]
     pub fn load_image_anim_from_memory(filetype: &str, data: &[u8], frame_num: &mut i32) -> Self {
-        let c_filetype = CString::new(filetype).unwrap();
+        let c_filetype =
+            CString::new(filetype).expect("filename should not contain an internal 0 byte");
 
         unsafe {
             Image(ffi::LoadImageAnimFromMemory(
                 c_filetype.as_ptr(),
                 data.as_ptr(),
-                data.len() as i32,
+                data.len()
+                    .try_into()
+                    .expect("data should not exceed i32::MAX elements"),
                 frame_num,
             ))
         }
     }
 
     /// Loads image from RAW file data.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`InvalidImageError::NullDataFromFile`] if [`ffi::LoadImageRaw`] returns
+    /// an image whose `data` is null.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     pub fn load_image_raw(
         filename: &str,
         width: i32,
@@ -1084,7 +1255,8 @@ impl Image {
         format: i32,
         header_size: i32,
     ) -> Result<Image, InvalidImageError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let i =
             unsafe { ffi::LoadImageRaw(c_filename.as_ptr(), width, height, format, header_size) };
         if i.data.is_null() {
@@ -1094,14 +1266,22 @@ impl Image {
     }
 
     /// Creates an image from `text` (custom font).
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[inline]
     #[must_use]
     pub fn image_text(text: &str, font_size: i32, color: impl Into<ffi::Color>) -> Image {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { Image(ffi::ImageText(c_text.as_ptr(), font_size, color.into())) }
     }
 
     /// Creates an image from `text` (custom font).
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `text` contains an internal 0 byte.
     #[inline]
     #[must_use]
     pub fn image_text_ex(
@@ -1111,7 +1291,7 @@ impl Image {
         spacing: f32,
         tint: impl Into<ffi::Color>,
     ) -> Image {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             Image(ffi::ImageTextEx(
                 *font.as_ref(),
@@ -1137,52 +1317,83 @@ impl RaylibTexture2D for WeakRenderTexture2D {}
 impl RaylibTexture2D for RenderTexture2D {}
 
 impl Texture2D {
-    pub unsafe fn make_weak(self) -> WeakTexture2D {
+    /// Convert `self` to its weak form, allowing it to be shared by multiple containers on the condition
+    /// that it is only unloaded once, manually.
+    ///
+    /// # Safety
+    ///
+    /// Must manually free memory by calling the proper unload function.
+    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// and copies must not be used after being unloaded to avoid use-after-free.
+    #[must_use]
+    #[inline]
+    pub const unsafe fn make_weak(self) -> WeakTexture2D {
         let m = WeakTexture2D(self.0);
         std::mem::forget(self);
         m
     }
 }
 
-pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
+/// [`Texture2D`] accessors and helper methods.
+pub trait RaylibTexture2D {
     /// Texture base width
     #[inline]
     #[must_use]
-    fn width(&self) -> i32 {
+    fn width(&self) -> i32
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         self.as_ref().width
     }
 
     /// Texture base height
     #[inline]
     #[must_use]
-    fn height(&self) -> i32 {
+    fn height(&self) -> i32
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         self.as_ref().height
     }
 
     /// Mipmap levels, 1 by default
     #[inline]
     #[must_use]
-    fn mipmaps(&self) -> i32 {
-        self.as_ref().width
+    fn mipmaps(&self) -> i32
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
+        self.as_ref().mipmaps
     }
 
-    /// Data format (PixelFormat type)
+    /// Data format ([`PixelFormat`] type)
     #[inline]
     #[must_use]
-    fn format(&self) -> i32 {
+    fn format(&self) -> i32
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         self.as_ref().format
     }
 
     /// Updates GPU texture with new data.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`UpdateTextureError::WrongDataSize`] if the incorrect number
+    /// of bytes are provided to update the full texture.
     #[inline]
-    fn update_texture(&mut self, pixels: &[u8]) -> Result<(), UpdateTextureError> {
-        let expected_len = unsafe {
-            get_pixel_data_size(
-                self.as_ref().width,
-                self.as_ref().height,
-                std::mem::transmute::<i32, ffi::PixelFormat>(self.as_ref().format),
-            ) as usize
-        };
+    fn update_texture(&mut self, pixels: &[u8]) -> Result<(), UpdateTextureError>
+    where
+        Self: AsMut<ffi::Texture2D>,
+    {
+        let expected_len = get_pixel_data_size(
+            self.as_mut().width,
+            self.as_mut().height,
+            pixelformat_from_i32(self.as_mut().format).expect("unknown format"),
+        )
+        .try_into()
+        .expect("get_pixel_data_size should not return a negative");
         if pixels.len() != expected_len {
             return Err(UpdateTextureError::WrongDataSize {
                 expect: expected_len,
@@ -1190,27 +1401,40 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
             });
         }
         unsafe {
-            ffi::UpdateTexture(
-                *self.as_mut(),
-                pixels.as_ptr() as *const std::os::raw::c_void,
-            );
+            ffi::UpdateTexture(*self.as_mut(), pixels.as_ptr().cast());
         }
 
         Ok(())
     }
 
     /// Update GPU texture rectangle with new data
+    ///
+    /// # Errors
+    ///
+    /// See [`UpdateTextureError`]
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if [`get_pixel_data_size`] returns a negative value.
     fn update_texture_rec(
         &mut self,
         rec: impl Into<ffi::Rectangle>,
         pixels: &[u8],
-    ) -> Result<(), UpdateTextureError> {
-        let rec = rec.into();
+    ) -> Result<(), UpdateTextureError>
+    where
+        Self: AsMut<ffi::Texture2D>,
+    {
+        #![allow(
+            clippy::cast_possible_truncation,
+            reason = "truncation is intentional here"
+        )]
+
+        let rec: ffi::Rectangle = rec.into();
 
         if (rec.x < 0.0)
             || (rec.y < 0.0)
-            || ((rec.x as i32 + rec.width as i32) > (self.as_ref().width))
-            || ((rec.y as i32 + rec.height as i32) > (self.as_ref().height))
+            || ((rec.x as i32 + rec.width as i32) > (self.as_mut().width))
+            || ((rec.y as i32 + rec.height as i32) > (self.as_mut().height))
         {
             return Err(UpdateTextureError::OutOfBounds);
         }
@@ -1218,13 +1442,13 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
             return Err(UpdateTextureError::NegativeSize);
         }
 
-        let expected_len = unsafe {
-            get_pixel_data_size(
-                rec.width as i32,
-                rec.height as i32,
-                std::mem::transmute::<i32, ffi::PixelFormat>(self.as_ref().format),
-            ) as usize
-        };
+        let expected_len = get_pixel_data_size(
+            rec.width as i32,
+            rec.height as i32,
+            pixelformat_from_i32(self.as_mut().format).expect("unknown format"),
+        )
+        .try_into()
+        .expect("pixel data should not be negative");
         if pixels.len() != expected_len {
             return Err(UpdateTextureError::WrongDataSize {
                 expect: expected_len,
@@ -1232,21 +1456,23 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
             });
         }
         unsafe {
-            ffi::UpdateTextureRec(
-                *self.as_ref(),
-                rec,
-                pixels.as_ptr() as *const std::os::raw::c_void,
-            )
+            ffi::UpdateTextureRec(*self.as_mut(), rec, pixels.as_ptr().cast());
         }
 
         Ok(())
     }
 
     /// Gets pixel data from GPU texture and returns an `Image`.
-    /// Fairly sure this would never fail. If it does wrap in result.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`InvalidImageError::NullDataFromTexture`] if [`ffi::LoadImageFromTexture`]
+    /// returns an image whose `data` is null.
     #[inline]
-    #[must_use]
-    fn load_image(&self) -> Result<Image, InvalidImageError> {
+    fn load_image(&self) -> Result<Image, InvalidImageError>
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         let i = unsafe { ffi::LoadImageFromTexture(*self.as_ref()) };
         if i.data.is_null() {
             return Err(InvalidImageError::NullDataFromTexture);
@@ -1256,7 +1482,10 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
 
     /// Generates GPU mipmaps for a `texture`.
     #[inline]
-    fn gen_texture_mipmaps(&mut self) {
+    fn gen_texture_mipmaps(&mut self)
+    where
+        Self: AsMut<ffi::Texture2D>,
+    {
         unsafe {
             ffi::GenTextureMipmaps(self.as_mut());
         }
@@ -1264,7 +1493,10 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
 
     /// Sets global `texture` scaling filter mode.
     #[inline]
-    fn set_texture_filter(&self, _: &RaylibThread, filter_mode: crate::consts::TextureFilter) {
+    fn set_texture_filter(&self, _: &RaylibThread, filter_mode: crate::consts::TextureFilter)
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         unsafe {
             ffi::SetTextureFilter(*self.as_ref(), filter_mode as i32);
         }
@@ -1272,7 +1504,10 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
 
     /// Sets global texture wrapping mode.
     #[inline]
-    fn set_texture_wrap(&self, _: &RaylibThread, wrap_mode: crate::consts::TextureWrap) {
+    fn set_texture_wrap(&self, _: &RaylibThread, wrap_mode: crate::consts::TextureWrap)
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         unsafe {
             ffi::SetTextureWrap(*self.as_ref(), wrap_mode as i32);
         }
@@ -1280,26 +1515,39 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
 
     /// Check if a texture is valid (loaded in GPU)
     #[inline]
-    fn is_texture_valid(&self) -> bool {
+    fn is_texture_valid(&self) -> bool
+    where
+        Self: AsRef<ffi::Texture2D>,
+    {
         unsafe { ffi::IsTextureValid(*self.as_ref()) }
     }
 }
 
 /// Gets pixel data size in bytes (image or texture).
 #[inline]
+#[must_use]
 pub fn get_pixel_data_size(width: i32, height: i32, format: ffi::PixelFormat) -> i32 {
     unsafe { ffi::GetPixelDataSize(width, height, format as i32) }
 }
 
 impl RaylibHandle {
     /// Loads texture from file into GPU memory (VRAM).
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadTextureError::TextureFromFileFailed`] if [`ffi::LoadTexture`]
+    /// fails to load a texture.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     pub fn load_texture(
         &mut self,
         _: &RaylibThread,
         filename: &str,
     ) -> Result<Texture2D, LoadTextureError> {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         let t = unsafe { ffi::LoadTexture(c_filename.as_ptr()) };
         if t.id == 0 {
             return Err(LoadTextureError::TextureFromFileFailed {
@@ -1310,7 +1558,11 @@ impl RaylibHandle {
     }
 
     /// Load cubemap from image, multiple image cubemap layouts supported
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadTextureError::CubemapFromImageFailed`] if
+    /// [`ffi::LoadTextureCubemap`] fails to load a cubemap.
     pub fn load_texture_cubemap(
         &mut self,
         _: &RaylibThread,
@@ -1325,8 +1577,13 @@ impl RaylibHandle {
     }
 
     /// Loads texture from image data.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadTextureError::InvalidData`] if `image.width` or `image.height` is 0,
+    /// or [`LoadTextureError::TextureFromImageFailed`] if [`ffi::LoadTextureFromImage`] fails to load
+    /// a texture.
     #[inline]
-    #[must_use]
     pub fn load_texture_from_image(
         &mut self,
         _: &RaylibThread,
@@ -1343,14 +1600,29 @@ impl RaylibHandle {
     }
 
     /// Loads texture for rendering (framebuffer).
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`LoadTextureError::CreateRenderTextureFailed`] if
+    /// [`ffi::LoadRenderTexture`] fails to load a render texture.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `width` or `height` is greater than [`i32::MAX`].
     pub fn load_render_texture(
         &mut self,
         _: &RaylibThread,
         width: u32,
         height: u32,
     ) -> Result<RenderTexture2D, LoadTextureError> {
-        let t = unsafe { ffi::LoadRenderTexture(width as i32, height as i32) };
+        let t = unsafe {
+            ffi::LoadRenderTexture(
+                width.try_into().expect("width should not exceed i32::MAX"),
+                height
+                    .try_into()
+                    .expect("height should not exceed i32::MAX"),
+            )
+        };
         if t.id == 0 {
             return Err(LoadTextureError::CreateRenderTextureFailed);
         }
@@ -1359,16 +1631,66 @@ impl RaylibHandle {
 }
 
 impl RaylibHandle {
-    /// Weak Textures will leak memory if they are not unloaded
     /// Unload textures from GPU memory (VRAM)
+    ///
+    /// Weak `Textures` will leak memory if they are not unloaded
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `texture`.
+    /// The caller must ensure that `texture` has not yet been unloaded, and that no copies
+    /// of `texture` are accessed or unloaded after this method returns.
     #[inline]
     pub unsafe fn unload_texture(&mut self, _: &RaylibThread, texture: WeakTexture2D) {
-        unsafe { ffi::UnloadTexture(*texture.as_ref()) }
+        unsafe { ffi::UnloadTexture(texture.to_raw()) }
     }
-    /// Weak RenderTextures will leak memory if they are not unloaded
-    /// Unload RenderTextures from GPU memory (VRAM)
+    /// Unload `RenderTextures` from GPU memory (VRAM)
+    ///
+    /// Weak `RenderTextures` will leak memory if they are not unloaded
+    ///
+    /// # Safety
+    ///
+    /// This method frees the resource associated with `texture`.
+    /// The caller must ensure that `texture` has not yet been unloaded, and that no copies
+    /// of `texture` are accessed or unloaded after this method returns.
     #[inline]
     pub unsafe fn unload_render_texture(&mut self, _: &RaylibThread, texture: WeakRenderTexture2D) {
-        unsafe { ffi::UnloadRenderTexture(*texture.as_ref()) }
+        unsafe { ffi::UnloadRenderTexture(texture.to_raw()) }
+    }
+}
+
+/// Safely convert [`i32`] to [`ffi::PixelFormat`].
+///
+/// Returns [`None`] if `format` is not a valid discriminant of [`ffi::PixelFormat`].
+#[must_use]
+pub const fn pixelformat_from_i32(format: i32) -> Option<ffi::PixelFormat> {
+    #[allow(clippy::enum_glob_use, reason = "variants are prefixed")]
+    use ffi::PixelFormat::*;
+    match format {
+        1 => Some(PIXELFORMAT_UNCOMPRESSED_GRAYSCALE),
+        2 => Some(PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA),
+        3 => Some(PIXELFORMAT_UNCOMPRESSED_R5G6B5),
+        4 => Some(PIXELFORMAT_UNCOMPRESSED_R8G8B8),
+        5 => Some(PIXELFORMAT_UNCOMPRESSED_R5G5B5A1),
+        6 => Some(PIXELFORMAT_UNCOMPRESSED_R4G4B4A4),
+        7 => Some(PIXELFORMAT_UNCOMPRESSED_R8G8B8A8),
+        8 => Some(PIXELFORMAT_UNCOMPRESSED_R32),
+        9 => Some(PIXELFORMAT_UNCOMPRESSED_R32G32B32),
+        10 => Some(PIXELFORMAT_UNCOMPRESSED_R32G32B32A32),
+        11 => Some(PIXELFORMAT_UNCOMPRESSED_R16),
+        12 => Some(PIXELFORMAT_UNCOMPRESSED_R16G16B16),
+        13 => Some(PIXELFORMAT_UNCOMPRESSED_R16G16B16A16),
+        14 => Some(PIXELFORMAT_COMPRESSED_DXT1_RGB),
+        15 => Some(PIXELFORMAT_COMPRESSED_DXT1_RGBA),
+        16 => Some(PIXELFORMAT_COMPRESSED_DXT3_RGBA),
+        17 => Some(PIXELFORMAT_COMPRESSED_DXT5_RGBA),
+        18 => Some(PIXELFORMAT_COMPRESSED_ETC1_RGB),
+        19 => Some(PIXELFORMAT_COMPRESSED_ETC2_RGB),
+        20 => Some(PIXELFORMAT_COMPRESSED_ETC2_EAC_RGBA),
+        21 => Some(PIXELFORMAT_COMPRESSED_PVRT_RGB),
+        22 => Some(PIXELFORMAT_COMPRESSED_PVRT_RGBA),
+        23 => Some(PIXELFORMAT_COMPRESSED_ASTC_4x4_RGBA),
+        24 => Some(PIXELFORMAT_COMPRESSED_ASTC_8x8_RGBA),
+        _ => None,
     }
 }

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -134,7 +134,7 @@ impl RenderTexture2D {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
     #[inline]
     #[must_use]
@@ -201,24 +201,28 @@ impl Image {
     pub const fn width(&self) -> i32 {
         self.0.width
     }
+
     /// Image base height
     #[inline]
     #[must_use]
     pub const fn height(&self) -> i32 {
         self.0.height
     }
+
     /// Mipmap levels, 1 by default
     #[inline]
     #[must_use]
     pub const fn mipmaps(&self) -> i32 {
         self.0.mipmaps
     }
+
     /// Image raw data
     #[inline]
     #[must_use]
     pub const fn data(&self) -> *const ::std::os::raw::c_void {
         self.0.data
     }
+
     /// Image raw data
     #[inline]
     #[must_use]
@@ -231,22 +235,26 @@ impl Image {
     pub fn blur_gaussian(&mut self, blur_size: i32) {
         unsafe { ffi::ImageBlurGaussian(&mut self.0, blur_size) }
     }
+
     /// Rotate image by input angle in degrees (-359 to 359)
     #[inline]
     pub fn rotate(&mut self, degrees: i32) {
         unsafe { ffi::ImageRotate(&mut self.0, degrees) }
     }
+
     /// Get image pixel color at (x, y) position
     #[inline]
     #[must_use]
     pub fn get_color(&self, x: i32, y: i32) -> Color {
         unsafe { ffi::GetImageColor(self.0, x, y) }
     }
+
     /// Draw circle outline within an image
     #[inline]
     pub fn draw_circle_lines(&mut self, center_x: i32, center_y: i32, radius: i32, color: Color) {
         unsafe { ffi::ImageDrawCircleLines(&mut self.0, center_x, center_y, radius, color) }
     }
+
     /// Draw circle outline within an image (Vector version)
     #[inline]
     pub fn draw_circle_lines_v(
@@ -266,8 +274,8 @@ impl Image {
     }
 
     /// Create an image from another image piece
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn from_image(&self, rec: impl Into<ffi::Rectangle>) -> Image {
         unsafe { Image(ffi::ImageFromImage(self.0, rec.into())) }
     }
@@ -278,6 +286,7 @@ impl Image {
     pub fn from_channel(&self, selected_channel: i32) -> Image {
         unsafe { Image(ffi::ImageFromChannel(self.0, selected_channel)) }
     }
+
     /// Exports image as a PNG file.
     ///
     /// # Panics
@@ -371,6 +380,7 @@ impl Image {
         }
         res
     }
+
     /// Extract color palette from image to maximum size
     ///
     /// # Panics
@@ -1005,6 +1015,7 @@ impl Image {
     pub fn gen_image_color(width: i32, height: i32, color: impl Into<ffi::Color>) -> Image {
         unsafe { Image(ffi::GenImageColor(width, height, color.into())) }
     }
+
     /// Generate image: perlin noise
     #[inline]
     #[must_use]
@@ -1065,8 +1076,8 @@ impl Image {
 
     /// Generate images an image linear gradient.
     /// `direction` in expected to be degrees [0..360]. 0 results in a vertical gradient
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn gen_image_gradient_linear(
         width: i32,
         height: i32,
@@ -1080,10 +1091,11 @@ impl Image {
             ))
         }
     }
+
     /// Generate images an image with a square gradient
     /// For best results, `density` should be `0.0..=1.0`
-    #[must_use]
     #[inline]
+    #[must_use]
     pub fn gen_image_gradient_square(
         width: i32,
         height: i32,
@@ -1323,10 +1335,10 @@ impl Texture2D {
     /// # Safety
     ///
     /// Must manually free memory by calling the proper unload function.
-    /// Even if `self` implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
+    /// Even if the return implements [`Copy`], exactly one instance should be unloaded to avoid double-free,
     /// and copies must not be used after being unloaded to avoid use-after-free.
-    #[must_use]
     #[inline]
+    #[must_use]
     pub const unsafe fn make_weak(self) -> WeakTexture2D {
         let m = WeakTexture2D(self.0);
         std::mem::forget(self);
@@ -1644,6 +1656,7 @@ impl RaylibHandle {
     pub unsafe fn unload_texture(&mut self, _: &RaylibThread, texture: WeakTexture2D) {
         unsafe { ffi::UnloadTexture(texture.to_raw()) }
     }
+
     /// Unload `RenderTextures` from GPU memory (VRAM)
     ///
     /// Weak `RenderTextures` will leak memory if they are not unloaded

--- a/raylib/src/core/vr.rs
+++ b/raylib/src/core/vr.rs
@@ -3,13 +3,13 @@ use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 
 make_thin_wrapper!(
-    /// VrStereoConfig, VR stereo rendering configuration for simulator
+    /// [`VrStereoConfig`], VR stereo rendering configuration for simulator
     VrStereoConfig,
     ffi::VrStereoConfig,
     ffi::UnloadVrStereoConfig
 );
 
-/// VrDeviceInfo, Head-Mounted-Display device parameters
+/// [`VrDeviceInfo`], Head-Mounted-Display device parameters
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VrDeviceInfo {
@@ -39,25 +39,15 @@ impl From<ffi::VrDeviceInfo> for VrDeviceInfo {
     }
 }
 
-impl Into<ffi::VrDeviceInfo> for VrDeviceInfo {
-    fn into(self) -> ffi::VrDeviceInfo {
-        unsafe { std::mem::transmute(self) }
+impl From<VrDeviceInfo> for ffi::VrDeviceInfo {
+    fn from(v: VrDeviceInfo) -> Self {
+        unsafe { std::mem::transmute(v) }
     }
 }
 
-impl Into<ffi::VrDeviceInfo> for &VrDeviceInfo {
-    fn into(self) -> ffi::VrDeviceInfo {
-        ffi::VrDeviceInfo {
-            hResolution: self.h_resolution,  // Horizontal resolution in pixels
-            vResolution: self.v_resolution,   // Vertical resolution in pixels
-            hScreenSize: self.h_screen_size, // Horizontal size in meters
-            vScreenSize: self.v_screen_size, // Vertical size in meters
-            eyeToScreenDistance: self.eye_to_screen_distance, // Distance between eye and display in meters
-            lensSeparationDistance: self.lens_separation_distance, // Lens separation distance in meters
-            interpupillaryDistance: self.interpupillary_distance, // IPD (distance between pupils) in meters
-            lensDistortionValues: self.lens_distortion_values, // Lens distortion constant parameters
-            chromaAbCorrection: self.chroma_ab_correction, // Chromatic aberration correction parameters
-        }
+impl From<&VrDeviceInfo> for ffi::VrDeviceInfo {
+    fn from(v: &VrDeviceInfo) -> Self {
+        unsafe { std::mem::transmute(*v) }
     }
 }
 

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -2,249 +2,270 @@
 use crate::core::math::{Matrix, Ray, Vector2};
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::{MintVec2, MintVec3, ffi};
-use std::ffi::{CStr, CString, IntoStringError, NulError};
-use std::os::raw::c_char;
+use std::ffi::{CStr, CString, NulError};
+use std::str::Utf8Error;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// MonitorInfo grabs the sizes (virtual and physical) of your monitor
+/// [`MonitorInfo`] grabs the sizes (virtual and physical) of your monitor
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MonitorInfo {
+    /// The virtual width of the monitor
     pub width: i32,
+    /// The virtual height of the monitor
     pub height: i32,
+    /// The physical width of the monitor
     pub physical_width: i32,
+    /// The physical height of the monitor
     pub physical_height: i32,
+    /// The name of the monitor
     pub name: String,
+    /// The position of the monitor
     pub position: Vector2,
 }
 
+/// Bitflags describing the configuration of the window.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct WindowState(i32);
+pub struct WindowState(u32);
 
 impl WindowState {
     /// Whether to try enabling V-Sync on GPU
+    #[must_use]
     pub const fn vsync_hint(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_VSYNC_HINT as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_VSYNC_HINT as u32) != 0
     }
     /// Set to try enabling V-Sync on GPU
-    pub const fn set_vsync_hint(mut self, enabled: bool) -> Self {
+    pub const fn set_vsync_hint(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_VSYNC_HINT as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_VSYNC_HINT as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_VSYNC_HINT as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_VSYNC_HINT as u32);
         }
         self
     }
 
     /// Whether to run program in fullscreen
+    #[must_use]
     pub const fn fullscreen_mode(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32) != 0
     }
     /// Set to run program in fullscreen
-    pub const fn set_fullscreen_mode(mut self, enabled: bool) -> Self {
+    pub const fn set_fullscreen_mode(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32);
         }
         self
     }
 
     /// Whether to allow resizable window
+    #[must_use]
     pub const fn window_resizable(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32) != 0
     }
     /// Set to allow resizable window
-    pub const fn set_window_resizable(mut self, enabled: bool) -> Self {
+    pub const fn set_window_resizable(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32);
         }
         self
     }
 
     /// Whether to disable window decoration (frame and buttons)
+    #[must_use]
     pub const fn window_undecorated(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32) != 0
     }
     /// Set to disable window decoration (frame and buttons)
-    pub const fn set_window_undecorated(mut self, enabled: bool) -> Self {
+    pub const fn set_window_undecorated(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32);
         }
         self
     }
 
     /// Whether to hide window
+    #[must_use]
     pub const fn window_hidden(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32) != 0
     }
     /// Set to hide window
-    pub const fn set_window_hidden(mut self, enabled: bool) -> Self {
+    pub const fn set_window_hidden(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32);
         }
         self
     }
 
     /// Whether to minimize window (iconify)
+    #[must_use]
     pub const fn window_minimized(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32) != 0
     }
     /// Set to minimize window (iconify)
-    pub const fn set_window_minimized(mut self, enabled: bool) -> Self {
+    pub const fn set_window_minimized(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32);
         }
         self
     }
 
     /// Whether to maximize window (expanded to monitor)
+    #[must_use]
     pub const fn window_maximized(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32) != 0
     }
     /// Set to maximize window (expanded to monitor)
-    pub const fn set_window_maximized(mut self, enabled: bool) -> Self {
+    pub const fn set_window_maximized(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32);
         }
         self
     }
 
     /// Whether to window non focused
+    #[must_use]
     pub const fn window_unfocused(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32) != 0
     }
     /// Set to window non focused
-    pub const fn set_window_unfocused(mut self, enabled: bool) -> Self {
+    pub const fn set_window_unfocused(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32);
         }
         self
     }
 
     /// Whether to window always on top
+    #[must_use]
     pub const fn window_topmost(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32) != 0
     }
     /// Set to window always on top
-    pub const fn set_window_topmost(mut self, enabled: bool) -> Self {
+    pub const fn set_window_topmost(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32);
         }
         self
     }
 
     /// Whether to allow windows running while minimized
+    #[must_use]
     pub const fn window_always_run(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32) != 0
     }
     /// Set to allow windows running while minimized
-    pub const fn set_window_always_run(mut self, enabled: bool) -> Self {
+    pub const fn set_window_always_run(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32);
         }
         self
     }
 
     /// Whether to allow transparent framebuffer
+    #[must_use]
     pub const fn window_transparent(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32) != 0
     }
     /// Set to allow transparent framebuffer
-    pub const fn set_window_transparent(mut self, enabled: bool) -> Self {
+    pub const fn set_window_transparent(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32);
         }
         self
     }
 
-    /// Whether to support HighDPI
+    /// Whether to support high DPI
+    #[must_use]
     pub const fn window_highdpi(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32) != 0
     }
-    /// Set to support HighDPI
-    pub const fn set_window_highdpi(mut self, enabled: bool) -> Self {
+    /// Set to support high DPI
+    pub const fn set_window_highdpi(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32);
         }
         self
     }
 
     /// Whether to try enabling MSAA 4X
+    #[must_use]
     pub const fn msaa(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_MSAA_4X_HINT as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32) != 0
     }
     /// Set to try enabling MSAA 4X
-    pub const fn set_msaa(mut self, enabled: bool) -> Self {
+    pub const fn set_msaa(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_MSAA_4X_HINT as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_MSAA_4X_HINT as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32);
         }
         self
     }
 
     /// Whether to try enabling interlaced video format (for V3D)
+    #[must_use]
     pub const fn interlaced_hint(&self) -> bool {
-        self.0 & (ffi::ConfigFlags::FLAG_INTERLACED_HINT as i32) != 0
+        self.0 & (ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32) != 0
     }
     /// Set to try enabling interlaced video format (for V3D)
-    pub const fn set_interlaced_hint(mut self, enabled: bool) -> Self {
+    pub const fn set_interlaced_hint(&mut self, enabled: bool) -> &mut Self {
         if enabled {
             // set the bit
-            self.0 |= ffi::ConfigFlags::FLAG_INTERLACED_HINT as i32;
+            self.0 |= ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32;
         } else {
             // enable the bit
-            self.0 &= !(ffi::ConfigFlags::FLAG_INTERLACED_HINT as i32);
+            self.0 &= !(ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32);
         }
         self
     }
@@ -268,7 +289,7 @@ pub fn get_current_monitor() -> i32 {
 #[inline]
 #[must_use]
 pub fn get_current_monitor_index() -> i32 {
-    unsafe { ffi::GetCurrentMonitor() }
+    get_current_monitor()
 }
 
 /// Get specified monitor refresh rate
@@ -276,7 +297,7 @@ pub fn get_current_monitor_index() -> i32 {
 #[must_use]
 pub fn get_monitor_refresh_rate(monitor: i32) -> i32 {
     debug_assert!(
-        monitor < get_monitor_count() && monitor >= 0,
+        0 <= monitor && monitor < get_monitor_count(),
         "monitor index out of range"
     );
 
@@ -284,23 +305,25 @@ pub fn get_monitor_refresh_rate(monitor: i32) -> i32 {
 }
 
 /// Get width of monitor
+///
 /// Only checks that monitor index is in range in debug mode
 #[inline]
 #[must_use]
 pub fn get_monitor_width(monitor: i32) -> i32 {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
     unsafe { ffi::GetMonitorWidth(monitor) }
 }
 
 /// Get height of monitor
+///
 /// Only checks that monitor index is in range in debug mode
 #[inline]
 #[must_use]
 pub fn get_monitor_height(monitor: i32) -> i32 {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
     unsafe { ffi::GetMonitorHeight(monitor) }
 }
@@ -311,64 +334,74 @@ pub fn get_monitor_height(monitor: i32) -> i32 {
 #[must_use]
 pub fn get_monitor_physical_width(monitor: i32) -> i32 {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
     unsafe { ffi::GetMonitorPhysicalWidth(monitor) }
 }
 
 /// Get physical height of monitor
+///
 /// Only checks that monitor index is in range in debug mode
 #[inline]
 #[must_use]
 pub fn get_monitor_physical_height(monitor: i32) -> i32 {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
     unsafe { ffi::GetMonitorPhysicalHeight(monitor) }
 }
 
 /// Get name of monitor
+///
 /// Only checks that monitor index is in range in debug mode
+///
+/// # Errors
+///
+/// This function returns [`Utf8Error`] if [`ffi::GetMonitorName`] returns a
+/// string that is not encoded in UTF-8.
 #[inline]
-#[must_use]
-pub fn get_monitor_name(monitor: i32) -> Result<String, IntoStringError> {
+pub fn get_monitor_name(monitor: i32) -> Result<String, Utf8Error> {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
-    Ok(unsafe {
-        let c = CString::from_raw(ffi::GetMonitorName(monitor) as *mut c_char);
-        c.into_string()?
-    })
+    let monitor_name = unsafe { ffi::GetMonitorName(monitor) };
+    let c = unsafe { CStr::from_ptr(monitor_name) };
+    Ok(c.to_str()?.to_owned())
 }
 
 /// Get position of monitor
+///
 /// Only checks that monitor index is in range in debug mode
 #[inline]
 #[must_use]
 pub fn get_monitor_position(monitor: i32) -> Vector2 {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
     unsafe { ffi::GetMonitorPosition(monitor).into() }
 }
 
 /// Gets the attributes of the monitor as well as the name
-/// fails if monitor name is not a utf8 string
-/// ```rust
-/// use std::ffi::IntoStringError;
-/// use raylib::prelude::*;
-/// fn main() -> Result<(), IntoStringError> {
+///
+/// # Example
+/// ```
+/// # use std::str::Utf8Error;
+/// # use raylib::prelude::*;
+/// fn main() -> Result<(), Utf8Error> {
 ///     let count = get_monitor_count();
-///     for i in (0..count) {
+///     for i in 0..count {
 ///         println!("{:?}", get_monitor_info(i)?);
 ///     }
 ///     Ok(())
 /// }
 /// ```
-#[must_use]
-pub fn get_monitor_info(monitor: i32) -> Result<MonitorInfo, IntoStringError> {
+///
+/// # Errors
+///
+/// This function returns [`Utf8Error`] if [`get_monitor_name`] fails.
+pub fn get_monitor_info(monitor: i32) -> Result<MonitorInfo, Utf8Error> {
     let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+    debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
 
     Ok(MonitorInfo {
         width: get_monitor_width(monitor),
@@ -381,18 +414,18 @@ pub fn get_monitor_info(monitor: i32) -> Result<MonitorInfo, IntoStringError> {
 }
 
 /// Returns camera transform matrix (view matrix)
-/// ```rust
-/// use raylib::prelude::*;
-/// fn main() {
-///     let c = Camera::perspective(
-///            Vector3::new(0.0, 0.0, 0.0),
-///            Vector3::new(0.0, 0.0, -1.0),
-///            Vector3::new(0.0, 1.0, 0.0),
-///            90.0,
-///        );
-///        let m = get_camera_matrix(&c);
-///        assert_eq!(m, Matrix::identity());
-/// }
+///
+/// # Example
+/// ```
+/// # use raylib::prelude::*;
+/// let c = Camera::perspective(
+///     Vector3::new(0.0, 0.0, 0.0),
+///     Vector3::new(0.0, 0.0, -1.0),
+///     Vector3::new(0.0, 1.0, 0.0),
+///     90.0,
+/// );
+/// let m = get_camera_matrix(&c);
+/// assert_eq!(m, Matrix::identity());
 /// ```
 #[must_use]
 pub fn get_camera_matrix(camera: impl Into<ffi::Camera>) -> Matrix {
@@ -400,35 +433,41 @@ pub fn get_camera_matrix(camera: impl Into<ffi::Camera>) -> Matrix {
 }
 
 /// Returns camera 2D transform matrix (view matrix)
-/// ```rust
-/// use raylib::prelude::*;
-/// fn main() {
-///     let c = Camera2D::default();
-///     let m = get_camera_matrix2D(&c);
-///     let mut check = Matrix::zero();
-///     check.m10 = 1.0;
-///     check.m15 = 1.0;
-///     assert_eq!(m, check);
-/// }
+///
+/// # Example
 /// ```
-#[allow(non_snake_case)]
+/// # use raylib::prelude::*;
+/// let c = Camera2D::default();
+/// let m = get_camera_matrix2D(&c);
+/// let mut check = Matrix::zero();
+/// check.m10 = 1.0;
+/// check.m15 = 1.0;
+/// assert_eq!(m, check);
+/// ```
+#[allow(non_snake_case, reason = "consistent style")]
 #[must_use]
 pub fn get_camera_matrix2D(camera: impl Into<ffi::Camera2D>) -> Matrix {
     unsafe { ffi::GetCameraMatrix2D(camera.into()).into() }
 }
 
 impl RaylibHandle {
-    #[must_use]
     /// Get clipboard text content
-    pub fn get_clipboard_text(&self) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let c = ffi::GetClipboardText();
-            let c = CStr::from_ptr(c as *mut c_char);
-            c.to_str().map(|s| s.to_owned())
-        }
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Utf8Error`] if the clipboard does not contain valid UTF-8.
+    pub fn get_clipboard_text(&self) -> Result<String, Utf8Error> {
+        // TODO: can this be null?
+        let c = unsafe { ffi::GetClipboardText() };
+        let c = unsafe { CStr::from_ptr(c) };
+        Ok(c.to_str()?.to_owned())
     }
 
     /// Set clipboard text content
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`NulError`] if `text` contains an internal 0 byte.
     pub fn set_clipboard_text(&mut self, text: &str) -> Result<(), NulError> {
         let s = CString::new(text)?;
         unsafe {
@@ -466,7 +505,7 @@ impl RaylibHandle {
         }
     }
 
-    /// Returns the screen space position for a 3d world space position
+    /// Returns the screen space position for a 3D world space position
     #[inline]
     #[must_use]
     pub fn get_world_to_screen(
@@ -477,8 +516,8 @@ impl RaylibHandle {
         unsafe { ffi::GetWorldToScreen(position.into(), camera.into()).into() }
     }
 
-    /// Returns the screen space position for a 2d camera world space position
-    #[allow(non_snake_case)]
+    /// Returns the screen space position for a 2D camera world space position
+    #[allow(non_snake_case, reason = "consisten style")]
     #[inline]
     #[must_use]
     pub fn get_world_to_screen2D(
@@ -489,7 +528,7 @@ impl RaylibHandle {
         unsafe { ffi::GetWorldToScreen2D(position.into(), camera.into()).into() }
     }
 
-    /// Returns size position for a 3d world space position
+    /// Returns size position for a 3D world space position
     #[inline]
     #[must_use]
     pub fn get_world_to_screen_ex(
@@ -502,8 +541,8 @@ impl RaylibHandle {
         unsafe { ffi::GetWorldToScreenEx(position.into(), camera.into(), width, height).into() }
     }
 
-    /// Returns the world space position for a 2d camera screen space position
-    #[allow(non_snake_case)]
+    /// Returns the world space position for a 2D camera screen space position
+    #[allow(non_snake_case, reason = "consistent style")]
     #[inline]
     #[must_use]
     pub fn get_screen_to_world2D(
@@ -518,18 +557,30 @@ impl RaylibHandle {
 // Timing related functions
 impl RaylibHandle {
     /// Set target FPS (maximum)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `fps` is greater than [`i32::MAX`].
     #[inline]
     pub fn set_target_fps(&mut self, fps: u32) {
         unsafe {
-            ffi::SetTargetFPS(fps as i32);
+            ffi::SetTargetFPS(fps.try_into().expect("fps should not exceed i32::MAX"));
         }
     }
 
     /// Returns current FPS
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if [`ffi::GetFPS`] returns a negative number.
     #[inline]
     #[must_use]
     pub fn get_fps(&self) -> u32 {
-        unsafe { ffi::GetFPS() as u32 }
+        unsafe {
+            ffi::GetFPS()
+                .try_into()
+                .expect("FPS should never be negative")
+        }
     }
 
     /// Returns time in seconds for last frame drawn
@@ -539,7 +590,7 @@ impl RaylibHandle {
         unsafe { ffi::GetFrameTime() }
     }
 
-    /// Returns elapsed time in seconds since InitWindow()
+    /// Returns elapsed time in seconds since [`ffi::InitWindow()`]
     #[inline]
     #[must_use]
     pub fn get_time(&self) -> f64 {
@@ -617,14 +668,14 @@ impl RaylibHandle {
         unsafe { ffi::IsWindowFullscreen() }
     }
 
-    /// Check if window is currently focused (only PLATFORM_DESKTOP)
+    /// Check if window is currently focused (only `PLATFORM_DESKTOP`)
     #[inline]
     #[must_use]
     pub fn is_window_focused(&self) -> bool {
         unsafe { ffi::IsWindowFocused() }
     }
 
-    /// Check if window is currently focused (only PLATFORM_DESKTOP)
+    /// Check if window is currently focused (only `PLATFORM_DESKTOP`)
     #[inline]
     #[must_use]
     pub fn get_window_scale_dpi(&self) -> Vector2 {
@@ -655,63 +706,62 @@ impl RaylibHandle {
     /// Set window configuration state using flags
     #[inline]
     pub fn set_window_state(&mut self, state: WindowState) {
-        unsafe { ffi::SetWindowState(state.0 as u32) }
+        unsafe { ffi::SetWindowState(state.0) }
     }
 
     /// Clear window configuration state flags
     #[inline]
     pub fn clear_window_state(&mut self, state: WindowState) {
-        unsafe { ffi::ClearWindowState(state.0 as u32) }
+        unsafe { ffi::ClearWindowState(state.0) }
     }
 
     /// Get the window config state
     #[must_use]
     pub fn get_window_state(&self) -> WindowState {
-        let state = WindowState::default();
-        unsafe {
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_VSYNC_HINT as u32) {
-                state.set_vsync_hint(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32) {
-                state.set_fullscreen_mode(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32) {
-                state.set_window_resizable(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32) {
-                state.set_window_undecorated(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32) {
-                state.set_window_hidden(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32) {
-                state.set_window_minimized(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32) {
-                state.set_window_maximized(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32) {
-                state.set_window_unfocused(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32) {
-                state.set_window_topmost(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32) {
-                state.set_window_always_run(true);
-            }
+        let mut state = WindowState::default();
 
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32) {
-                state.set_window_transparent(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32) {
-                state.set_window_highdpi(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32) {
-                state.set_msaa(true);
-            }
-            if ffi::IsWindowState(ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32) {
-                state.set_interlaced_hint(true);
-            }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_VSYNC_HINT as u32) } {
+            state.set_vsync_hint(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32) } {
+            state.set_fullscreen_mode(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32) } {
+            state.set_window_resizable(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32) } {
+            state.set_window_undecorated(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32) } {
+            state.set_window_hidden(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32) } {
+            state.set_window_minimized(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32) } {
+            state.set_window_maximized(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32) } {
+            state.set_window_unfocused(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32) } {
+            state.set_window_topmost(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32) } {
+            state.set_window_always_run(true);
+        }
+
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32) } {
+            state.set_window_transparent(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32) } {
+            state.set_window_highdpi(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32) } {
+            state.set_msaa(true);
+        }
+        if unsafe { ffi::IsWindowState(ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32) } {
+            state.set_interlaced_hint(true);
         }
         state
     }
@@ -725,16 +775,31 @@ impl RaylibHandle {
     }
 
     /// Set icon for window (multiple images, RGBA 32bit)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `images` has a length greater than [`i32::MAX`].
     #[inline]
-    pub fn set_window_icons(&mut self, images: &mut [raylib_sys::Image]) {
-        use std::convert::TryInto;
-        unsafe { ffi::SetWindowIcons(images.as_mut_ptr(), images.len().try_into().unwrap()) }
+    pub fn set_window_icons(&mut self, images: &mut [ffi::Image]) {
+        unsafe {
+            ffi::SetWindowIcons(
+                images.as_mut_ptr(),
+                images
+                    .len()
+                    .try_into()
+                    .expect("images should not exceed i32::MAX elements"),
+            );
+        }
     }
 
     /// Sets title for window (only on desktop platforms).
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `title` contains an internal 0 byte.
     #[inline]
     pub fn set_window_title(&self, _: &RaylibThread, title: &str) {
-        let c_title = CString::new(title).unwrap();
+        let c_title = CString::new(title).expect("title should not contain an internal 0 byte");
         unsafe {
             ffi::SetWindowTitle(c_title.as_ptr());
         }
@@ -752,7 +817,7 @@ impl RaylibHandle {
     #[inline]
     pub fn set_window_monitor(&mut self, monitor: i32) {
         let len = get_monitor_count();
-        debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
+        debug_assert!(0 <= monitor && monitor < len, "monitor index out of range");
         unsafe {
             ffi::SetWindowMonitor(monitor);
         }

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -37,6 +37,7 @@ impl WindowState {
     pub const fn vsync_hint(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_VSYNC_HINT as u32) != 0
     }
+
     /// Set to try enabling V-Sync on GPU
     pub const fn set_vsync_hint(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -54,6 +55,7 @@ impl WindowState {
     pub const fn fullscreen_mode(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32) != 0
     }
+
     /// Set to run program in fullscreen
     pub const fn set_fullscreen_mode(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -71,6 +73,7 @@ impl WindowState {
     pub const fn window_resizable(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32) != 0
     }
+
     /// Set to allow resizable window
     pub const fn set_window_resizable(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -88,6 +91,7 @@ impl WindowState {
     pub const fn window_undecorated(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32) != 0
     }
+
     /// Set to disable window decoration (frame and buttons)
     pub const fn set_window_undecorated(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -105,6 +109,7 @@ impl WindowState {
     pub const fn window_hidden(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32) != 0
     }
+
     /// Set to hide window
     pub const fn set_window_hidden(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -122,6 +127,7 @@ impl WindowState {
     pub const fn window_minimized(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32) != 0
     }
+
     /// Set to minimize window (iconify)
     pub const fn set_window_minimized(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -139,6 +145,7 @@ impl WindowState {
     pub const fn window_maximized(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32) != 0
     }
+
     /// Set to maximize window (expanded to monitor)
     pub const fn set_window_maximized(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -156,6 +163,7 @@ impl WindowState {
     pub const fn window_unfocused(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32) != 0
     }
+
     /// Set to window non focused
     pub const fn set_window_unfocused(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -173,6 +181,7 @@ impl WindowState {
     pub const fn window_topmost(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32) != 0
     }
+
     /// Set to window always on top
     pub const fn set_window_topmost(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -190,6 +199,7 @@ impl WindowState {
     pub const fn window_always_run(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32) != 0
     }
+
     /// Set to allow windows running while minimized
     pub const fn set_window_always_run(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -207,6 +217,7 @@ impl WindowState {
     pub const fn window_transparent(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32) != 0
     }
+
     /// Set to allow transparent framebuffer
     pub const fn set_window_transparent(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -224,6 +235,7 @@ impl WindowState {
     pub const fn window_highdpi(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32) != 0
     }
+
     /// Set to support high DPI
     pub const fn set_window_highdpi(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -241,6 +253,7 @@ impl WindowState {
     pub const fn msaa(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32) != 0
     }
+
     /// Set to try enabling MSAA 4X
     pub const fn set_msaa(&mut self, enabled: bool) -> &mut Self {
         if enabled {
@@ -258,6 +271,7 @@ impl WindowState {
     pub const fn interlaced_hint(&self) -> bool {
         self.0 & (ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32) != 0
     }
+
     /// Set to try enabling interlaced video format (for V3D)
     pub const fn set_interlaced_hint(&mut self, enabled: bool) -> &mut Self {
         if enabled {

--- a/raylib/src/ease.rs
+++ b/raylib/src/ease.rs
@@ -20,6 +20,15 @@ Permission is granted to anyone to use this software for any purpose, including 
 //!
 //! [`Tween`]: struct.Tween.html
 
+#![allow(
+    clippy::many_single_char_names,
+    clippy::float_cmp,
+    clippy::needless_return,
+    clippy::redundant_else,
+    clippy::unreadable_literal,
+    reason = "consistency with original definition, from which this was translated nearly 1:1"
+)]
+
 use std::f32::consts::PI;
 
 /// The type alias used for all easing functions.
@@ -49,13 +58,14 @@ impl Tween {
     }
 
     /// Resets the tween to the beginning.
-    pub fn reset(&mut self) {
+    pub const fn reset(&mut self) {
         self.current_time = 0.0;
         self.completed = false;
     }
 
     /// Returns true if the tween has completed.
-    pub fn has_completed(&self) -> bool {
+    #[must_use]
+    pub const fn has_completed(&self) -> bool {
         self.completed
     }
 
@@ -81,59 +91,82 @@ impl Tween {
     }
 
     /// Returns the current time position of the tween.
-    pub fn current_time(&self) -> f32 {
+    #[must_use]
+    pub const fn current_time(&self) -> f32 {
         self.current_time
     }
 
     /// Returns the starting value of the tween.
-    pub fn start_value(&self) -> f32 {
+    #[must_use]
+    pub const fn start_value(&self) -> f32 {
         self.start_value
     }
 
     /// Returns the ending value of the tween.
-    pub fn end_value(&self) -> f32 {
+    #[must_use]
+    pub const fn end_value(&self) -> f32 {
         self.end_value
     }
 
     /// Returns the duration of the tween.
-    pub fn duration(&self) -> f32 {
+    #[must_use]
+    pub const fn duration(&self) -> f32 {
         self.duration
     }
 }
 
+/// Ease: Linear
+#[must_use]
 pub fn linear_none(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
+/// Ease: Linear In
+#[must_use]
 pub fn linear_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
+/// Ease: Linear Out
+#[must_use]
 pub fn linear_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
+/// Ease: Linear In Out
+#[must_use]
 pub fn linear_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
 
+/// Ease: Sine In
+#[must_use]
 pub fn sine_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     -c * (t / d * (PI / 2.0)).cos() + c + b
 }
+/// Ease: Sine Out
+#[must_use]
 pub fn sine_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * (t / d * (PI / 2.0)).sin() + b
 }
+/// Ease: Sine In Out
+#[must_use]
 pub fn sine_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     -c / 2.0 * ((PI * t / d).cos() - 1.0) + b
 }
-
+/// Ease: Circular In
+#[must_use]
 pub fn circ_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d;
     -c * ((1.0 - td * td).sqrt() - 1.0) + b
 }
 
+/// Ease: Circular Out
+#[must_use]
 pub fn circ_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d - 1.0;
     c * (1.0 - td * td).sqrt() + b
 }
 
+/// Ease: Circular In Out
+#[must_use]
 pub fn circ_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let mut td = t / (d / 2.0);
     if td < 1.0 {
@@ -144,16 +177,22 @@ pub fn circ_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Cubic In
+#[must_use]
 pub fn cubic_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d;
     c * td * td * td + b
 }
 
+/// Ease: Cubic Out
+#[must_use]
 pub fn cubic_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d - 1.0;
     c * (td * td * td + 1.0) + b
 }
 
+/// Ease: Cubic In Out
+#[must_use]
 pub fn cubic_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let mut td = t / (d / 2.0);
     if td < 1.0 {
@@ -164,16 +203,22 @@ pub fn cubic_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Quadratic In
+#[must_use]
 pub fn quad_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d;
     c * td * td + b
 }
 
+/// Ease: Quadratic Out
+#[must_use]
 pub fn quad_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d;
     -c * td * (td - 2.0) + b
 }
 
+/// Ease: Quadratic In Out
+#[must_use]
 pub fn quad_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / (d / 2.0);
     if td < 1.0 {
@@ -183,6 +228,8 @@ pub fn quad_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Exponential In
+#[must_use]
 pub fn expo_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     if t == 0.0 {
         b
@@ -191,6 +238,8 @@ pub fn expo_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Exponential Out
+#[must_use]
 pub fn expo_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     if t == d {
         b + c
@@ -199,6 +248,8 @@ pub fn expo_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Exponential In Out
+#[must_use]
 pub fn expo_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     if t == 0.0 {
         return b;
@@ -214,18 +265,24 @@ pub fn expo_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Back In
+#[must_use]
 pub fn back_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let s = 1.70158f32;
     let postfix = t / d;
     c * postfix * postfix * ((s + 1.0) * postfix - s) + b
 }
 
+/// Ease: Back Out
+#[must_use]
 pub fn back_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let s = 1.70158f32;
     let td = t / d - 1.0;
     c * (td * td * ((s + 1.0) * td + s) + 1.0) + b
 }
 
+/// Ease: Back In Out
+#[must_use]
 pub fn back_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let mut s = 1.70158f32;
     let td = t / (d / 2.0);
@@ -239,6 +296,8 @@ pub fn back_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Bounce Out
+#[must_use]
 pub fn bounce_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let mut td = t / d;
     if td < (1.0 / 2.75) {
@@ -255,10 +314,14 @@ pub fn bounce_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Bounce In
+#[must_use]
 pub fn bounce_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c - bounce_out(d - t, 0.0, c, d) + b
 }
 
+/// Ease: Bounce In Out
+#[must_use]
 pub fn bounce_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     if t < (d / 2.0) {
         (bounce_in(t * 2.0, 0.0, c, d) * 0.5) + b
@@ -267,6 +330,8 @@ pub fn bounce_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Elastic In
+#[must_use]
 pub fn elastic_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let mut td = t / d;
 
@@ -284,6 +349,8 @@ pub fn elastic_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Elastic Out
+#[must_use]
 pub fn elastic_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let td = t / d;
 
@@ -299,6 +366,8 @@ pub fn elastic_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     }
 }
 
+/// Ease: Elastic In Out
+#[must_use]
 pub fn elastic_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     let mut td = t / (d / 2.0);
 

--- a/raylib/src/ease.rs
+++ b/raylib/src/ease.rs
@@ -120,16 +120,19 @@ impl Tween {
 pub fn linear_none(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
+
 /// Ease: Linear In
 #[must_use]
 pub fn linear_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
+
 /// Ease: Linear Out
 #[must_use]
 pub fn linear_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * t / d + b
 }
+
 /// Ease: Linear In Out
 #[must_use]
 pub fn linear_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
@@ -141,16 +144,19 @@ pub fn linear_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
 pub fn sine_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     -c * (t / d * (PI / 2.0)).cos() + c + b
 }
+
 /// Ease: Sine Out
 #[must_use]
 pub fn sine_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     c * (t / d * (PI / 2.0)).sin() + b
 }
+
 /// Ease: Sine In Out
 #[must_use]
 pub fn sine_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
     -c / 2.0 * ((PI * t / d).cos() - 1.0) + b
 }
+
 /// Ease: Circular In
 #[must_use]
 pub fn circ_in(t: f32, b: f32, c: f32, d: f32) -> f32 {

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -37,7 +37,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 //!
 //! The classic "Hello, world":
 //!
-//! ```no_run
+//! ```ignore
 //! use raylib::prelude::*;
 //!
 //! fn main() {
@@ -45,10 +45,10 @@ Permission is granted to anyone to use this software for any purpose, including 
 //!         .size(640, 480)
 //!         .title("Hello, World")
 //!         .build();
-//!     
+//!
 //!     while !rl.window_should_close() {
 //!         let mut d = rl.begin_drawing(&thread);
-//!         
+//!
 //!         d.clear_background(Color::WHITE);
 //!         d.draw_text("Hello, world!", 12, 12, 20, Color::BLACK);
 //!     }
@@ -56,6 +56,12 @@ Permission is granted to anyone to use this software for any purpose, including 
 //! ```
 //#![cfg_attr(feature = "nightly", feature(auto_traits))]
 
+#![warn(
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    reason = "temporary while cleaning up"
+)]
 #![allow(dead_code)]
 pub mod consts;
 pub mod core;

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -59,6 +59,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 #![warn(
     clippy::all,
     clippy::pedantic,
+    clippy::style,
     clippy::unwrap_used,
     reason = "temporary while cleaning up"
 )]

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -75,6 +75,11 @@ Permission is granted to anyone to use this software for any purpose, including 
     reason = "the safety requirements of two unsafe operations are rarely (though not never) covered by the same documentation"
 )]
 #![warn(
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    reason = "safety docs on safe code can be confusing as to whether the operation is safe or not"
+)]
+#![warn(
     missing_docs,
     reason = "users deserve to know what a public API does and how to use it"
 )]

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -56,26 +56,50 @@ Permission is granted to anyone to use this software for any purpose, including 
 //! ```
 //#![cfg_attr(feature = "nightly", feature(auto_traits))]
 
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::style,
-    clippy::unwrap_used,
-    reason = "temporary while cleaning up"
-)]
 #![forbid(clippy::correctness, clippy::perf)]
 #![warn(
-    missing_docs,
-    clippy::allow_attributes_without_reason,
-    clippy::inline_always,
+    clippy::unwrap_used,
+    reason = "debugging is easier when you know what the unwrap represents"
+)]
+#![warn(
     clippy::missing_safety_doc,
-    // clippy::undocumented_unsafe_blocks, // TODO: Fixing safety would be a breaking change and deserves a separate PR
+    reason = "nobody can use your unsafe code soundly if you don't explain the requirements for soundness"
+)]
+#![warn(
+    clippy::undocumented_unsafe_blocks,
+    reason = "it is extremely difficult to verify soundness if you don't explain your assumptions"
+)]
+#![warn(
     clippy::multiple_unsafe_ops_per_block,
-    clippy::unnecessary_cast,
+    reason = "the safety requirements of two unsafe operations are rarely (though not never) covered by the same documentation"
+)]
+#![warn(
+    missing_docs,
+    reason = "users deserve to know what a public API does and how to use it"
+)]
+#![warn(
+    clippy::allow_attributes_without_reason,
+    reason = "making lints less restrictive should not be done without reason, and you will not always be there to explain it"
+)]
+#![warn(
+    clippy::inline_always,
+    reason = "sure, go ahead and tell the compiler you want stuff inlined. But don't go thinking inline is some magical
+            performance fountain that will somehow always be faster than not inlining. You told the compiler to inline it,
+            it decided it shouldn't. So you'd better have some DATA before you tell it to proceed *in spite of that*."
+)]
+#![warn(
+    clippy::missing_const_for_fn,
+    reason = "another function could be made const if this one was; or another function may *only* not be const because this one isn't"
+)]
+#![deny(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
+    clippy::unnecessary_cast,
+    reason = r#"if this is intentional, indicate it with a reason (`#[allow(clippy::..., reason = "...")]`)"#
+)]
+#![deny(
+    clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
     clippy::cast_ptr_alignment,
     clippy::cast_abs_to_unsigned,
@@ -85,16 +109,13 @@ Permission is granted to anyone to use this software for any purpose, including 
     clippy::fn_to_numeric_cast_any,
     clippy::fn_to_numeric_cast_with_truncation,
     clippy::cast_nan_to_int,
-    clippy::char_lit_as_u8,
     clippy::ref_as_ptr,
     clippy::ptr_as_ptr,
     clippy::as_ptr_cast_mut,
     clippy::as_underscore,
     clippy::borrow_as_ptr,
-    clippy::match_as_ref,
     clippy::ptr_cast_constness,
-    clippy::cast_enum_truncation,
-    clippy::missing_const_for_fn,
+    reason = r"do not mistake `as` for being lossless. it can fail, but it won't tell you, and you need to handle that"
 )]
 #![allow(dead_code, reason = "future use, and some features are incomplete")]
 pub mod consts;

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -66,6 +66,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 #![forbid(clippy::correctness, clippy::perf)]
 #![warn(
     missing_docs,
+    clippy::allow_attributes_without_reason,
     clippy::inline_always,
     clippy::missing_safety_doc,
     // clippy::undocumented_unsafe_blocks, // TODO: Fixing safety would be a breaking change and deserves a separate PR
@@ -76,6 +77,10 @@ Permission is granted to anyone to use this software for any purpose, including 
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
+    clippy::cast_ptr_alignment,
+    clippy::cast_abs_to_unsigned,
+    clippy::cast_enum_constructor,
+    clippy::cast_slice_from_raw_parts,
     clippy::fn_to_numeric_cast,
     clippy::fn_to_numeric_cast_any,
     clippy::fn_to_numeric_cast_with_truncation,
@@ -91,7 +96,7 @@ Permission is granted to anyone to use this software for any purpose, including 
     clippy::cast_enum_truncation,
     clippy::missing_const_for_fn,
 )]
-#![allow(dead_code)]
+#![allow(dead_code, reason = "future use, and some features are incomplete")]
 pub mod consts;
 pub mod core;
 pub mod ease;

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -65,6 +65,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 )]
 #![forbid(clippy::correctness, clippy::perf)]
 #![warn(
+    missing_docs,
     clippy::missing_safety_doc,
     // clippy::undocumented_unsafe_blocks, // TODO: Fixing safety would be a breaking change and deserves a separate PR
     clippy::multiple_unsafe_ops_per_block,

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -37,7 +37,8 @@ Permission is granted to anyone to use this software for any purpose, including 
 //!
 //! The classic "Hello, world":
 //!
-//! ```ignore
+#![allow(clippy::needless_doctest_main, reason = "being used as an example")]
+//! ```no_run
 //! use raylib::prelude::*;
 //!
 //! fn main() {

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -20,7 +20,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 //!
 //! To get started, take a look at the [`init_window`] function. This initializes Raylib and shows a window, and returns a [`RaylibHandle`]. This handle is very important, because it is the way in which one accesses the vast majority of Raylib's functionality. This means that it must not go out of scope until the game is ready to exit. You will also receive a !Send and !Sync [`RaylibThread`] required for thread local functions.
 //!
-//! For more control over the game window, the [`init`] function will return a [`RaylibBuilder`] which allows for tweaking various settings such as VSync, anti-aliasing, fullscreen, and so on. Calling [`RaylibBuilder::build`] will then provide a [`RaylibHandle`].
+//! For more control over the game window, the [`init`] function will return a [`RaylibBuilder`] which allows for tweaking various settings such as Vsync, anti-aliasing, fullscreen, and so on. Calling [`RaylibBuilder::build`] will then provide a [`RaylibHandle`].
 //!
 //! Some useful constants can be found in the [`consts`] module, which is also re-exported in the [`prelude`] module. In most cases you will probably want to `use raylib::prelude::*;` to make your experience more smooth.
 //!
@@ -63,11 +63,31 @@ Permission is granted to anyone to use this software for any purpose, including 
     clippy::unwrap_used,
     reason = "temporary while cleaning up"
 )]
+#![forbid(clippy::correctness, clippy::perf)]
 #![warn(
     clippy::missing_safety_doc,
     // clippy::undocumented_unsafe_blocks, // TODO: Fixing safety would be a breaking change and deserves a separate PR
-    clippy::as_conversions,
-    clippy::multiple_unsafe_ops_per_block
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::unnecessary_cast,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::fn_to_numeric_cast,
+    clippy::fn_to_numeric_cast_any,
+    clippy::fn_to_numeric_cast_with_truncation,
+    clippy::cast_nan_to_int,
+    clippy::char_lit_as_u8,
+    clippy::ref_as_ptr,
+    clippy::ptr_as_ptr,
+    clippy::as_ptr_cast_mut,
+    clippy::as_underscore,
+    clippy::borrow_as_ptr,
+    clippy::match_as_ref,
+    clippy::ptr_cast_constness,
+    clippy::cast_enum_truncation,
+    clippy::missing_const_for_fn,
 )]
 #![allow(dead_code)]
 pub mod consts;

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -63,6 +63,12 @@ Permission is granted to anyone to use this software for any purpose, including 
     clippy::unwrap_used,
     reason = "temporary while cleaning up"
 )]
+#![warn(
+    clippy::missing_safety_doc,
+    // clippy::undocumented_unsafe_blocks, // TODO: Fixing safety would be a breaking change and deserves a separate PR
+    clippy::as_conversions,
+    clippy::multiple_unsafe_ops_per_block
+)]
 #![allow(dead_code)]
 pub mod consts;
 pub mod core;

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -66,6 +66,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 #![forbid(clippy::correctness, clippy::perf)]
 #![warn(
     missing_docs,
+    clippy::inline_always,
     clippy::missing_safety_doc,
     // clippy::undocumented_unsafe_blocks, // TODO: Fixing safety would be a breaking change and deserves a separate PR
     clippy::multiple_unsafe_ops_per_block,
@@ -104,11 +105,11 @@ pub mod ffi {
 
 pub use crate::core::collision::*;
 
-pub type MintVec2 = ffi::Vector2;
-pub type MintVec3 = ffi::Vector3;
-pub type MintVec4 = ffi::Vector4;
-pub type MintMatrix = ffi::Matrix;
-pub type MintQuat = ffi::Quaternion;
+pub use ffi::Matrix as MintMatrix;
+pub use ffi::Quaternion as MintQuat;
+pub use ffi::Vector2 as MintVec2;
+pub use ffi::Vector3 as MintVec3;
+pub use ffi::Vector4 as MintVec4;
 
 pub use crate::core::logging::*;
 pub use crate::core::misc::open_url;

--- a/raylib/src/rgui/mod.rs
+++ b/raylib/src/rgui/mod.rs
@@ -1,2 +1,4 @@
+//! Raylib GUI
+
 mod safe;
 pub use safe::*;

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -28,10 +28,10 @@ impl RaylibHandle {
     pub fn gui_unlock(&mut self) {
         unsafe { ffi::GuiUnlock() }
     }
-    // Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
+    /// Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
     #[inline]
     pub fn gui_fade(&mut self, color: Color, alpha: f32) -> Color {
-        unsafe { ffi::Fade(color.into(), alpha).into() }
+        unsafe { ffi::Fade(color, alpha) }
     }
     /// Set gui state (global state)
     #[inline]
@@ -41,7 +41,8 @@ impl RaylibHandle {
     /// Get gui state (global state)
     #[inline]
     pub fn gui_get_state(&mut self) -> crate::consts::GuiState {
-        unsafe { std::mem::transmute(ffi::GuiGetState()) }
+        let state = unsafe { ffi::GuiGetState() };
+        unsafe { std::mem::transmute(state) }
     }
     /// Set gui custom font (global state)
     #[inline]
@@ -74,9 +75,14 @@ impl RaylibHandle {
         unsafe { ffi::GuiGetStyle(control as i32, property.as_i32()) }
     }
     /// Load style file (.rgs)
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `filename` contains an internal 0 byte.
     #[inline]
     pub fn gui_load_style(&mut self, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe { ffi::GuiLoadStyle(c_filename.as_ptr()) }
     }
     /// Load style default over global style
@@ -98,18 +104,33 @@ impl RaylibHandle {
     }
 
     /// Set tooltip string
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `tooltip` contains an internal 0 byte.
     #[inline]
     pub fn gui_set_tooltip(&mut self, tooltip: &str) {
-        let c_text = CString::new(tooltip).unwrap();
+        let c_text = CString::new(tooltip).expect("tooltip should not contain an internal 0 byte");
         unsafe {
             ffi::GuiSetTooltip(c_text.as_ptr());
         }
     }
 }
 
-impl<D: RaylibDraw> RaylibDrawGui for D {}
+unsafe impl<D: RaylibDraw> RaylibDrawGui for D {}
 
-pub trait RaylibDrawGui {
+/// Types through which it is safe to call Raylib GUI drawing functions.
+///
+/// # Safety
+///
+/// The default implementation of the draw functions provided by this trait (which generally should never be overridden)
+/// access global static memory without locking, perform calls with function pointers that may not have been loaded,
+/// and expect for there to be a window, buffer, & projection matrix to target--all without any checks.
+///
+/// Implementors must guarantee that their type can only exist if Raylib has been successfully initialized with a window,
+/// has successfully loaded any necessary GL libraries, the calling thread is the same one that initialized Raylib, and
+/// [`ffi::BeginDrawing`] has been called this frame without the corresponding [`ffi::EndDrawing`] having been called yet.
+pub unsafe trait RaylibDrawGui {
     /// Enable gui controls (global state)
     #[inline]
     fn gui_enable(&mut self) {
@@ -137,10 +158,10 @@ pub trait RaylibDrawGui {
         unsafe { ffi::GuiIsLocked() }
     }
 
-    // Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
+    /// Set gui controls alpha (global state), alpha goes from 0.0 to 1.0
     #[inline]
     fn gui_fade(&mut self, color: Color, alpha: f32) -> Color {
-        unsafe { ffi::Fade(color.into(), alpha).into() }
+        unsafe { ffi::Fade(color, alpha) }
     }
     /// Set gui state (global state)
     #[inline]
@@ -150,7 +171,8 @@ pub trait RaylibDrawGui {
     /// Get gui state (global state)
     #[inline]
     fn gui_get_state(&mut self) -> crate::consts::GuiState {
-        unsafe { std::mem::transmute(ffi::GuiGetState()) }
+        let state = unsafe { ffi::GuiGetState() };
+        unsafe { std::mem::transmute(state) }
     }
     /// Set gui custom font (global state)
     #[inline]
@@ -188,7 +210,8 @@ pub trait RaylibDrawGui {
     /// Load style file (.rgs)
     #[inline]
     fn gui_load_style(&mut self, filename: &str) {
-        let c_filename = CString::new(filename).unwrap();
+        let c_filename =
+            CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe { ffi::GuiLoadStyle(c_filename.as_ptr()) }
     }
     /// Load style default over global style
@@ -199,19 +222,19 @@ pub trait RaylibDrawGui {
     /// Window Box control, shows a window that can be closed
     #[inline]
     fn gui_window_box(&mut self, bounds: impl Into<ffi::Rectangle>, title: &str) -> bool {
-        let c_filename = CString::new(title).unwrap();
+        let c_filename = CString::new(title).expect("title should not contain an internal 0 byte");
         unsafe { ffi::GuiWindowBox(bounds.into(), c_filename.as_ptr()) > 0 }
     }
     /// Group Box control with text name
     #[inline]
     fn gui_group_box(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_filename = CString::new(text).unwrap();
+        let c_filename = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiGroupBox(bounds.into(), c_filename.as_ptr()) > 0 }
     }
     /// Line separator control, could contain text
     #[inline]
     fn gui_line(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_filename = CString::new(text).unwrap();
+        let c_filename = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiLine(bounds.into(), c_filename.as_ptr()) > 0 }
     }
     /// Panel control, useful to group controls
@@ -221,7 +244,7 @@ pub trait RaylibDrawGui {
         let c_text = if text.is_empty() {
             std::ptr::null()
         } else {
-            cstr = CString::new(text).unwrap();
+            cstr = CString::new(text).expect("text should not contain an internal 0 byte");
             cstr.as_ptr()
         };
         unsafe { ffi::GuiPanel(bounds.into(), c_text) > 0 }
@@ -238,7 +261,7 @@ pub trait RaylibDrawGui {
     ) -> (bool, Rectangle, Vector2) {
         let mut scroll = scroll.into();
         let mut view = view.into();
-        let c_filename = CString::new(text).unwrap();
+        let c_filename = CString::new(text).expect("text should not contain an internal 0 byte");
         let result = unsafe {
             ffi::GuiScrollPanel(
                 bounds.into(),
@@ -248,24 +271,24 @@ pub trait RaylibDrawGui {
                 &mut view,
             )
         };
-        (result > 0, view.into(), scroll.into())
+        (result > 0, view, scroll)
     }
     /// Label control, shows text
     #[inline]
     fn gui_label(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiLabel(bounds.into(), c_text.as_ptr()) > 0 }
     }
     /// Button control, returns true when clicked
     #[inline]
     fn gui_button(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiButton(bounds.into(), c_text.as_ptr()) > 0 }
     }
     /// Label button control, show true when clicked
     #[inline]
     fn gui_label_button(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiLabelButton(bounds.into(), c_text.as_ptr()) > 0 }
     }
     /// Toggle Button control, returns true when active
@@ -276,7 +299,7 @@ pub trait RaylibDrawGui {
         text: &str,
         active: &mut bool,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiToggle(bounds.into(), c_text.as_ptr(), active) > 0 }
     }
     /// Toggle Group control, returns active toggle index
@@ -287,7 +310,7 @@ pub trait RaylibDrawGui {
         text: &str,
         active: &mut i32,
     ) -> i32 {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiToggleGroup(bounds.into(), c_text.as_ptr(), active) }
     }
     /// Check Box control, returns true when active
@@ -298,7 +321,7 @@ pub trait RaylibDrawGui {
         text: &str,
         checked: &mut bool,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiCheckBox(bounds.into(), c_text.as_ptr(), checked) > 0 }
     }
     /// Combo Box control, returns selected item index
@@ -309,7 +332,7 @@ pub trait RaylibDrawGui {
         text: &str,
         active: &mut i32,
     ) -> i32 {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiComboBox(bounds.into(), c_text.as_ptr(), active) }
     }
     /// Dropdown Box control, returns selected item
@@ -321,7 +344,7 @@ pub trait RaylibDrawGui {
         active: &mut i32,
         edit_mode: bool,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiDropdownBox(bounds.into(), c_text.as_ptr(), active, edit_mode) > 0 }
     }
     /// Spinner control, returns selected value
@@ -335,7 +358,7 @@ pub trait RaylibDrawGui {
         max_value: i32,
         edit_mode: bool,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             ffi::GuiSpinner(
                 bounds.into(),
@@ -359,7 +382,7 @@ pub trait RaylibDrawGui {
         max_value: i32,
         edit_mode: bool,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe {
             ffi::GuiValueBox(
                 bounds.into(),
@@ -384,7 +407,14 @@ pub trait RaylibDrawGui {
         buffer.push('\0');
         let (ptr, capacity) = (buffer.as_mut_ptr(), buffer.capacity());
         let res = unsafe {
-            ffi::GuiTextBox(bounds.into(), ptr as *mut i8, capacity as i32, edit_mode) > 0
+            ffi::GuiTextBox(
+                bounds.into(),
+                ptr.cast(),
+                capacity
+                    .try_into()
+                    .expect("capacity should not exceed i32::MAX"),
+                edit_mode,
+            ) > 0
         };
         let cap = buffer.capacity();
 
@@ -419,8 +449,10 @@ pub trait RaylibDrawGui {
         min_value: f32,
         max_value: f32,
     ) -> bool {
-        let c_text_left = CString::new(text_left).unwrap();
-        let c_text_right = CString::new(text_right).unwrap();
+        let c_text_left =
+            CString::new(text_left).expect("text_left should not contain an internal 0 byte");
+        let c_text_right =
+            CString::new(text_right).expect("text_right should not contain an internal 0 byte");
         unsafe {
             ffi::GuiSlider(
                 bounds.into(),
@@ -443,8 +475,10 @@ pub trait RaylibDrawGui {
         min_value: f32,
         max_value: f32,
     ) -> bool {
-        let c_text_left = CString::new(text_left).unwrap();
-        let c_text_right = CString::new(text_right).unwrap();
+        let c_text_left =
+            CString::new(text_left).expect("text_left should not contain an internal 0 byte");
+        let c_text_right =
+            CString::new(text_right).expect("text_right should not contain an internal 0 byte");
         unsafe {
             ffi::GuiSliderBar(
                 bounds.into(),
@@ -467,8 +501,10 @@ pub trait RaylibDrawGui {
         min_value: f32,
         max_value: f32,
     ) -> bool {
-        let c_text_left = CString::new(text_left).unwrap();
-        let c_text_right = CString::new(text_right).unwrap();
+        let c_text_left =
+            CString::new(text_left).expect("text_left should not contain an internal 0 byte");
+        let c_text_right =
+            CString::new(text_right).expect("text_right should not contain an internal 0 byte");
         unsafe {
             ffi::GuiProgressBar(
                 bounds.into(),
@@ -483,7 +519,7 @@ pub trait RaylibDrawGui {
     /// Status Bar control, shows info text
     #[inline]
     fn gui_status_bar(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiStatusBar(bounds.into(), c_text.as_ptr()) > 0 }
     }
 
@@ -496,7 +532,7 @@ pub trait RaylibDrawGui {
         spacing: f32,
         subdivs: i32,
     ) -> (bool, Vector2) {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         let mut mouse_cell = MintVec2 { x: 0.0, y: 0.0 };
         (
             unsafe {
@@ -508,7 +544,7 @@ pub trait RaylibDrawGui {
                     &mut mouse_cell,
                 ) > 0
             },
-            mouse_cell.into(),
+            mouse_cell,
         )
     }
     /// List View control, returns selected list item index
@@ -520,7 +556,7 @@ pub trait RaylibDrawGui {
         scroll_index: &mut i32,
         active: &mut i32,
     ) -> i32 {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiListView(bounds.into(), c_text.as_ptr(), scroll_index, active) }
     }
     /// List View with extended parameters
@@ -535,7 +571,11 @@ pub trait RaylibDrawGui {
     ) -> i32 {
         // We need to keep track of all CStr buffers.
         let buffer: Box<[Box<CStr>]> = text
-            .map(|s| CString::new(s.as_ref()).unwrap().into_boxed_c_str())
+            .map(|s| {
+                CString::new(s.as_ref())
+                    .expect("text should not contain an internal 0 byte")
+                    .into_boxed_c_str()
+            })
             .collect();
 
         let mut text_params: Box<[*const c_char]> =
@@ -545,7 +585,10 @@ pub trait RaylibDrawGui {
             ffi::GuiListViewEx(
                 bounds.into(),
                 text_params.as_mut_ptr(),
-                text_params.len() as i32,
+                text_params
+                    .len()
+                    .try_into()
+                    .expect("text_params should not exceed i32::MAX elements"),
                 focus,
                 scroll_index,
                 active,
@@ -561,9 +604,11 @@ pub trait RaylibDrawGui {
         message: &str,
         buttons: &str,
     ) -> i32 {
-        let c_text = CString::new(text).unwrap();
-        let c_message = CString::new(message).unwrap();
-        let c_buttons = CString::new(buttons).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+        let c_message =
+            CString::new(message).expect("message should not contain an internal 0 byte");
+        let c_buttons =
+            CString::new(buttons).expect("buttons should not contain an internal 0 byte");
         unsafe {
             ffi::GuiMessageBox(
                 bounds.into(),
@@ -575,6 +620,7 @@ pub trait RaylibDrawGui {
     }
     /// Text Input Box control, ask for text
     #[inline]
+    #[allow(clippy::too_many_arguments, reason = "all are needed")]
     fn gui_text_input_box(
         &mut self,
         bounds: impl Into<ffi::Rectangle>,
@@ -585,22 +631,30 @@ pub trait RaylibDrawGui {
         text_max_size: i32,
         secret_view_active: &mut bool,
     ) -> i32 {
-        text.reserve(text_max_size as usize);
+        text.reserve(
+            text_max_size
+                .try_into()
+                .expect("text_max_size should not be negative"),
+        );
         // NOTE: method of dealing with null terminated strings copied from imgui(input_widget.rs:289, build func)
         text.push('\0');
         let (ptr, capacity) = (text.as_mut_ptr(), text.capacity());
 
-        let c_title = CString::new(title).unwrap();
-        let c_message = CString::new(message).unwrap();
-        let c_buttons = CString::new(buttons).unwrap();
+        let c_title = CString::new(title).expect("title should not contain an internal 0 byte");
+        let c_message =
+            CString::new(message).expect("message should not contain an internal 0 byte");
+        let c_buttons =
+            CString::new(buttons).expect("buttons should not contain an internal 0 byte");
         let btn_index = unsafe {
             ffi::GuiTextInputBox(
                 bounds.into(),
                 c_title.as_ptr(),
                 c_message.as_ptr(),
                 c_buttons.as_ptr(),
-                ptr as *mut i8,
-                capacity as i32,
+                ptr.cast(),
+                capacity
+                    .try_into()
+                    .expect("capacity should not exceed i32::MAX"),
                 secret_view_active,
             )
         };
@@ -634,17 +688,18 @@ pub trait RaylibDrawGui {
         text: &str,
         color: &mut Color,
     ) -> i32 {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
 
-        let result = unsafe { ffi::GuiColorPicker(bounds.into(), c_text.as_ptr(), &mut *color) };
-        return result;
+        unsafe { ffi::GuiColorPicker(bounds.into(), c_text.as_ptr(), &mut *color) }
     }
-    // Get text with icon id prepended
-    // NOTE: Useful to add icons by name id (enum) instead of
-    // a number that can change between ricon versions
+    /// Get text with icon id prepended
+    ///
+    /// NOTE: Useful to add icons by name id (enum) instead of
+    /// a number that can change between ricon versions
     #[inline]
     fn gui_icon_text(&mut self, icon_id: crate::consts::GuiIconName, text: &str) -> String {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
+        // GuiIconText returns a pointer to a static buffer that can be copied to an owned string, which will not leak memory.
         let buffer = unsafe { ffi::GuiIconText(icon_id as i32, c_text.as_ptr()) };
         if buffer.is_null() {
             let ptr = c_text.as_ptr();
@@ -655,9 +710,7 @@ pub trait RaylibDrawGui {
         }
         let c_str = unsafe { CStr::from_ptr(buffer) };
         let str_slice = c_str.to_str().unwrap_or("");
-        let str_buf = str_slice.to_owned();
-        // THERE IS NO WAY THIS DOESN"T LEEK MEMORY. TODO figure out a way to free this buffer.
-        str_buf
+        str_slice.to_owned()
     }
 
     /// Color Bar Alpha control
@@ -669,7 +722,7 @@ pub trait RaylibDrawGui {
         text: &str,
         alpha: &mut f32,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
 
         unsafe { ffi::GuiColorBarAlpha(bounds.into(), c_text.as_ptr(), alpha) > 0 }
     }
@@ -682,7 +735,7 @@ pub trait RaylibDrawGui {
         text: &str,
         active: &mut i32,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
 
         unsafe { ffi::GuiToggleSlider(bounds.into(), c_text.as_ptr(), active) > 0 }
     }
@@ -690,7 +743,7 @@ pub trait RaylibDrawGui {
     /// Dummy control for placeholders
     #[inline]
     fn gui_dummy_rec(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
 
         unsafe { ffi::GuiDummyRec(bounds.into(), c_text.as_ptr()) > 0 }
     }
@@ -703,17 +756,23 @@ pub trait RaylibDrawGui {
         text: &str,
         value: &mut f32,
     ) -> bool {
-        let c_text = CString::new(text).unwrap();
+        let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
 
         unsafe { ffi::GuiColorBarHue(bounds.into(), c_text.as_ptr(), value) > 0 }
     }
 }
 
+/// Lossy conversion to [`i32`]
 #[diagnostic::on_unimplemented(
     message = "{Self} is not a gui property, or does not implement the GuiProperty trait.",
     note = "As of Raylib 5.5, raygui functions that once took \"property enum as i32\" now just take the enum."
 )]
 pub trait GuiProperty {
+    /// Convert to [`i32`] using the `as` keyword
+    #[allow(
+        clippy::wrong_self_convention,
+        reason = "the 'as_' prefix in this case refers to the `as` keyword"
+    )]
     fn as_i32(self) -> i32;
 }
 

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -428,8 +428,9 @@ pub unsafe trait RaylibDrawGui {
         let buf = unsafe { std::slice::from_raw_parts(buffer.as_ptr(), cap) };
         if let Some(len) = buf.iter().position(|x| *x == b'\0') {
             // `len` is the position of the first `\0` byte in the String
+            let vec = unsafe { buffer.as_mut_vec() };
             unsafe {
-                buffer.as_mut_vec().set_len(len);
+                vec.set_len(len);
             }
         } else {
             // There is no null terminator, the best we can do is to not
@@ -670,8 +671,9 @@ pub unsafe trait RaylibDrawGui {
         let buf = unsafe { std::slice::from_raw_parts(text.as_ptr(), cap) };
         if let Some(len) = buf.iter().position(|x| *x == b'\0') {
             // `len` is the position of the first `\0` byte in the String
+            let vec = unsafe { text.as_mut_vec() };
             unsafe {
-                text.as_mut_vec().set_len(len);
+                vec.set_len(len);
             }
         } else {
             // There is no null terminator, the best we can do is to not

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -13,47 +13,56 @@ impl RaylibHandle {
     pub fn gui_enable(&mut self) {
         unsafe { ffi::GuiEnable() }
     }
+
     /// Disable gui controls (global state)
     #[inline]
     pub fn gui_disable(&mut self) {
         unsafe { ffi::GuiDisable() }
     }
+
     /// Lock gui controls (global state)
     #[inline]
     pub fn gui_lock(&mut self) {
         unsafe { ffi::GuiLock() }
     }
+
     /// Unlock gui controls (global state)
     #[inline]
     pub fn gui_unlock(&mut self) {
         unsafe { ffi::GuiUnlock() }
     }
+
     /// Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
     #[inline]
     pub fn gui_fade(&mut self, color: Color, alpha: f32) -> Color {
         unsafe { ffi::Fade(color, alpha) }
     }
+
     /// Set gui state (global state)
     #[inline]
     pub fn gui_set_state(&mut self, state: crate::consts::GuiState) {
         unsafe { ffi::GuiSetState(state as i32) }
     }
+
     /// Get gui state (global state)
     #[inline]
     pub fn gui_get_state(&mut self) -> crate::consts::GuiState {
         let state = unsafe { ffi::GuiGetState() };
         unsafe { std::mem::transmute(state) }
     }
+
     /// Set gui custom font (global state)
     #[inline]
     pub fn gui_set_font(&mut self, font: impl AsRef<ffi::Font>) {
         unsafe { ffi::GuiSetFont(*font.as_ref()) }
     }
+
     /// Get gui custom font (global state)
     #[inline]
     pub fn gui_get_font(&mut self) -> WeakFont {
         unsafe { WeakFont(ffi::GuiGetFont()) }
     }
+
     /// Set one style property
     #[inline]
     pub fn gui_set_style(
@@ -74,6 +83,7 @@ impl RaylibHandle {
     ) -> i32 {
         unsafe { ffi::GuiGetStyle(control as i32, property.as_i32()) }
     }
+
     /// Load style file (.rgs)
     ///
     /// # Panics
@@ -85,6 +95,7 @@ impl RaylibHandle {
             CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe { ffi::GuiLoadStyle(c_filename.as_ptr()) }
     }
+
     /// Load style default over global style
     #[inline]
     pub fn gui_load_style_default(&mut self) {
@@ -136,16 +147,19 @@ pub unsafe trait RaylibDrawGui {
     fn gui_enable(&mut self) {
         unsafe { ffi::GuiEnable() }
     }
+
     /// Disable gui controls (global state)
     #[inline]
     fn gui_disable(&mut self) {
         unsafe { ffi::GuiDisable() }
     }
+
     /// Lock gui controls (global state)
     #[inline]
     fn gui_lock(&mut self) {
         unsafe { ffi::GuiLock() }
     }
+
     /// Unlock gui controls (global state)
     #[inline]
     fn gui_unlock(&mut self) {
@@ -163,27 +177,32 @@ pub unsafe trait RaylibDrawGui {
     fn gui_fade(&mut self, color: Color, alpha: f32) -> Color {
         unsafe { ffi::Fade(color, alpha) }
     }
+
     /// Set gui state (global state)
     #[inline]
     fn gui_set_state(&mut self, state: crate::consts::GuiState) {
         unsafe { ffi::GuiSetState(state as i32) }
     }
+
     /// Get gui state (global state)
     #[inline]
     fn gui_get_state(&mut self) -> crate::consts::GuiState {
         let state = unsafe { ffi::GuiGetState() };
         unsafe { std::mem::transmute(state) }
     }
+
     /// Set gui custom font (global state)
     #[inline]
     fn gui_set_font(&mut self, font: impl AsRef<ffi::Font>) {
         unsafe { ffi::GuiSetFont(*font.as_ref()) }
     }
+
     /// Get gui custom font (global state)
     #[inline]
     fn gui_get_font(&mut self) -> WeakFont {
         unsafe { WeakFont(ffi::GuiGetFont()) }
     }
+
     /// Set one style property
     #[inline]
     fn gui_set_style(
@@ -207,6 +226,7 @@ pub unsafe trait RaylibDrawGui {
     fn gui_get_style(&self, control: crate::consts::GuiControl, property: impl GuiProperty) -> i32 {
         unsafe { ffi::GuiGetStyle(control as i32, property.as_i32()) }
     }
+
     /// Load style file (.rgs)
     #[inline]
     fn gui_load_style(&mut self, filename: &str) {
@@ -214,29 +234,34 @@ pub unsafe trait RaylibDrawGui {
             CString::new(filename).expect("filename should not contain an internal 0 byte");
         unsafe { ffi::GuiLoadStyle(c_filename.as_ptr()) }
     }
+
     /// Load style default over global style
     #[inline]
     fn gui_load_style_default(&mut self) {
         unsafe { ffi::GuiLoadStyleDefault() }
     }
+
     /// Window Box control, shows a window that can be closed
     #[inline]
     fn gui_window_box(&mut self, bounds: impl Into<ffi::Rectangle>, title: &str) -> bool {
         let c_filename = CString::new(title).expect("title should not contain an internal 0 byte");
         unsafe { ffi::GuiWindowBox(bounds.into(), c_filename.as_ptr()) > 0 }
     }
+
     /// Group Box control with text name
     #[inline]
     fn gui_group_box(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
         let c_filename = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiGroupBox(bounds.into(), c_filename.as_ptr()) > 0 }
     }
+
     /// Line separator control, could contain text
     #[inline]
     fn gui_line(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
         let c_filename = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiLine(bounds.into(), c_filename.as_ptr()) > 0 }
     }
+
     /// Panel control, useful to group controls
     #[inline]
     fn gui_panel(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
@@ -249,6 +274,7 @@ pub unsafe trait RaylibDrawGui {
         };
         unsafe { ffi::GuiPanel(bounds.into(), c_text) > 0 }
     }
+
     /// Scroll Panel control
     #[inline]
     fn gui_scroll_panel(
@@ -273,24 +299,28 @@ pub unsafe trait RaylibDrawGui {
         };
         (result > 0, view, scroll)
     }
+
     /// Label control, shows text
     #[inline]
     fn gui_label(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiLabel(bounds.into(), c_text.as_ptr()) > 0 }
     }
+
     /// Button control, returns true when clicked
     #[inline]
     fn gui_button(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiButton(bounds.into(), c_text.as_ptr()) > 0 }
     }
+
     /// Label button control, show true when clicked
     #[inline]
     fn gui_label_button(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiLabelButton(bounds.into(), c_text.as_ptr()) > 0 }
     }
+
     /// Toggle Button control, returns true when active
     #[inline]
     fn gui_toggle(
@@ -302,6 +332,7 @@ pub unsafe trait RaylibDrawGui {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiToggle(bounds.into(), c_text.as_ptr(), active) > 0 }
     }
+
     /// Toggle Group control, returns active toggle index
     #[inline]
     fn gui_toggle_group(
@@ -313,6 +344,7 @@ pub unsafe trait RaylibDrawGui {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiToggleGroup(bounds.into(), c_text.as_ptr(), active) }
     }
+
     /// Check Box control, returns true when active
     #[inline]
     fn gui_check_box(
@@ -324,6 +356,7 @@ pub unsafe trait RaylibDrawGui {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiCheckBox(bounds.into(), c_text.as_ptr(), checked) > 0 }
     }
+
     /// Combo Box control, returns selected item index
     #[inline]
     fn gui_combo_box(
@@ -335,6 +368,7 @@ pub unsafe trait RaylibDrawGui {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiComboBox(bounds.into(), c_text.as_ptr(), active) }
     }
+
     /// Dropdown Box control, returns selected item
     #[inline]
     fn gui_dropdown_box(
@@ -347,6 +381,7 @@ pub unsafe trait RaylibDrawGui {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiDropdownBox(bounds.into(), c_text.as_ptr(), active, edit_mode) > 0 }
     }
+
     /// Spinner control, returns selected value
     #[inline]
     fn gui_spinner(
@@ -371,6 +406,7 @@ pub unsafe trait RaylibDrawGui {
             ) > 0
         }
     }
+
     /// Value Box control, updates input text with numbers
     #[inline]
     fn gui_value_box(
@@ -394,6 +430,7 @@ pub unsafe trait RaylibDrawGui {
             ) > 0
         }
     }
+
     /// Text Box control, updates input text
     /// Use at your own risk!!! The allocated vector MUST have enough space for edits.
     #[inline]
@@ -465,6 +502,7 @@ pub unsafe trait RaylibDrawGui {
             ) > 0
         }
     }
+
     /// Slider Bar control, returns selected value
     #[inline]
     fn gui_slider_bar(
@@ -491,6 +529,7 @@ pub unsafe trait RaylibDrawGui {
             ) > 0
         }
     }
+
     /// Progress Bar control, shows current progress value
     #[inline]
     fn gui_progress_bar(
@@ -517,6 +556,7 @@ pub unsafe trait RaylibDrawGui {
             ) > 0
         }
     }
+
     /// Status Bar control, shows info text
     #[inline]
     fn gui_status_bar(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
@@ -548,6 +588,7 @@ pub unsafe trait RaylibDrawGui {
             mouse_cell,
         )
     }
+
     /// List View control, returns selected list item index
     #[inline]
     fn gui_list_view(
@@ -560,6 +601,7 @@ pub unsafe trait RaylibDrawGui {
         let c_text = CString::new(text).expect("text should not contain an internal 0 byte");
         unsafe { ffi::GuiListView(bounds.into(), c_text.as_ptr(), scroll_index, active) }
     }
+
     /// List View with extended parameters
     #[inline]
     fn gui_list_view_ex(
@@ -596,6 +638,7 @@ pub unsafe trait RaylibDrawGui {
             )
         }
     }
+
     /// Message Box control, displays a message
     #[inline]
     fn gui_message_box(
@@ -619,6 +662,7 @@ pub unsafe trait RaylibDrawGui {
             )
         }
     }
+
     /// Text Input Box control, ask for text
     #[inline]
     #[allow(clippy::too_many_arguments, reason = "all are needed")]
@@ -694,6 +738,7 @@ pub unsafe trait RaylibDrawGui {
 
         unsafe { ffi::GuiColorPicker(bounds.into(), c_text.as_ptr(), &mut *color) }
     }
+
     /// Get text with icon id prepended
     ///
     /// NOTE: Useful to add icons by name id (enum) instead of


### PR DESCRIPTION
Running clippy in the library is difficult because so much of the library goes against the lints. I have cleaned up almost everything, leaving only the undocumented `unsafe` blocks and missing `# Safety` docs where I genuinely don't know what the safety requirements are. Aside from those, everything has been cleaned up to the linter's taste.