### PR TITLE
Fixing raw AudioStream callback functionality

### DIFF
--- a/raylib-test/Cargo.toml
+++ b/raylib-test/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/raylib-rs/raylib-rs"
 
 [dependencies]
 raylib = { version = "5.7.0", path = "../raylib" }
-raylib_sys = { version = "5.7.0", path = "../raylib-sys" }
+raylib-sys = { version = "5.7.0", path = "../raylib-sys" }
 lazy_static = "1.2.0"
 colored = "1.9.1"
 

--- a/raylib-test/src/automation.rs
+++ b/raylib-test/src/automation.rs
@@ -33,7 +33,7 @@ pub(crate) mod automation_test {
         let mut events = aelist.events();
 
         while !rl.window_should_close() {
-            rl.update_camera(&mut camera, CameraMode::CAMERA_FIRST_PERSON);
+            camera.update_camera(CameraMode::CAMERA_FIRST_PERSON);
 
             if rl.is_key_released(KeyboardKey::KEY_SPACE) {
                 if !is_recording {

--- a/raylib-test/src/callbacks.rs
+++ b/raylib-test/src/callbacks.rs
@@ -101,7 +101,7 @@ pub mod callback_tests {
             let mut handle = TEST_HANDLE.write().unwrap();
             let rl = handle.as_mut().unwrap();
             {
-                rl.set_trace_log_callback(custom_callback).unwrap();
+                set_trace_log_callback(custom_callback).unwrap();
                 for _ in 0..5 {
                     let noise = Image::gen_image_white_noise(10, 10, 1.0);
                     let _ = rl.load_texture_from_image(&thread, &noise).unwrap();
@@ -115,10 +115,8 @@ pub mod callback_tests {
             "\n{}\n",
             "Setting file data saver callback".bold().underline(),
         );
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
         {
-            rl.set_save_file_data_callback(custom_save_file_data_callback)
+            set_save_file_data_callback(custom_save_file_data_callback)
                 .unwrap();
         }
     }
@@ -128,10 +126,8 @@ pub mod callback_tests {
             "\n{}\n",
             "Setting file text saver callback".bold().underline(),
         );
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
         {
-            rl.set_save_file_text_callback(custom_save_file_text_callback)
+            set_save_file_text_callback(custom_save_file_text_callback)
                 .unwrap();
         }
     }
@@ -141,10 +137,8 @@ pub mod callback_tests {
             "\n{}\n",
             "Setting file data loader callback".bold().underline(),
         );
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
         {
-            rl.set_load_file_data_callback(custom_read_file_data_callback)
+            set_load_file_data_callback(custom_read_file_data_callback)
                 .unwrap();
         }
     }

--- a/raylib-test/src/data.rs
+++ b/raylib-test/src/data.rs
@@ -1,14 +1,10 @@
 #[cfg(test)]
 mod data_test {
     use crate::tests::*;
-    use colored::Colorize;
     use raylib::prelude::*;
 
     ray_test!(data_test);
     fn data_test(_: &RaylibThread) {
-        //let mut handle = TEST_HANDLE.write().unwrap();
-        //let rl = handle.as_mut().unwrap();
-
         export_data_as_code(
             "The quick brown fox jumped over the lazy dog.".as_bytes(),
             "./test_out/export_data.txt",
@@ -18,10 +14,37 @@ mod data_test {
     ray_test!(base64);
     fn base64(_: &RaylibThread) {
         let encoded = encode_data_base64("This is a test".as_bytes());
-        let enc: Vec<u8> = encoded.to_vec().iter().map(|f| *f as u8).collect();
-        let decoded = decode_data_base64(&enc);
-
+        let enc: Vec<u8> = encoded.expect("encode ok").to_vec().iter().map(|f| *f as u8).collect();
+        let decoded = decode_data_base64(&enc).expect("decode ok");
         let fin = std::str::from_utf8(&decoded).unwrap();
-        assert!(fin == "This is a test")
+        assert_eq!(fin, "This is a test")
+    }
+
+    ray_test!(base64_encode_and_decode);
+    fn base64_encode_and_decode(_: &RaylibThread) {
+        let encoded = encode_data_base64(b"This is a test").expect("encode ok");
+        let mut enc = encoded.as_ref();
+        if enc.ends_with(&[0]) {
+            enc = &enc[..enc.len() - 1];
+        }
+        let decoded = decode_data_base64(enc).expect("decode ok");
+        assert_eq!(decoded.as_ref(), b"This is a test");
+    }
+
+    ray_test!(base64_decode_plain_str);
+    fn base64_decode_plain_str(_: &RaylibThread) {
+        //non-trailing null
+        let str = b"VGhpcyBpcyBhIHRlc3Q=";
+        let out = decode_data_base64(str).expect("decode plain ok");
+        assert_eq!(out.as_ref(), b"This is a test");
+    }
+
+    ray_test!(base64_decode_with_trailing_null);
+    fn base64_decode_with_trailing_null(_: &RaylibThread) {
+        // trailing null
+        let mut c_str = b"SGVsbG8sIHdvcmxkIQ==".to_vec();
+        c_str.push(0);
+        let out = decode_data_base64(&c_str).expect("decode c-string ok");
+        assert_eq!(out.as_ref(), b"Hello, world!");
     }
 }

--- a/raylib-test/src/image.rs
+++ b/raylib-test/src/image.rs
@@ -32,7 +32,7 @@ mod image_test {
 
             d.draw_texture(&tex, 0, 0, Color::WHITE);
         }
-        rl.take_screenshot(&thread, &format!("test_image_{}.png", name));
+        rl.take_screenshot(&thread, &format!("test_out/test_image_{}.png", name));
         {
             let mut d = rl.begin_drawing(&thread);
 

--- a/raylib-test/src/logging.rs
+++ b/raylib-test/src/logging.rs
@@ -5,10 +5,8 @@ mod test_logging {
 
     ray_test!(test_logs);
     fn test_logs(_: &RaylibThread) {
-        let mut handle = TEST_HANDLE.write().unwrap();
-        let rl = handle.as_mut().unwrap();
-        rl.set_trace_log(TraceLogLevel::LOG_ALL);
-        rl.trace_log(TraceLogLevel::LOG_DEBUG, "This Is From `test_logs`");
-        rl.set_trace_log(TraceLogLevel::LOG_INFO);
+        set_trace_log(TraceLogLevel::LOG_ALL);
+        trace_log(TraceLogLevel::LOG_DEBUG, "This Is From `test_logs`");
+        set_trace_log(TraceLogLevel::LOG_INFO);
     }
 }

--- a/raylib-test/src/misc.rs
+++ b/raylib-test/src/misc.rs
@@ -6,8 +6,8 @@ mod core_test {
     fn test_screenshot(t: &RaylibThread) {
         let mut handle = TEST_HANDLE.write().unwrap();
         let rl = handle.as_mut().unwrap();
-        rl.take_screenshot(t, "./screenshot.png");
-        assert!(std::path::Path::new("./screenshot.png").exists());
+        rl.take_screenshot(t, "test_out/screenshot.png");
+        assert!(std::path::Path::new("test_out/screenshot.png").exists());
     }
 
     ray_test!(test_screendata);

--- a/raylib-test/src/models.rs
+++ b/raylib-test/src/models.rs
@@ -37,7 +37,7 @@ mod model_test {
         let mesh = unsafe { Mesh::gen_mesh_cube(&thread, 1.0, 1.0, 1.0).make_weak() };
         let model = rl.load_model_from_mesh(&thread, mesh).unwrap();
 
-        let zero = Vector3::zero();
+        let zero = Vector3::ZERO;
 
         let camera = Camera3D::perspective(zero, zero, zero, 10.0);
 

--- a/raylib-test/src/tests.rs
+++ b/raylib-test/src/tests.rs
@@ -156,7 +156,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
         }
 
         // take_screenshot takes the last frames screenshot
-        rl.take_screenshot(&thread, &format!("{}.png", t.name));
+        rl.take_screenshot(&thread, &format!("test_out/{}.png", t.name));
         {
             let mut d = rl.begin_drawing(&thread);
             d.clear_background(Color::WHITE);
@@ -180,7 +180,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
             (t.test)(&mut d, &thread, &assets);
         }
         // take_screenshot takes the last frames screenshot
-        rl.take_screenshot(&thread, &format!("{}.png", t.name));
+        rl.take_screenshot(&thread, &format!("test_out/{}.png", t.name));
         {
             let mut d_ = rl.begin_drawing(&thread);
             let mut d = d_.begin_mode3D(&camera);

--- a/raylib-test/src/text.rs
+++ b/raylib-test/src/text.rs
@@ -27,7 +27,7 @@ mod text_test {
         let f = rl
             .load_font(thread, "resources/alagard.png")
             .expect("couldn't load font");
-        f.export_as_code("test_out/font.h");
+        let _ = f.export_font_as_code("test_out/font.h");
     }
 
     ray_draw_test!(test_default_font);

--- a/raylib-test/src/window.rs
+++ b/raylib-test/src/window.rs
@@ -20,14 +20,14 @@ mod core_test {
         let handle = TEST_HANDLE.read().unwrap();
         let rl = handle.as_ref().unwrap();
         let c = Camera::orthographic(
-            Vector3::zero(),
+            Vector3::ZERO,
             Vector3::new(0.0, 0.0, 1.0),
-            Vector3::up(),
+            Vector3::Y,
             90.0,
         );
-        let _ = rl.get_mouse_ray(Vector2::zero(), &c);
+        let _ = rl.get_screen_to_world_ray(Vector2::ZERO, &c);
         // Should be the middle of the screen
-        let _ = rl.get_world_to_screen(Vector3::zero(), &c);
+        let _ = rl.get_world_to_screen(Vector3::ZERO, &c);
     }
 
     #[test]

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -301,7 +301,7 @@ impl<'aud> Wave<'aud> {
     /// Copies a wave to a new wave.
     #[inline]
     #[must_use]
-    pub(crate) fn copy(&self) -> Wave {
+    pub(crate) fn copy(&'_ self) -> Wave<'_> {
         unsafe { Wave(ffi::WaveCopy(self.0), self.1) }
     }
 

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -112,11 +112,11 @@ extern "C" fn custom_load_file_data_callback(path: *const c_char, size: *mut c_i
     }
 }
 
-extern "C" fn custom_save_file_text_callback(a: *const c_char, b: *mut c_char) -> bool {
+extern "C" fn custom_save_file_text_callback(a: *const c_char, b: *const c_char) -> bool {
     let save_file_text = save_file_text_callback().unwrap();
     let a = unsafe { CStr::from_ptr(a) };
     let b = unsafe { CStr::from_ptr(b) };
-    return save_file_text(a.to_str().unwrap(), b.to_str().unwrap());
+    save_file_text(a.to_str().unwrap(), b.to_str().unwrap())
 }
 extern "C" fn custom_load_file_text_callback(a: *const c_char) -> *mut c_char {
     let load_file_text = load_file_text_callback().unwrap();

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -314,17 +314,17 @@ impl RaylibHandle {
     /// Set custom trace log
     #[deprecated = "Decoupled from RaylibHandle. Use [set_trace_log_callback](core::callbacks::set_trace_log_callback) instead."]
     pub fn set_trace_log_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(TraceLogLevel, &str),
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_trace_log_callback(cb)
     }
     /// Set custom file binary data saver
     #[deprecated = "Decoupled from RaylibHandle. Use [set_save_file_data_callback](core::callbacks::set_save_file_data_callback) instead."]
     pub fn set_save_file_data_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str, &[u8]) -> bool,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_save_file_data_callback(cb)
     }
     /// Set custom file binary data loader
@@ -332,17 +332,17 @@ impl RaylibHandle {
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
     #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_data_callback](core::callbacks::set_load_file_data_callback) instead."]
     pub fn set_load_file_data_callback<'b>(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str) -> Vec<u8>,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_load_file_data_callback(cb)
     }
     /// Set custom file text data saver
     #[deprecated = "Decoupled from RaylibHandle. Use [set_save_file_text_callback](core::callbacks::set_save_file_text_callback) instead."]
     pub fn set_save_file_text_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str, &str) -> bool,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_save_file_text_callback(cb)
     }
     /// Set custom file text data loader
@@ -350,19 +350,19 @@ impl RaylibHandle {
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
     #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_text_callback](core::callbacks::set_load_file_text_callback) instead."]
     pub fn set_load_file_text_callback(
-        &mut self,
+        &'_ mut self,
         cb: fn(&str) -> String,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_load_file_text_callback(cb)
     }
 
     /// Audio thread callback to request new data
     #[deprecated = "Decoupled from RaylibHandle. Use [set_audio_stream_callback](core::callbacks::set_audio_stream_callback) instead."]
     pub fn set_audio_stream_callback(
-        &mut self,
+        &'_ mut self,
         stream: AudioStream,
         cb: fn(&[u8]),
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire) == 0 {
             AUDIO_STREAM_CALLBACK.store(cb as _, Ordering::Release);
             unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -12,6 +12,7 @@ use std::{
     slice::from_raw_parts_mut,
     sync::atomic::{AtomicUsize, Ordering},
 };
+pub mod audio_stream_callback;
 mod stream_processor_with_user_data_wrapper;
 use super::audio::Music;
 use stream_processor_with_user_data_wrapper::*;
@@ -126,6 +127,8 @@ extern "C" fn custom_load_file_text_callback(a: *const c_char) -> *mut c_char {
     oh.as_ptr() as *mut c_char
 }
 
+//TODO: before any merge find out what the status of the deprecated functions are and how to best finalize removing them
+#[deprecated = "use [set_audio_stream_callback](core::callbacks::audio_stream::set_audio_stream_callback) and its trampoline instead."]
 extern "C" fn custom_audio_stream_callback(a: *mut c_void, b: u32) {
     let audio_stream = audio_stream_callback().unwrap();
     let a = unsafe { std::slice::from_raw_parts(a as *mut u8, b as usize) };
@@ -297,17 +300,6 @@ where
     ));
     assert!(stream_processor_callback.callback_index.is_some());
     Box::into_pin(stream_processor_callback)
-}
-
-/// Audio thread callback to request new data
-pub fn set_audio_stream_callback(stream: AudioStream, cb: fn(&[u8])) -> Result<(), SetLogError> {
-    if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire) == 0 {
-        AUDIO_STREAM_CALLBACK.store(cb as _, Ordering::Release);
-        unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }
-        Ok(())
-    } else {
-        Err(SetLogError("audio stream"))
-    }
 }
 
 impl RaylibHandle {

--- a/raylib/src/core/callbacks/audio_stream_callback.rs
+++ b/raylib/src/core/callbacks/audio_stream_callback.rs
@@ -1,0 +1,82 @@
+use crate::audio::{AudioSample, AudioStream};
+use crate::error::UpdateAudioStreamError;
+use crate::ffi;
+use std::os::raw::c_void;
+use std::ptr::null_mut;
+use std::slice::from_raw_parts_mut;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+struct AudioCallbackWrapper {
+    channels: u16,
+    bytes_per_sample: usize,
+    callback_fn: Box<dyn FnMut(&mut [u8]) + Send>,
+}
+
+static AUDIO_STREAM_CALLBACK_SLOT: AtomicPtr<AudioCallbackWrapper> = AtomicPtr::new(null_mut());
+
+/// Audio thread callback to request new data
+pub fn set_audio_stream_callback<T, F>(
+    stream: &AudioStream,
+    cb: F,
+) -> Result<(), UpdateAudioStreamError>
+where
+    T: AudioSample,
+    F: FnMut(&mut [T]) + Send + 'static,
+{
+    if !AUDIO_STREAM_CALLBACK_SLOT.load(Ordering::Acquire).is_null() {
+        return Err(UpdateAudioStreamError::CallbackSlotBusy);
+    }
+    let expected_sample_size =
+        usize::try_from(stream.sample_size()).expect("sampleSize should be 8, 16, or 32");
+    let provided_sample_size_bits = size_of::<T>() * u8::BITS as usize;
+    if provided_sample_size_bits != expected_sample_size {
+        return Err(UpdateAudioStreamError::SampleSizeMismatch {
+            expected: expected_sample_size,
+            provided: provided_sample_size_bits,
+        });
+    }
+    let channels = u16::try_from(stream.channels()).expect("channels should fit in u16");
+    let bytes_per_sample = size_of::<T>();
+    let callback_fn: Box<dyn FnMut(&mut [u8]) + Send> = Box::new({
+        let mut closure_captured = cb;
+        move |bytes: &mut [u8]| {
+            let byte_len = bytes.len() / bytes_per_sample;
+            let buffer_ptr = bytes.as_mut_ptr() as *mut T;
+            let buffer_slice = unsafe { from_raw_parts_mut(buffer_ptr, byte_len) };
+            closure_captured(buffer_slice);
+        }
+    });
+    let callback_wrapper = Box::new(AudioCallbackWrapper {
+        channels,
+        bytes_per_sample,
+        callback_fn,
+    });
+
+    let raw_ptr_for_callback = Box::into_raw(callback_wrapper);
+    AUDIO_STREAM_CALLBACK_SLOT.store(raw_ptr_for_callback, Ordering::Release);
+    unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }
+    Ok(())
+}
+
+pub fn unset_audio_stream_callback(stream: &AudioStream) {
+    unsafe { ffi::SetAudioStreamCallback(stream.0, None) }
+    let raw_ptr_for_callback = AUDIO_STREAM_CALLBACK_SLOT.swap(null_mut(), Ordering::AcqRel);
+    if !raw_ptr_for_callback.is_null() {
+        unsafe {
+            drop(Box::from_raw(raw_ptr_for_callback));
+        }
+    }
+}
+
+extern "C" fn custom_audio_stream_callback(data: *mut c_void, frame_count: u32) {
+    let raw_ptr_to_callback = AUDIO_STREAM_CALLBACK_SLOT.load(Ordering::Acquire);
+    if raw_ptr_to_callback.is_null() {
+        // this should never happen, i imagine there is a more elegant way to make sure...
+        return;
+    }
+    let callback_wrapper = unsafe { &mut *raw_ptr_to_callback };
+    let channels = callback_wrapper.channels as usize;
+    let byte_len = frame_count as usize * channels * callback_wrapper.bytes_per_sample;
+    let buffer_slice = unsafe { from_raw_parts_mut(data as *mut u8, byte_len) };
+    (callback_wrapper.callback_fn)(buffer_slice);
+}

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -40,12 +40,6 @@ pub fn compress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
 /// let data = decompress_data(input).unwrap();
 /// assert_eq!(data.as_ref(), expected);
 /// ```
-/// ^^^Test executable failed (exit status: 102).
-/// TODO: Perhaps related to upstream issue introduced here:
-///  https://github.com/raysan5/raylib/commit/1777da9056ac84bb7410392e103c6a0964570d67
-///  Ray forgot to sinflate the data0 instead of data (NULL)... in the update, unsure if it was reviewed,
-///  updated on discord, but keeping note here to fix before any PR merge
-
 pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     #[cfg(debug_assertions)]
     println!("{:?}", data.len());

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -4,6 +4,7 @@ use std::{
     mem::MaybeUninit,
     path::Path,
 };
+use crate::error::Base64Error;
 
 /// Compress data (DEFLATE algorithm)
 /// ```rust
@@ -80,53 +81,24 @@ pub fn export_data_as_code(data: &[u8], file_name: impl AsRef<Path>) -> bool {
 }
 
 /// Encode data to Base64 string
-pub fn encode_data_base64(data: &[u8]) -> Vec<c_char> {
-    let mut output_size = 0;
-    let bytes =
-        unsafe { ffi::EncodeDataBase64(data.as_ptr(), data.len() as i32, &mut output_size) };
-
-    let s = unsafe { std::slice::from_raw_parts(bytes, output_size as usize) };
-    if s.contains(&0) {
-        // Work around a bug in Rust's from_raw_parts function
-        let mut keep = true;
-        let b: Vec<c_char> = s
-            .iter()
-            .filter(|f| {
-                if **f == 0 {
-                    keep = false;
-                }
-                keep
-            })
-            .copied()
-            .collect();
-        b
-    } else {
-        s.to_vec()
-    }
+pub fn encode_data_base64(data: &[u8]) -> Result<DataBuf<[u8]>, Base64Error> {
+    let mut output_size = MaybeUninit::<i32>::uninit();
+    let bytes = unsafe { ffi::EncodeDataBase64(data.as_ptr(), data.len() as i32, output_size.as_mut_ptr()) };
+    unsafe { DataBuf::slice_from_raw(bytes as *mut u8, output_size) }
+        .ok_or(Base64Error::EncodeFailed)
 }
 
 /// Decode Base64 data
-pub fn decode_data_base64(data: &[u8]) -> Vec<u8> {
-    let mut output_size = 0;
-
-    let bytes = unsafe { ffi::DecodeDataBase64(data.as_ptr(), &mut output_size) };
-
-    let s = unsafe { std::slice::from_raw_parts(bytes, output_size as usize) };
-    if s.contains(&0) {
-        // Work around a bug in Rust's from_raw_parts function
-        let mut keep = true;
-        let b: Vec<u8> = s
-            .iter()
-            .filter(|f| {
-                if **f == 0 {
-                    keep = false;
-                }
-                keep
-            })
-            .copied()
-            .collect();
-        b
-    } else {
-        s.to_vec()
-    }
+pub fn decode_data_base64(data: &[u8]) -> Result<DataBuf<[u8]>, Base64Error> {
+    let mut output_size = MaybeUninit::<i32>::uninit();
+    let null_trimmed_data = match data.iter().position(|&element| element == 0) {
+        Some(pos) => &data[..pos],
+        None => data,
+    };
+    let mut c_str = Vec::with_capacity(null_trimmed_data.len() + 1);
+    c_str.extend_from_slice(null_trimmed_data);
+    c_str.push(0);
+    let bytes = unsafe { ffi::DecodeDataBase64(c_str.as_ptr() as *const c_char, output_size.as_mut_ptr()) };
+    unsafe { DataBuf::slice_from_raw(bytes, output_size) }
+        .ok_or(Base64Error::DecodeFailed)
 }

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -40,6 +40,12 @@ pub fn compress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
 /// let data = decompress_data(input).unwrap();
 /// assert_eq!(data.as_ref(), expected);
 /// ```
+/// ^^^Test executable failed (exit status: 102).
+/// TODO: Perhaps related to upstream issue introduced here:
+///  https://github.com/raysan5/raylib/commit/1777da9056ac84bb7410392e103c6a0964570d67
+///  Ray forgot to sinflate the data0 instead of data (NULL)... in the update, unsure if it was reviewed,
+///  updated on discord, but keeping note here to fix before any PR merge
+
 pub fn decompress_data(data: &[u8]) -> Result<DataBuf<[u8]>, CompressionError> {
     #[cfg(debug_assertions)]
     println!("{:?}", data.len());

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -50,7 +50,7 @@ pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle);
 impl<'a> RaylibDrawHandle<'a> {
     #[deprecated = "Calling begin_drawing within RaylibDrawHandle will result in a runtime error."]
     #[doc(hidden)]
-    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle {
+    pub fn begin_drawing(&'_ mut self, _: &RaylibThread) -> RaylibDrawHandle<'_> {
         panic!("Nested begin_drawing call")
     }
     #[deprecated = "Calling draw within RaylibDrawHandle will result in a runtime error."]

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -67,6 +67,14 @@ pub enum CompressionError {
 }
 
 #[derive(Error, Debug)]
+pub enum Base64Error {
+    #[error("could not decode base64 data")]
+    DecodeFailed,
+    #[error("could not encode base64 data")]
+    EncodeFailed,
+}
+
+#[derive(Error, Debug)]
 pub enum LoadModelError {
     #[error("could not load model\npath: {path:?}")]
     LoadFromFileFailed { path: String },

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -44,6 +44,8 @@ pub enum UpdateAudioStreamError {
     SampleSizeMismatch { expected: usize, provided: usize },
     #[error("Attempting to write too many frames to buffer: provided {provided}, max {max}")]
     TooManyFrames { max: usize, provided: usize },
+    #[error("AudioStream's callback slot is already in use; call unset_audio_stream_callback() to clear it")]
+    CallbackSlotBusy
 }
 
 #[derive(Error, Debug)]

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -250,6 +250,7 @@ impl RaylibHandle {
         chars: Option<&str>,
         sdf: i32,
     ) -> Option<RSliceGlyphInfo> {
+        let mut glyph_count_out: i32 = 0;
         unsafe {
             let ci_arr_ptr = match chars {
                 Some(c) => {
@@ -261,6 +262,7 @@ impl RaylibHandle {
                         co.0.as_mut_ptr(),
                         co.0.len().try_into().expect(TOO_MANY_CODEPOINTS),
                         sdf,
+                        &mut glyph_count_out,
                     )
                 }
                 None => ffi::LoadFontData(
@@ -270,6 +272,7 @@ impl RaylibHandle {
                     std::ptr::null_mut(),
                     0,
                     sdf,
+                    &mut glyph_count_out,
                 ),
             };
             let ci_size = if let Some(c) = chars { c.len() } else { 95 }; // raylib assumes 95 if none given

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -116,3 +116,7 @@ path = "snake.rs"
 [[bin]]
 name = "audio_raw_stream"
 path = "./audio_raw_stream.rs"
+
+[[bin]]
+name = "audio_raw_stream_callback"
+path = "./audio_raw_stream_callback.rs"

--- a/samples/audio_raw_stream_callback.rs
+++ b/samples/audio_raw_stream_callback.rs
@@ -1,0 +1,209 @@
+use raylib::callbacks::audio_stream_callback::{
+    set_audio_stream_callback, unset_audio_stream_callback,
+};
+use raylib::error::UpdateAudioStreamError;
+use raylib::prelude::glam::vec2;
+use raylib::prelude::MouseButton::MOUSE_BUTTON_LEFT;
+use raylib::prelude::*;
+use std::f32::consts::PI;
+use std::sync::{Arc, Mutex};
+
+const MAX_SAMPLES: usize = 512;
+const MAX_SAMPLES_PER_UPDATE: i32 = 4096;
+
+const SAMPLE_RATE: u32 = 44100;
+const SAMPLE_RATE_HALVED: f32 = 22050.0;
+
+struct PCMData {
+    frequency: f32,
+    audio_frequency: f32,
+    old_frequency: f32,
+    sine_idx: f32,
+}
+
+fn audio_callback_16_mono(samples: &mut [i16], cb_data: &Arc<Mutex<PCMData>>) {
+    let mut data = cb_data.lock().unwrap();
+    data.audio_frequency = data.frequency + (data.audio_frequency - data.frequency) * 0.95;
+    let incr = data.audio_frequency / SAMPLE_RATE as f32;
+    for sample in samples.iter_mut() {
+        let v = 32000.0 * (2.0 * PI * data.sine_idx).sin();
+        *sample = v as i16;
+        data.sine_idx += incr;
+        if data.sine_idx > 1.0 {
+            data.sine_idx -= 1.0;
+        }
+    }
+}
+
+fn audio_callback_16_stereo(samples: &mut [i16], cb_data: &Arc<Mutex<PCMData>>) {
+    let mut data = cb_data.lock().unwrap();
+    data.audio_frequency = data.frequency + (data.audio_frequency - data.frequency) * 0.95;
+    let incr = data.audio_frequency / SAMPLE_RATE as f32;
+    for frame in samples.chunks_exact_mut(2) {
+        let sample = ((2.0 * PI * data.sine_idx).sin() * 32000.0) as i16;
+        frame[0] = sample;
+        frame[1] = sample;
+        data.sine_idx += incr;
+        if data.sine_idx > 1.0 {
+            data.sine_idx -= 1.0;
+        }
+    }
+}
+
+fn audio_callback_8_mono(samples: &mut [u8], cb_data: &Arc<Mutex<PCMData>>) {
+    let mut data = cb_data.lock().unwrap();
+    data.audio_frequency = data.frequency + (data.audio_frequency - data.frequency) * 0.95;
+    let incr = data.audio_frequency / SAMPLE_RATE as f32;
+    for sample in samples.iter_mut() {
+        let x = (2.0 * PI * data.sine_idx).sin();
+        let v = (x * 127.0 + 128.0).clamp(0.0, 255.0);
+        *sample = v as u8;
+        data.sine_idx += incr;
+        if data.sine_idx > 1.0 {
+            data.sine_idx -= 1.0;
+        }
+    }
+}
+
+fn audio_callback_32_mono(samples: &mut [f32], cb_data: &Arc<Mutex<PCMData>>) {
+    let mut data = cb_data.lock().unwrap();
+    data.audio_frequency = data.frequency + (data.audio_frequency - data.frequency) * 0.95;
+    let incr = data.audio_frequency / SAMPLE_RATE as f32;
+    for sample in samples.iter_mut() {
+        *sample = (2.0 * PI * data.sine_idx).sin();
+        data.sine_idx += incr;
+        if data.sine_idx > 1.0 {
+            data.sine_idx -= 1.0;
+        }
+    }
+}
+
+fn main() {
+
+    let screen_width = 800;
+    let screen_height = 450;
+
+    let (mut raylib_handle, raylib_thread) = init()
+        .size(screen_width, screen_height)
+        .title("raylib [audio] example - raw audio streaming")
+        .build();
+
+    raylib_handle.set_target_fps(30);
+
+    let raylib_audio = RaylibAudio::init_audio_device().unwrap();
+
+    error_cases_detour_test(&raylib_audio);  // run the Error handling cases
+
+    raylib_audio.set_audio_stream_buffer_size_default(MAX_SAMPLES_PER_UPDATE);
+
+    let pcm_data_state = Arc::new(Mutex::new(PCMData {
+        frequency: 440.0,
+        audio_frequency: 440.0,
+        old_frequency: 1.0,
+        sine_idx: 0.0,
+    }));
+    let cb_data = Arc::clone(&pcm_data_state);
+    // TODO: may be more appropriate to move copy pasted test config patterns to the raylib-test location
+    // let stream = raylib_audio.new_audio_stream(SAMPLE_RATE, 16, 1);
+    let stream = raylib_audio.new_audio_stream(SAMPLE_RATE, 16, 2);
+    // let stream = raylib_audio.new_audio_stream(SAMPLE_RATE, 8, 1);
+    // let stream = raylib_audio.new_audio_stream(SAMPLE_RATE, 32, 1);
+    set_audio_stream_callback(&stream, move |buffer| {
+        // audio_callback_16_mono(buffer, &cb_data);
+        audio_callback_16_stereo(buffer, &cb_data);
+        // audio_callback_8_mono(buffer, &cb_data);
+        // audio_callback_32_mono(buffer, &cb_data);
+    })
+    .unwrap();
+    let mut data: [i16; MAX_SAMPLES] = [0; MAX_SAMPLES];
+    stream.play();
+    let mut position = vec2(0.0, 0.0);
+    while !raylib_handle.window_should_close() {
+        let mouse_position = raylib_handle.get_mouse_position();
+        if raylib_handle.is_mouse_button_down(MOUSE_BUTTON_LEFT) {
+            pcm_data_state.lock().unwrap().frequency = 40.0 + mouse_position.y;
+            let invert_mouse_x_position = -1.0;
+            let pan = invert_mouse_x_position * mouse_position.x / screen_width as f32;
+            stream.set_pan(pan);
+        }
+        {
+            let mut pcm_data = pcm_data_state.lock().unwrap();
+            if pcm_data.frequency != pcm_data.old_frequency {
+                let mut wave_length = (SAMPLE_RATE_HALVED / pcm_data.frequency) as usize;
+                if wave_length > MAX_SAMPLES / 2 {
+                    wave_length = MAX_SAMPLES / 2;
+                }
+                if wave_length < 1 {
+                    wave_length = 1;
+                }
+                for i in 0..wave_length * 2 {
+                    data[i] = ((2.0 * PI * i as f32 / wave_length as f32).sin()
+                        * 32000f32) as i16;
+                }
+                for j in wave_length * 2..MAX_SAMPLES {
+                    data[j] = 0;
+                }
+                pcm_data.old_frequency = pcm_data.frequency;
+            }
+        }
+        let mut draw_handle = raylib_handle.begin_drawing(&raylib_thread);
+        draw_handle.clear_background(Color::RAYWHITE);
+
+        {
+            let st = pcm_data_state.lock().unwrap();
+            draw_handle.draw_text(
+                &format!("sine frequency: {}", st.frequency as i32),
+                screen_width - 220,
+                10,
+                20,
+                Color::RED,
+            );
+        }
+
+        draw_handle.draw_text(
+            "click mouse button to change frequency or pan",
+            10,
+            10,
+            20,
+            Color::DARKGRAY,
+        );
+
+        for i in 0..screen_width {
+            position.x = i as f32;
+            position.y = 250.0
+                + 50.0 * data[i as usize * MAX_SAMPLES / screen_width as usize] as f32 / 32000f32;
+            draw_handle.draw_pixel_v(position, Color::RED);
+        }
+    }
+}
+
+fn error_cases_detour_test(audio: &RaylibAudio) {
+    // 1) mismatched format: 16-bit stream + f32 callback -> SampleSizeMismatch
+    let stream_mismatch = audio.new_audio_stream(SAMPLE_RATE, 16, 1);
+    type Not16Bit = f32;
+    let mismatch_result =
+        set_audio_stream_callback::<Not16Bit, _>(&stream_mismatch, |_buf: &mut [Not16Bit]| {});
+    println!("mismatch types (16-bit stream =/= Not16Bit callback): {mismatch_result:?}");
+    assert!(matches!(
+        mismatch_result,
+        Err(UpdateAudioStreamError::SampleSizeMismatch { .. })
+    ));
+
+    // 2) successful registration: 16-bit stream + i16 callback → Ok and callback slot becomes busy
+    let stream = audio.new_audio_stream(SAMPLE_RATE, 16, 1);
+    let result = set_audio_stream_callback::<i16, _>(&stream, |_buf: &mut [i16]| {});
+    println!("normal callback registration (16-bit + i16): {result:?}");
+    assert!(result.is_ok());
+
+    // 3) second registration while busy -> CallbackSlotBusy
+    let stream_busy = audio.new_audio_stream(SAMPLE_RATE, 16, 1);
+    let busy_result = set_audio_stream_callback::<i16, _>(&stream_busy, |_buf: &mut [i16]| {});
+    println!("registration attempt while busy: {busy_result:?}");
+    assert!(matches!(
+        busy_result,
+        Err(UpdateAudioStreamError::CallbackSlotBusy)
+    ));
+
+    // 4) cleanup
+    unset_audio_stream_callback(&stream);
+}


### PR DESCRIPTION
note: i am having trouble with raylib core version pinning stuff to avoid the errors that are being solved in: https://github.com/raylib-rs/raylib-rs/pull/231 so i had to stack #231's changes into this PR, but the only important changes in this PR are for AudioStream, i.e. https://github.com/raylib-rs/raylib-rs/pull/233/commits/8419a136462c12340bbd8570fcb95b6df74d25f1 <-  this commit alone is what this PR is related to.

**SUMMARY**

I have added fixes to the `set_audio_stream_callback` function to now allow for:

- closures (partially inspired by the music calback implementation https://github.com/raylib-rs/raylib-rs/blob/unstable/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs)
- `AudioSample` type checks (`u8`, `i16`, `f32`) and mono vs stereo configuration support
- `sampleSize` bit length checks (similar to how it was implemented in: https://github.com/raylib-rs/raylib-rs/blob/unstable/raylib/src/core/audio.rs#L431


**TESTS**
https://github.com/meisei4/raylib-rs/blob/audio_raw_stream_callback_functions/samples/audio_raw_stream_callback.rs
- covers behavior from raylib core example: https://github.com/raysan5/raylib/blob/master/examples/audio/audio_raw_stream.c (the uncommented out part)
- -covers alternative audio stream sampling configurations
- covers some error cases with bad usage (sampling configuration mismatches, callback slot state)

I will also perhaps be investigating the remaining inconsistencies in the two other `AudioStream` types (`Music` and `Sound`), where raw `AudioStream` now allows for a good range of sampling configurations (24-bit is out of scope, but could be added i feel like, would have to investigate), and thus those practices in raw `AudioStream` can be reflected in `Music` and `Sound` now (e.g. `Sound` still hard codes 32-bit sample size)


