### PR TITLE
ci(showcase): scope continue-on-error to wasm-build only

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -25,12 +25,6 @@ env:
 
 jobs:
   build:
-    # Non-blocking: showcase builds 229 examples × 3 OSes and is a slow leg.
-    # Failures here surface as warnings but don't gate merges/publishes until
-    # the post-release wasm/showcase build-speed workstream lands. Re-enable
-    # blocking by removing this `continue-on-error` once that workstream
-    # establishes a faster baseline (matrix-split, sccache re-enabled, etc.).
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -62,8 +56,14 @@ jobs:
         run: cargo nextest run -p raylib-showcase
 
   wasm-build:
-    # Non-blocking: ~18 min iterate-and-build over 229 wasm examples.
-    # See `build` job comment + the post-release-web-build-speed memory.
+    # Non-blocking: ~18 min iterate-and-build over 229 wasm examples is the
+    # current CI bottleneck. Failures surface as warnings on the run page but
+    # don't fail the workflow's reported conclusion. Re-enable blocking after
+    # the post-release wasm/showcase build-speed workstream lands (matrix-
+    # split `xtask-wasm-build`, sccache re-enabled once the GHA artifact-
+    # cache outage clears, raylib-sys hoisted out of the per-example loop).
+    # The native `build` job above stays blocking — it's fast (~5 min) and
+    # is the actual signal for 229-example correctness on desktop.
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #298. The squash-merge captured an intermediate state where **both** showcase jobs were marked \`continue-on-error: true\`. The intended scope is **wasm-build only**:

- \`build\` (229 examples × 3 OSes, ~5 min) is the **correctness signal** for the showcase ports — must stay blocking
- \`wasm-build\` (~18 min iterate-and-build over 229 wasm examples) is the slow leg — non-blocking until the post-release wasm build-speed workstream lands

## Change

Revert the \`build\` job back to blocking. Keep \`wasm-build\` non-blocking with a clearer rationale comment pointing at the future build-speed workstream.

## Test plan

- [ ] Merge this PR
- [ ] Showcase \`build\` failures gate canonical CI again
- [ ] Showcase \`wasm-build\` failures continue to be informational

🤖 Generated with [Claude Code](https://claude.com/claude-code)