### PR TITLE
Fix module doc comment in `logging.rs`

### DIFF
--- a/raylib/src/core/logging.rs
+++ b/raylib/src/core/logging.rs
@@ -1,4 +1,4 @@
-///! Functions to change the behavior of raylib logging.
+//! Functions to change the behavior of raylib logging.
 // TODO: refactor this entire thing to use log
 use crate::consts::TraceLogLevel;
 use crate::ffi;


### PR DESCRIPTION
`///!` creates a doc comment on the next item, starting with "!". This is likely unwanted. The correct syntax for a module doc comment is `//!`.