### PR TITLE
Build/nix shell for x11

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ pkgs.mkShell {
     xorg.libXinerama
     xorg.libXcursor
     xorg.libXi
+    libGL
     # Web support (uncomment to enable) -- Untested - @JamesKEbert
     # emscripten
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 pkgs.mkShell {
   packages = with pkgs; [
     rustup
@@ -6,16 +6,18 @@ pkgs.mkShell {
     cmake
     clang
     wayland
-    # Web support (uncomment to enable) -- Untested - @JamesKEbert
-    # emscripten
-  ];
-  
-  LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
-    libGL
+    libx11
     xorg.libXrandr
     xorg.libXinerama
     xorg.libXcursor
     xorg.libXi
+    # Web support (uncomment to enable) -- Untested - @JamesKEbert
+    # emscripten
+  ];
+
+  LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
+    libGL
   ];
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 }
+


### PR DESCRIPTION
Fixes https://github.com/raylib-rs/raylib-rs/issues/288

I added the `libx11` package. I also added the packages used in the `LD_LIBRARY_PATH` env var for the development shell to be more complete. This makes it possible to remove some of the librairies from the `LD_LIBRARY_PATH`. libGL is still needed tho

I tested using `cargo test`, `cargo test --doc` and running some of the samples! Let me know if you have any questions