### PR TITLE
Add links setting to raylib-sys and export include path

### DIFF
--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bindings", "raylib", "gamedev", "ffi"]
 categories = ["external-ffi-bindings"]
 edition = "2024"
 exclude = ["raylib/examples/*", "raylib/projects/*", "raylib/templates/*"]
+links = "raylib"
 
 [dependencies]
 mint = { version = "0.5" }

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -329,6 +329,9 @@ fn gen_bindings() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    // export include path information for dependent crates
+    println!("cargo::metadata=include={}/include", out_path.display())
 }
 
 fn gen_rgui() {


### PR DESCRIPTION
The [links key in the package-section of Cargo.toml](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) allows sys-crates to export relevant information to dependent crates. One relevant example of this in action is the [libz-sys crate](https://github.com/rust-lang/libz-sys/blob/8eb6f9e8f45cef71f8a3fa94d849ac54a263c090/build.rs#L94) ([the Cargo.toml file](https://github.com/rust-lang/libz-sys/blob/8eb6f9e8f45cef71f8a3fa94d849ac54a263c090/Cargo.toml#L6) shows the links setting) and [its usage in libpng-sys](https://github.com/kornelski/rust-libpng-sys/blob/065b1b2a292a9bad613c2044e3357d6f46c8b77e/build.rs#L98). 


There are many Raylib C utility libraries out there, and having a setting like this would simplify the setup in the `build.rs` file when making Rust sys-crate versions. Instead of fiddling with our own includes, we can simply do this:
```rust
    // include directory from raylib-sys crate
    let raylib_include = &std::env::var("DEP_RAYLIB_INCLUDE").unwrap();
    build.include(raylib_include);
```
(the unwrapping could have better error handling, but this example is only for showing a point!)

It also fixes the problem of conflicting header versions, as dependent libraries uses the same header versions as the raylib-sys crate. A nice first step in making our raylib-rs compatible crates for Raylib C util libraries.


Feel free to close this PR if you don't want it, or otherwise don't find it useful. I thought it made my life simpler when experimenting locally with a dependent crate :smile_cat: 