### PR TITLE
Port raylib-sys to work with #![no_std] environments.

### DIFF
--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -23,7 +23,8 @@ bindgen = "0.71"
 [features]
 # default features follow the cmake version: https://github.com/raysan5/raylib/wiki/CMake-Build-Options
 # NOTE: some are critical, e.g: SUPPORT_STANDARD_FILEIO should always be turned on because many things like `LoadShader()` uses it to read text
-default = [
+default = ["std", "default_cmake_build_options"]
+default_cmake_build_options = [
   "GLFW_BUILD_X11",
   "USE_AUDIO",
   "SUPPORT_MODULE_RSHAPES",
@@ -71,6 +72,7 @@ default = [
   "SUPPORT_STANDARD_FILEIO",
   "SUPPORT_TRACELOG",
 ]
+std = []
 serde = ["dep:serde", "mint/serde"]
 raygui = []
 # Do not autogenerate bindings, instead read an existing one specified by env RAYLIB_BINDGEN_LOCATION

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -292,6 +292,7 @@ fn gen_bindings() {
     }
     let mut builder = bindgen::Builder::default()
         .header(header)
+        .use_core()
         .rustified_enum(".+")
         .derive_partialeq(true)
         .derive_default(true)

--- a/raylib-sys/src/color.rs
+++ b/raylib-sys/src/color.rs
@@ -51,7 +51,7 @@ impl From<(u8, u8, u8, u8)> for Color {
 
 impl Color {
     /// produces Color from a hex string(6 characters long)
-    pub fn from_hex(color_hex_str: &str) -> Result<Color, std::num::ParseIntError> {
+    pub fn from_hex(color_hex_str: &str) -> Result<Color, core::num::ParseIntError> {
         let color = i32::from_str_radix(color_hex_str, 16)?;
         let b = color % 0x100;
         let g = (color - b) / 0x100 % 0x100;

--- a/raylib-sys/src/lib.rs
+++ b/raylib-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
On some systems the rust standard library has not been ported yet.
I have patched build.rs and color.rs to use the core instead of std, since core is a subset of std, it should not change things.
In Cargo.toml I have created a 'std' feature that is on by default.
According to https://github.com/rust-lang/cargo/issues/3126 there is currently no way to disable a single feature from the default features, thus I have moved the old defaults into a new 'default_cmake_build_options'