### PR TITLE
chore(release): bump 6.0.0 → 6.0.0-rc.2 (wider-review snapshot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # raylib-rs Changelog
 
-## 6.0.0 — 2026-06-02
+## 6.0.0-rc.2 — 2026-06-02
 
 Upgrade from raylib 5.x to **raylib 6.0**. MSRV bumped to **1.85** (edition 2024).
+
+> Release candidate 2 for the 6.0 line — published as `6.0.0-rc.2` to
+> get wider eyes on the canonical merge before the final `6.0.0` cut.
+> The headings under this block describe what will ship in `6.0.0`
+> final; `rc.2` is the verbatim source snapshot of the current canonical
+> `unstable` HEAD. The final-cut commit will flip this header to
+> `## 6.0.0 — YYYY-MM-DD` and bump the Cargo.toml versions accordingly.
 
 ### Highlights
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Follow instructions for building raylib for your platform [here](https://github.
 
 ```toml
 [dependencies]
-raylib = { version = "6.0", features = [] }
+raylib = { version = "6.0.0-rc.2", features = [] }
 ```
 
 2. Start coding!

--- a/book/src/core-concepts/features.md
+++ b/book/src/core-concepts/features.md
@@ -38,15 +38,15 @@ Three common `Cargo.toml` stanzas:
 ```text
 # 1. Default desktop build (OpenGL 3.3, no optional adapters)
 [dependencies]
-raylib = "6.0"
+raylib = "6.0.0-rc.2"
 
 # 2. Headless / CI build using the software renderer (no GPU required)
 [dependencies]
-raylib = { version = "6.0", features = ["software_renderer"] }
+raylib = { version = "6.0.0-rc.2", features = ["software_renderer"] }
 
 # 3. Game with glam math and serde serialization
 [dependencies]
-raylib = { version = "6.0", features = ["glam", "serde"] }
+raylib = { version = "6.0.0-rc.2", features = ["glam", "serde"] }
 ```
 
 ## Gotchas

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -8,8 +8,10 @@ In your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raylib = "6.0"
+raylib = "6.0.0-rc.2"
 ```
+
+> **Note:** `6.0.0-rc.2` is the published release-candidate of the 6.0 line on crates.io while the canonical merge gets additional review. The headings under this book chapter describe what is shipping in the eventual `6.0.0` final release; cargo will not pick up a pre-release tag from `raylib = "6.0"` alone, so the exact `6.0.0-rc.2` pin is intentional.
 
 ## Open a window
 

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raylib-sys"
-version = "6.0.0"
+version = "6.0.0-rc.2"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 description = "Raw FFI bindings for Raylib"

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raylib"
-version = "6.0.0"
+version = "6.0.0-rc.2"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 readme = "../README.md"
@@ -14,7 +14,7 @@ rust-version = "1.85"
 autoexamples = false
 
 [dependencies]
-raylib-sys = { version = "6.0.0", path = "../raylib-sys", default-features = false }
+raylib-sys = { version = "6.0.0-rc.2", path = "../raylib-sys", default-features = false }
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 

--- a/showcase/Cargo.toml
+++ b/showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raylib-showcase"
-version = "6.0.0"
+version = "6.0.0-rc.2"
 authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 edition = "2024"
 rust-version = "1.85"
@@ -25,7 +25,7 @@ raygui = ["raylib/raygui"]
 SUPPORT_CUSTOM_FRAME_CONTROL = ["raylib/SUPPORT_CUSTOM_FRAME_CONTROL"]
 
 [dependencies]
-raylib = { version = "6.0.0", path = "../raylib" }
+raylib = { version = "6.0.0-rc.2", path = "../raylib" }
 phf = { version = "0.11", features = ["macros"] }
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Hold the final \`6.0.0\` publish days while the canonical merge gets additional review. Cut a \`6.0.0-rc.2\` to crates.io now so downstream consumers can pin against a published version rather than a git revision.

## Changes

- \`raylib\` + \`raylib-sys\` + \`showcase\` \`Cargo.toml\`: \`6.0.0\` → \`6.0.0-rc.2\` (workspace inter-crate pins synced)
- \`README.md\` + \`book/src/getting-started/quickstart.md\` + \`book/src/core-concepts/features.md\`: version snippets flipped to the **exact** \`6.0.0-rc.2\` pin (caret-style \`\"6.0\"\` won't pick up a pre-release tag, so the explicit pin is required)
- \`CHANGELOG.md\`: \`## 6.0.0 — 2026-06-02\` → \`## 6.0.0-rc.2 — 2026-06-02\` + restored an rc-rationale blockquote explaining this is a wider-review snapshot ahead of the final cut

Build verified locally: \`cargo build -p raylib -p raylib-sys --features full\` — clean.

## Tag handling

The \`v6.0.0\` tag on the merge commit \`47e126f\` stays in place per maintainer call — it's an accurate snapshot of the would-have-been \`6.0.0\` source state. The final \`6.0.0\` cut will reuse that tag (or move it to a fresh bump commit) days from now.

## Test plan

- [ ] Merge this PR
- [ ] Tag \`v6.0.0-rc.2\` on the merge commit
- [ ] Re-dispatch \`release-sys.yml\` with \`dry_run: true\` → green
- [ ] Dispatch \`release-sys.yml\` with \`dry_run: false\` → real publish of \`raylib-sys 6.0.0-rc.2\`
- [ ] Wait for crates.io indexing (~5-15 min); verify \`cargo search raylib-sys\` lists \`6.0.0-rc.2\`
- [ ] Dispatch \`release-safe.yml\` with \`dry_run: true\` then \`dry_run: false\` → \`raylib 6.0.0-rc.2\` lands on crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)