### PR TITLE
DRAFT: feat: expose gui_load_style_from_memory()

### DIFF
--- a/raylib-sys/binding/raygui.h
+++ b/raylib-sys/binding/raygui.h
@@ -744,6 +744,7 @@ extern "C"
 
     // Styles loading functions
     RAYGUIAPI void GuiLoadStyle(const char *fileName); // Load style file over global style variable (.rgs)
+    RAYGUIAPI void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize); // Load style from memory (binary only)
     RAYGUIAPI void GuiLoadStyleDefault(void);          // Load style default over global style
 
     // Tooltips management functions
@@ -1531,7 +1532,7 @@ static void DrawRectangleGradientV(int posX, int posY, int width, int height, Co
 //----------------------------------------------------------------------------------
 // Module specific Functions Declaration
 //----------------------------------------------------------------------------------
-static void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize); // Load style from memory (binary only)
+void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize); // Load style from memory (binary only)
 
 static int GetTextWidth(const char *text);                     // Gui get text width using gui font and style
 static Rectangle GetTextBounds(int control, Rectangle bounds); // Get text bounds considering control bounds
@@ -4977,7 +4978,7 @@ void GuiSetIconScale(int scale)
 
 // Load style from memory
 // WARNING: Binary files only
-static void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize)
+void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize)
 {
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -84,6 +84,11 @@ impl RaylibHandle {
     pub fn gui_load_style_default(&mut self) {
         unsafe { ffi::GuiLoadStyleDefault() }
     }
+    /// Load style data from a given memory buffer.
+    #[inline]
+    pub fn gui_load_style_from_memory(&mut self, data: &[u8]) {
+        unsafe { ffi::GuiLoadStyleFromMemory(data.as_ptr(), data.len() as i32) }
+    }
 
     /// Enable gui tooltips (global state)
     #[inline]
@@ -195,6 +200,11 @@ pub trait RaylibDrawGui {
     #[inline]
     fn gui_load_style_default(&mut self) {
         unsafe { ffi::GuiLoadStyleDefault() }
+    }
+    /// Load style data from a given memory buffer.
+    #[inline]
+    fn gui_load_style_from_memory(&mut self, data: &[u8]) {
+        unsafe { ffi::GuiLoadStyleFromMemory(data.as_ptr(), data.len() as i32) }
     }
     /// Window Box control, shows a window that can be closed
     #[inline]


### PR DESCRIPTION
## _*WIP: Not intended for merge as-is.*_

This draft contains two commits, one of which is not intended for merging:

- First commit touches `raylib-sys/binding/raygui.h` to expose `GuiLoadStyleFromMemory`.
  - This is understandably not to be done for a real PR. The original library would have to be updated, and also release a new tagged version, perhaps.
  - See:
    - https://github.com/raysan5/raygui/issues/548 (Issue about the needed `raygui` update)
    - https://github.com/raysan5/raygui/pull/549
    - Edit: the mentioned PR was approved! I'll update this later. Would a new tagged `raygui` version need to be released? We'll see.
- Second commit adds `gui_load_style_from_memory` in `raylib/src/rgui/safe.rs`

I wonder if doing:
```rust
data.len() as i32
```
is effectively safe, in:
```rust
unsafe { ffi::GuiLoadStyleFromMemory(data.as_ptr(), data.len() as i32) }
```

If I got this right:
since
```rust
let data: &[u8] // Pseudocode
data.len()
```
understandably returns `usize`, the `as` would potentially wraparound and turn negative.

I imagine the underlying `C` code would ideally just reject the incoming negative `int` by returning `false` or something.

Currently, the underlying `C` `GuiLoadStyleFromMemory` function is returning `void`, so it doesn't signal failures. The `rgui/safe.rs` binding could still detect the overflow from `data.len()` with a `try_from` and stop before reaching the `unsafe` section at all.

Ultimately, it seems the underlying `C` does not use the passed size at all, for now:
https://github.com/raylib-rs/raylib-rs/blob/c574449e65d698d7bee1e7d623726f83947a2c13/raylib-sys/binding/raygui.h#L4980-L5207