### PR TITLE
Fix compile errors from raylib binding updates (and raylib-test misc deprecated issues)

### DIFF
--- a/raylib-test/Cargo.toml
+++ b/raylib-test/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/raylib-rs/raylib-rs"
 
 [dependencies]
 raylib = { version = "5.7.0", path = "../raylib" }
-raylib_sys = { version = "5.7.0", path = "../raylib-sys" }
+raylib-sys = { version = "5.7.0", path = "../raylib-sys" }
 lazy_static = "1.2.0"
 colored = "1.9.1"
 

--- a/raylib-test/src/automation.rs
+++ b/raylib-test/src/automation.rs
@@ -33,7 +33,7 @@ pub(crate) mod automation_test {
         let mut events = aelist.events();
 
         while !rl.window_should_close() {
-            rl.update_camera(&mut camera, CameraMode::CAMERA_FIRST_PERSON);
+            camera.update_camera(CameraMode::CAMERA_FIRST_PERSON);
 
             if rl.is_key_released(KeyboardKey::KEY_SPACE) {
                 if !is_recording {

--- a/raylib-test/src/callbacks.rs
+++ b/raylib-test/src/callbacks.rs
@@ -101,7 +101,7 @@ pub mod callback_tests {
             let mut handle = TEST_HANDLE.write().unwrap();
             let rl = handle.as_mut().unwrap();
             {
-                rl.set_trace_log_callback(custom_callback).unwrap();
+                set_trace_log_callback(custom_callback).unwrap();
                 for _ in 0..5 {
                     let noise = Image::gen_image_white_noise(10, 10, 1.0);
                     let _ = rl.load_texture_from_image(&thread, &noise).unwrap();
@@ -115,10 +115,8 @@ pub mod callback_tests {
             "\n{}\n",
             "Setting file data saver callback".bold().underline(),
         );
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
         {
-            rl.set_save_file_data_callback(custom_save_file_data_callback)
+            set_save_file_data_callback(custom_save_file_data_callback)
                 .unwrap();
         }
     }
@@ -128,10 +126,8 @@ pub mod callback_tests {
             "\n{}\n",
             "Setting file text saver callback".bold().underline(),
         );
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
         {
-            rl.set_save_file_text_callback(custom_save_file_text_callback)
+            set_save_file_text_callback(custom_save_file_text_callback)
                 .unwrap();
         }
     }
@@ -141,10 +137,8 @@ pub mod callback_tests {
             "\n{}\n",
             "Setting file data loader callback".bold().underline(),
         );
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
         {
-            rl.set_load_file_data_callback(custom_read_file_data_callback)
+            set_load_file_data_callback(custom_read_file_data_callback)
                 .unwrap();
         }
     }

--- a/raylib-test/src/data.rs
+++ b/raylib-test/src/data.rs
@@ -1,14 +1,10 @@
 #[cfg(test)]
 mod data_test {
     use crate::tests::*;
-    use colored::Colorize;
     use raylib::prelude::*;
 
     ray_test!(data_test);
     fn data_test(_: &RaylibThread) {
-        //let mut handle = TEST_HANDLE.write().unwrap();
-        //let rl = handle.as_mut().unwrap();
-
         export_data_as_code(
             "The quick brown fox jumped over the lazy dog.".as_bytes(),
             "./test_out/export_data.txt",
@@ -18,10 +14,37 @@ mod data_test {
     ray_test!(base64);
     fn base64(_: &RaylibThread) {
         let encoded = encode_data_base64("This is a test".as_bytes());
-        let enc: Vec<u8> = encoded.to_vec().iter().map(|f| *f as u8).collect();
-        let decoded = decode_data_base64(&enc);
-
+        let enc: Vec<u8> = encoded.expect("encode ok").to_vec().iter().map(|f| *f as u8).collect();
+        let decoded = decode_data_base64(&enc).expect("decode ok");
         let fin = std::str::from_utf8(&decoded).unwrap();
-        assert!(fin == "This is a test")
+        assert_eq!(fin, "This is a test")
+    }
+
+    ray_test!(base64_encode_and_decode);
+    fn base64_encode_and_decode(_: &RaylibThread) {
+        let encoded = encode_data_base64(b"This is a test").expect("encode ok");
+        let mut enc = encoded.as_ref();
+        if enc.ends_with(&[0]) {
+            enc = &enc[..enc.len() - 1];
+        }
+        let decoded = decode_data_base64(enc).expect("decode ok");
+        assert_eq!(decoded.as_ref(), b"This is a test");
+    }
+
+    ray_test!(base64_decode_plain_str);
+    fn base64_decode_plain_str(_: &RaylibThread) {
+        //non-trailing null
+        let str = b"VGhpcyBpcyBhIHRlc3Q=";
+        let out = decode_data_base64(str).expect("decode plain ok");
+        assert_eq!(out.as_ref(), b"This is a test");
+    }
+
+    ray_test!(base64_decode_with_trailing_null);
+    fn base64_decode_with_trailing_null(_: &RaylibThread) {
+        // trailing null
+        let mut c_str = b"SGVsbG8sIHdvcmxkIQ==".to_vec();
+        c_str.push(0);
+        let out = decode_data_base64(&c_str).expect("decode c-string ok");
+        assert_eq!(out.as_ref(), b"Hello, world!");
     }
 }

--- a/raylib-test/src/image.rs
+++ b/raylib-test/src/image.rs
@@ -32,7 +32,7 @@ mod image_test {
 
             d.draw_texture(&tex, 0, 0, Color::WHITE);
         }
-        rl.take_screenshot(&thread, &format!("test_image_{}.png", name));
+        rl.take_screenshot(&thread, &format!("test_out/test_image_{}.png", name));
         {
             let mut d = rl.begin_drawing(&thread);
 

--- a/raylib-test/src/logging.rs
+++ b/raylib-test/src/logging.rs
@@ -5,10 +5,8 @@ mod test_logging {
 
     ray_test!(test_logs);
     fn test_logs(_: &RaylibThread) {
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
-        rl.set_trace_log(TraceLogLevel::LOG_ALL);
-        rl.trace_log(TraceLogLevel::LOG_DEBUG, "This Is From `test_logs`");
-        rl.set_trace_log(TraceLogLevel::LOG_INFO);
+        set_trace_log(TraceLogLevel::LOG_ALL);
+        trace_log(TraceLogLevel::LOG_DEBUG, "This Is From `test_logs`");
+        set_trace_log(TraceLogLevel::LOG_INFO);
     }
 }

--- a/raylib-test/src/misc.rs
+++ b/raylib-test/src/misc.rs
@@ -6,8 +6,8 @@ mod core_test {
     fn test_screenshot(t: &RaylibThread) {
         let mut handle = TEST_HANDLE.write().unwrap();
         let rl = handle.as_mut().unwrap();
-        rl.take_screenshot(t, "./screenshot.png");
-        assert!(std::path::Path::new("./screenshot.png").exists());
+        rl.take_screenshot(t, "test_out/screenshot.png");
+        assert!(std::path::Path::new("test_out/screenshot.png").exists());
     }
 
     ray_test!(test_screendata);

--- a/raylib-test/src/models.rs
+++ b/raylib-test/src/models.rs
@@ -37,7 +37,7 @@ mod model_test {
         let mesh = unsafe { Mesh::gen_mesh_cube(&thread, 1.0, 1.0, 1.0).make_weak() };
         let model = rl.load_model_from_mesh(&thread, mesh).unwrap();
 
-        let zero = Vector3::zero();
+        let zero = Vector3::ZERO;
 
         let camera = Camera3D::perspective(zero, zero, zero, 10.0);
 

--- a/raylib-test/src/tests.rs
+++ b/raylib-test/src/tests.rs
@@ -156,7 +156,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
         }
 
         // take_screenshot takes the last frames screenshot
-        rl.take_screenshot(&thread, &format!("{}.png", t.name));
+        rl.take_screenshot(&thread, &format!("test_out/{}.png", t.name));
         {
             let mut d = rl.begin_drawing(&thread);
             d.clear_background(Color::WHITE);
@@ -180,7 +180,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
             (t.test)(&mut d, &thread, &assets);
         }
         // take_screenshot takes the last frames screenshot
-        rl.take_screenshot(&thread, &format!("{}.png", t.name));
+        rl.take_screenshot(&thread, &format!("test_out/{}.png", t.name));
         {
             let mut d_ = rl.begin_drawing(&thread);
             let mut d = d_.begin_mode3D(&camera);

--- a/raylib-test/src/text.rs
+++ b/raylib-test/src/text.rs
@@ -27,7 +27,7 @@ mod text_test {
         let f = rl
             .load_font(thread, "resources/alagard.png")
             .expect("couldn't load font");
-        f.export_as_code("test_out/font.h");
+        let _ = f.export_font_as_code("test_out/font.h");
     }
 
     ray_draw_test!(test_default_font);

--- a/raylib-test/src/window.rs
+++ b/raylib-test/src/window.rs
@@ -20,14 +20,14 @@ mod core_test {
         let handle = TEST_HANDLE.read().unwrap();
         let rl = handle.as_ref().unwrap();
         let c = Camera::orthographic(
-            Vector3::zero(),
+            Vector3::ZERO,
             Vector3::new(0.0, 0.0, 1.0),
-            Vector3::up(),
+            Vector3::Y,
             90.0,
         );
-        let _ = rl.get_mouse_ray(Vector2::zero(), &c);
+        let _ = rl.get_screen_to_world_ray(Vector2::ZERO, &c);
         // Should be the middle of the screen
-        let _ = rl.get_world_to_screen(Vector3::zero(), &c);
+        let _ = rl.get_world_to_screen(Vector3::ZERO, &c);
     }
 
     #[test]

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -301,7 +301,7 @@ impl<'aud> Wave<'aud> {
     /// Copies a wave to a new wave.
     #[inline]
     #[must_use]
-    pub(crate) fn copy(&self) -> Wave {
+    pub(crate) fn copy(&'_ self) -> Wave<'_> {
         unsafe { Wave(ffi::WaveCopy(self.0), self.1) }
     }
 

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -112,11 +112,11 @@ extern "C" fn custom_load_file_data_callback(path: *const c_char, size: *mut c_i
     }
 }
 
-extern "C" fn custom_save_file_text_callback(a: *const c_char, b: *mut c_char) -> bool {
+extern "C" fn custom_save_file_text_callback(a: *const c_char, b: *const c_char) -> bool {
     let save_file_text = save_file_text_callback().unwrap();
     let a = unsafe { CStr::from_ptr(a) };
     let b = unsafe { CStr::from_ptr(b) };
-    return save_file_text(a.to_str().unwrap(), b.to_str().unwrap());
+    save_file_text(a.to_str().unwrap(), b.to_str().unwrap())
 }
 extern "C" fn custom_load_file_text_callback(a: *const c_char) -> *mut c_char {
     let load_file_text = load_file_text_callback().unwrap();

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -314,17 +314,17 @@ impl RaylibHandle {
     /// Set custom trace log
     #[deprecated = "Decoupled from RaylibHandle. Use [set_trace_log_callback](core::callbacks::set_trace_log_callback) instead."]
     pub fn set_trace_log_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(TraceLogLevel, &str),
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_trace_log_callback(cb)
     }
     /// Set custom file binary data saver
     #[deprecated = "Decoupled from RaylibHandle. Use [set_save_file_data_callback](core::callbacks::set_save_file_data_callback) instead."]
     pub fn set_save_file_data_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str, &[u8]) -> bool,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_save_file_data_callback(cb)
     }
     /// Set custom file binary data loader
@@ -332,17 +332,17 @@ impl RaylibHandle {
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
     #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_data_callback](core::callbacks::set_load_file_data_callback) instead."]
     pub fn set_load_file_data_callback<'b>(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str) -> Vec<u8>,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_load_file_data_callback(cb)
     }
     /// Set custom file text data saver
     #[deprecated = "Decoupled from RaylibHandle. Use [set_save_file_text_callback](core::callbacks::set_save_file_text_callback) instead."]
     pub fn set_save_file_text_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str, &str) -> bool,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_save_file_text_callback(cb)
     }
     /// Set custom file text data loader
@@ -350,19 +350,19 @@ impl RaylibHandle {
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
     #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_text_callback](core::callbacks::set_load_file_text_callback) instead."]
     pub fn set_load_file_text_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str) -> String,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_load_file_text_callback(cb)
     }
 
     /// Audio thread callback to request new data
     #[deprecated = "Decoupled from RaylibHandle. Use [set_audio_stream_callback](core::callbacks::set_audio_stream_callback) instead."]
     pub fn set_audio_stream_callback(
-        &mut self,
+        &'_ mut self,
         stream: AudioStream,
         cb: fn(&[u8]),
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire) == 0 {
             AUDIO_STREAM_CALLBACK.store(cb as _, Ordering::Release);
             unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -40,12 +40,6 @@ pub fn compress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
 /// let data = decompress_data(input).unwrap();
 /// assert_eq!(data.as_ref(), expected);
 /// ```
-/// ^^^Test executable failed (exit status: 102).
-/// TODO: Perhaps related to upstream issue introduced here:
-///  https://github.com/raysan5/raylib/commit/1777da9056ac84bb7410392e103c6a0964570d67
-///  Ray forgot to sinflate the data0 instead of data (NULL)... in the update, unsure if it was reviewed,
-///  updated on discord, but keeping note here to fix before any PR merge
-
 pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     #[cfg(debug_assertions)]
     println!("{:?}", data.len());

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -4,6 +4,7 @@ use std::{
     mem::MaybeUninit,
     path::Path,
 };
+use crate::error::Base64Error;
 
 /// Compress data (DEFLATE algorithm)
 /// ```rust
@@ -80,53 +81,24 @@ pub fn export_data_as_code(data: &[u8], file_name: impl AsRef<Path>) -> bool {
 }
 
 /// Encode data to Base64 string
-pub fn encode_data_base64(data: &[u8]) -> Vec<c_char> {
-    let mut output_size = 0;
-    let bytes =
-        unsafe { ffi::EncodeDataBase64(data.as_ptr(), data.len() as i32, &mut output_size) };
-
-    let s = unsafe { std::slice::from_raw_parts(bytes, output_size as usize) };
-    if s.contains(&0) {
-        // Work around a bug in Rust's from_raw_parts function
-        let mut keep = true;
-        let b: Vec<c_char> = s
-            .iter()
-            .filter(|f| {
-                if **f == 0 {
-                    keep = false;
-                }
-                keep
-            })
-            .copied()
-            .collect();
-        b
-    } else {
-        s.to_vec()
-    }
+pub fn encode_data_base64(data: &[u8]) -> Result<DataBuf<[u8]>, Base64Error> {
+    let mut output_size = MaybeUninit::<i32>::uninit();
+    let bytes = unsafe { ffi::EncodeDataBase64(data.as_ptr(), data.len() as i32, output_size.as_mut_ptr()) };
+    unsafe { DataBuf::slice_from_raw(bytes as *mut u8, output_size) }
+        .ok_or(Base64Error::EncodeFailed)
 }
 
 /// Decode Base64 data
-pub fn decode_data_base64(data: &[u8]) -> Vec<u8> {
-    let mut output_size = 0;
-
-    let bytes = unsafe { ffi::DecodeDataBase64(data.as_ptr(), &mut output_size) };
-
-    let s = unsafe { std::slice::from_raw_parts(bytes, output_size as usize) };
-    if s.contains(&0) {
-        // Work around a bug in Rust's from_raw_parts function
-        let mut keep = true;
-        let b: Vec<u8> = s
-            .iter()
-            .filter(|f| {
-                if **f == 0 {
-                    keep = false;
-                }
-                keep
-            })
-            .copied()
-            .collect();
-        b
-    } else {
-        s.to_vec()
-    }
+pub fn decode_data_base64(data: &[u8]) -> Result<DataBuf<[u8]>, Base64Error> {
+    let mut output_size = MaybeUninit::<i32>::uninit();
+    let null_trimmed_data = match data.iter().position(|&element| element == 0) {
+        Some(pos) => &data[..pos],
+        None => data,
+    };
+    let mut c_str = Vec::with_capacity(null_trimmed_data.len() + 1);
+    c_str.extend_from_slice(null_trimmed_data);
+    c_str.push(0);
+    let bytes = unsafe { ffi::DecodeDataBase64(c_str.as_ptr() as *const c_char, output_size.as_mut_ptr()) };
+    unsafe { DataBuf::slice_from_raw(bytes, output_size) }
+        .ok_or(Base64Error::DecodeFailed)
 }

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -40,6 +40,12 @@ pub fn compress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
 /// let data = decompress_data(input).unwrap();
 /// assert_eq!(data.as_ref(), expected);
 /// ```
+/// ^^^Test executable failed (exit status: 102).
+/// TODO: Perhaps related to upstream issue introduced here:
+///  https://github.com/raysan5/raylib/commit/1777da9056ac84bb7410392e103c6a0964570d67
+///  Ray forgot to sinflate the data0 instead of data (NULL)... in the update, unsure if it was reviewed,
+///  updated on discord, but keeping note here to fix before any PR merge
+
 pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     #[cfg(debug_assertions)]
     println!("{:?}", data.len());

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -50,7 +50,7 @@ pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle);
 impl<'a> RaylibDrawHandle<'a> {
     #[deprecated = "Calling begin_drawing within RaylibDrawHandle will result in a runtime error."]
     #[doc(hidden)]
-    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle {
+    pub fn begin_drawing(&'_ mut self, _: &RaylibThread) -> RaylibDrawHandle<'_> {
         panic!("Nested begin_drawing call")
     }
     #[deprecated = "Calling draw within RaylibDrawHandle will result in a runtime error."]

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -67,6 +67,14 @@ pub enum CompressionError {
 }
 
 #[derive(Error, Debug)]
+pub enum Base64Error {
+    #[error("could not decode base64 data")]
+    DecodeFailed,
+    #[error("could not encode base64 data")]
+    EncodeFailed,
+}
+
+#[derive(Error, Debug)]
 pub enum LoadModelError {
     #[error("could not load model\npath: {path:?}")]
     LoadFromFileFailed { path: String },

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -250,6 +250,7 @@ impl RaylibHandle {
         chars: Option<&str>,
         sdf: i32,
     ) -> Option<RSliceGlyphInfo> {
+        let mut glyph_count_out: i32 = 0;
         unsafe {
             let ci_arr_ptr = match chars {
                 Some(c) => {
@@ -261,6 +262,7 @@ impl RaylibHandle {
                         co.0.as_mut_ptr(),
                         co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
                         sdf,
+                        &mut glyph_count_out,
                     )
                 }
                 None => ffi::LoadFontData(
@@ -270,6 +272,7 @@ impl RaylibHandle {
                     std::ptr::null_mut(),
                     0,
                     sdf,
+                    &mut glyph_count_out,
                 ),
             };
             let ci_size = if let Some(c) = chars { c.len() } else { 95 }; // raylib assumes 95 if none given


### PR DESCRIPTION
**summary**
this PR catches `raylib-rs` up to upstream raylib changes so `unstable` builds and the tests run again. it’s mostly signature/FFI alignment plus some small test cleanups. no intentional behavior changes beyond matching upstream expectations

## the main two fixes

### 1) `data.rs`
* rewrote **encode/decode** to match new parameter expectations from upstream: https://github.com/raysan5/raylib/commit/d7148f5f9d7a6f091adcc0d6444ef3f2c1040007
* tried to follow the same style Amy used around compression and `DataBuf` usage. it might not be perfect, but i added tests and it behaves how I understand it should
* changed APIs to return `Result<DataBuf<[u8]>, Base64Error>` so callers can tell encode/decode failures apart from empty output (just to follow the compression/decompression functions style)

### 2) `callbacks.rs`
* synced to raylib core typedef changes: 
https://github.com/raysan5/raylib/commit/aa684a33de143b2cb9e63a93ef4db2925a6d7c48
https://github.com/raysan5/raylib/commit/63b988ade906adc7264a8bec8fccec5f47befb55
* specifically: `SaveFileTextCallback` is now `(..., const char *text)`. i updated the rust side to then use `*const c_char`

### 3) `text.rs` / `load_font_data`
* updated to reflect upstream `LoadFontData` change (adds an out-param for the actual glyph count): [https://github.com/raysan5/raylib/commit/29ce5d8aa9d261eba395e24437e08c6bd744616e](https://github.com/raysan5/raylib/commit/29ce5d8aa9d261eba395e24437e08c6bd744616e)
  bindings now pass `&mut glyph_count_out` through to the FFI call.
* **NOTE: NOT SURE IF THERE IS A BETTER/CLEANER WAY TO DO THIS, THIS IS ONLY TO GET THE NEW FFI call SATISFIED**

## misc test fixes (raylib-test)
the `raylib-test` directory wasn’t running (and a bunch of tests were out of date from current bidnings). while updating the `data.rs` tests i fixed the simple deprecations and made the tests at least "runnable" again:

* **Cargo.toml**: `raylib_sys` → `raylib-sys` (this typo was why tests weren’t running from my understanding).
* switched a few method calls to the non-deprecated functions (`set_trace_log_callback`, etc.)
* updated paths so screenshots and artifacts land under `test_out/…` instead of the root directory
* minor API nits to match current crate:
  * `Vector2::zero()`/`Vector3::zero()` → `Vector2::ZERO`/`Vector3::ZERO`.
  * `get_mouse_ray`/`get_world_to_screen` call sites updated to current names.
  * `export_font_as_code` usage in `text.rs` test
  
* added several base64 tests:
  * encode->decode round-trip
  * decoding plain base64 string
  * decoding strings with trailing nulls 

## small lint/clarity cleanups
* silenced the `mismatched_lifetime_syntaxes` warnings by making the elided lifetime explicit where it’s already implied by `&self`:
  * `Wave::copy(&self) -> Wave<'_>`
  * `RaylibDrawHandle::begin_drawing(&mut self, ...) -> RaylibDrawHandle<'_>`
  * deprecated callback setters now return `Result<_, SetLogError<'_>>`
NOTE: I AM NOT SURE IF THIS IS APPROPRIATE STYLE I SEE DIFFERENT PLACES DOING DIFFERENT WAYS
