### PR TITLE
Fix RaylibHandle::get_window_state

### DIFF
--- a/raylib-test/src/misc.rs
+++ b/raylib-test/src/misc.rs
@@ -6,8 +6,8 @@ mod core_test {
     fn test_screenshot(t: &RaylibThread) {
         let mut handle = TEST_HANDLE.write().unwrap();
         let rl = handle.as_mut().unwrap();
-        rl.take_screenshot(t, "test_out/screenshot.png");
-        assert!(std::path::Path::new("test_out/screenshot.png").exists());
+        rl.take_screenshot(t, "screenshot.png");
+        assert!(std::path::Path::new("screenshot.png").exists());
     }
 
     ray_test!(test_screendata);

--- a/raylib-test/src/window.rs
+++ b/raylib-test/src/window.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod core_test {
-
     use crate::tests::*;
     use raylib::camera::*;
     use raylib::math::*;
@@ -105,5 +104,30 @@ mod core_test {
         rl.disable_cursor();
         rl.enable_cursor();
         rl.enable_cursor();
+    }
+
+    #[test]
+    #[ignore] // todo: Updating MSAA and Interlaced Hint fails after window is already initialized. test_window_ops also crashes (on macOS) after raylib -> glfw -> objc platform code
+    fn test_get_window_state() {
+        let mut handle = TEST_HANDLE.write().unwrap();
+        let rl = handle.as_mut().unwrap();
+
+        assert!(!rl.get_window_state().msaa());
+
+        let with_interlaced_hint = rl.get_window_state().set_interlaced_hint(true);
+        rl.set_window_state(with_interlaced_hint);
+        rl.set_window_state(with_interlaced_hint);
+        assert!(rl.get_window_state().interlaced_hint());
+
+        let with_msaa = rl.get_window_state().set_msaa(true);
+        rl.set_window_state(with_msaa);
+        rl.set_window_state(with_msaa);
+        assert!(rl.get_window_state().msaa());
+        assert!(rl.get_window_state().interlaced_hint());
+
+        let without_msaa = rl.get_window_state().set_msaa(false);
+        rl.set_window_state(without_msaa);
+        rl.set_window_state(without_msaa);
+        assert!(!rl.get_window_state().msaa());
     }
 }

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -667,50 +667,49 @@ impl RaylibHandle {
     /// Get the window config state
     #[must_use]
     pub fn get_window_state(&self) -> WindowState {
-        let state = WindowState::default();
+        let mut state = WindowState::default();
         unsafe {
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_VSYNC_HINT as u32) {
-                state.set_vsync_hint(true);
+                state = state.set_vsync_hint(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as u32) {
-                state.set_fullscreen_mode(true);
+                state = state.set_fullscreen_mode(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as u32) {
-                state.set_window_resizable(true);
+                state = state.set_window_resizable(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as u32) {
-                state.set_window_undecorated(true);
+                state = state.set_window_undecorated(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as u32) {
-                state.set_window_hidden(true);
+                state = state.set_window_hidden(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as u32) {
-                state.set_window_minimized(true);
+                state = state.set_window_minimized(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as u32) {
-                state.set_window_maximized(true);
+                state = state.set_window_maximized(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as u32) {
-                state.set_window_unfocused(true);
+                state = state.set_window_unfocused(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as u32) {
-                state.set_window_topmost(true);
+                state = state.set_window_topmost(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as u32) {
-                state.set_window_always_run(true);
+                state = state.set_window_always_run(true);
             }
-
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as u32) {
-                state.set_window_transparent(true);
+                state = state.set_window_transparent(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as u32) {
-                state.set_window_highdpi(true);
+                state = state.set_window_highdpi(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_MSAA_4X_HINT as u32) {
-                state.set_msaa(true);
+                state = state.set_msaa(true);
             }
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_INTERLACED_HINT as u32) {
-                state.set_interlaced_hint(true);
+                state = state.set_interlaced_hint(true);
             }
         }
         state

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -30,6 +30,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_VSYNC_HINT as i32) != 0
     }
     /// Set to try enabling V-Sync on GPU
+    #[must_use]
     pub const fn set_vsync_hint(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -46,6 +47,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_FULLSCREEN_MODE as i32) != 0
     }
     /// Set to run program in fullscreen
+    #[must_use]
     pub const fn set_fullscreen_mode(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -62,6 +64,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_RESIZABLE as i32) != 0
     }
     /// Set to allow resizable window
+    #[must_use]
     pub const fn set_window_resizable(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -78,6 +81,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNDECORATED as i32) != 0
     }
     /// Set to disable window decoration (frame and buttons)
+    #[must_use]
     pub const fn set_window_undecorated(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -94,6 +98,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIDDEN as i32) != 0
     }
     /// Set to hide window
+    #[must_use]
     pub const fn set_window_hidden(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -110,6 +115,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MINIMIZED as i32) != 0
     }
     /// Set to minimize window (iconify)
+    #[must_use]
     pub const fn set_window_minimized(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -126,6 +132,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_MAXIMIZED as i32) != 0
     }
     /// Set to maximize window (expanded to monitor)
+    #[must_use]
     pub const fn set_window_maximized(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -142,6 +149,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_UNFOCUSED as i32) != 0
     }
     /// Set to window non focused
+    #[must_use]
     pub const fn set_window_unfocused(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -158,6 +166,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TOPMOST as i32) != 0
     }
     /// Set to window always on top
+    #[must_use]
     pub const fn set_window_topmost(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -174,6 +183,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_ALWAYS_RUN as i32) != 0
     }
     /// Set to allow windows running while minimized
+    #[must_use]
     pub const fn set_window_always_run(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -190,6 +200,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_TRANSPARENT as i32) != 0
     }
     /// Set to allow transparent framebuffer
+    #[must_use]
     pub const fn set_window_transparent(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -206,6 +217,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_WINDOW_HIGHDPI as i32) != 0
     }
     /// Set to support HighDPI
+    #[must_use]
     pub const fn set_window_highdpi(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -222,6 +234,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_MSAA_4X_HINT as i32) != 0
     }
     /// Set to try enabling MSAA 4X
+    #[must_use]
     pub const fn set_msaa(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit
@@ -238,6 +251,7 @@ impl WindowState {
         self.0 & (ffi::ConfigFlags::FLAG_INTERLACED_HINT as i32) != 0
     }
     /// Set to try enabling interlaced video format (for V3D)
+    #[must_use]
     pub const fn set_interlaced_hint(mut self, enabled: bool) -> Self {
         if enabled {
             // set the bit


### PR DESCRIPTION
`RaylibHandle::get_window_state` always returns `WindowState::default()`. Since `WindowState` implements `Copy`, the `mut self` parameter to the setters are a clone of the receiver, so the return value must be reassigned to the accumulator. I added `#[must_use]` onto these setters to mitigate this issue in the future.

I tried modifying `test_window_ops` but realized it's ignored and crashes when GLFW invokes macOS's platform code to hide the window (not sure why).

I tried adding a `test_get_window_state` test (which is present in this PR), but since msaa/interlaced hints cannot be set after the window is initialized, the underlying Raylib state is not actually updated by `set_window_state`. I couldn't easily find a way to run a test inside the `raylib-test` crate without running the `test_runner`. Should I just add the test to the `raylib` crate instead?

On a separate note, without any modifications, `test_screenshot` fails because the "test_out/" part of the path is being stripped out by Raylib. From `rcore.c`:
```c
// Takes a screenshot of current screen
// NOTE: Provided fileName should not contain paths, saving to working directory
void TakeScreenshot(const char *fileName)
```

For extra context, the following code prints
```
MSAA enabled1: false
MSAA enabled2: true
```
<img width="847" height="327" alt="Screenshot 2025-10-22 at 1 28 49 AM" src="https://github.com/user-attachments/assets/8dc2e52c-02da-4175-b787-c8836826e415" />