### PR TITLE
fix(showcase): synthesize per-example HTML + pin gen-thumbnails CWD

### DIFF
--- a/showcase/src/bin/gen_thumbnails.rs
+++ b/showcase/src/bin/gen_thumbnails.rs
@@ -109,7 +109,7 @@ fn main() {
             .get(&meta.name)
             .cloned()
             .unwrap_or_default();
-        let result = run_one(&meta.name, frames, &out, &extra_features);
+        let result = run_one(&meta.name, frames, &out, &extra_features, &manifest_dir);
         match result {
             Ok(()) => manifest.push(ManifestEntry {
                 name: meta.name.clone(),
@@ -160,7 +160,13 @@ fn find_examples_meta(workspace_root: &Path) -> Option<PathBuf> {
     None
 }
 
-fn run_one(name: &str, frames: usize, out: &Path, extra_features: &[String]) -> Result<(), String> {
+fn run_one(
+    name: &str,
+    frames: usize,
+    out: &Path,
+    extra_features: &[String],
+    manifest_dir: &Path,
+) -> Result<(), String> {
     let mut features = vec!["software_renderer".to_string()];
     features.extend(extra_features.iter().cloned());
     let features_arg = features.join(",");
@@ -175,6 +181,12 @@ fn run_one(name: &str, frames: usize, out: &Path, extra_features: &[String]) -> 
         "--example",
         name,
     ]);
+    // Pin CWD to the showcase package dir so examples' relative
+    // `resources/<cat>/...` paths resolve against the vendored
+    // `showcase/resources/` tree. Without this, gen-thumbnails inherits
+    // the caller's CWD (workspace root in CI), and every resource-loading
+    // example fails to find its files.
+    cmd.current_dir(manifest_dir);
     cmd.env("RAYLIB_SHOWCASE_THUMBNAIL_FRAMES", frames.to_string());
     cmd.env(
         "RAYLIB_SHOWCASE_THUMBNAIL_OUT",

--- a/showcase/src/bin/xtask_build_pages.rs
+++ b/showcase/src/bin/xtask_build_pages.rs
@@ -116,11 +116,22 @@ fn main() {
 
     // Per-example HTML pages: copy wasm artifacts for buildable examples,
     // or write a "desktop only" placeholder for wasm-excluded ones.
+    //
+    // The shell template (`index/example_shell.html`) is loaded once and
+    // used to synthesize the per-example HTML wrapper around the emscripten
+    // `.js` loader. We don't rely on emcc emitting HTML itself, because
+    // `cargo build --target wasm32-unknown-emscripten` invokes emcc with a
+    // `.js` output path, so emcc never enters HTML-emit mode and the
+    // `EMCC_CFLAGS --shell-file ...` is silently ignored. Synthesizing the
+    // wrapper here keeps the substitution deterministic and avoids a second
+    // emcc invocation.
     let wasm_dir = workspace_root
         .join("target")
         .join("wasm32-unknown-emscripten")
         .join("release")
         .join("examples");
+    let shell_template = fs::read_to_string(manifest_dir.join("index/example_shell.html"))
+        .expect("index/example_shell.html not found; required to synthesize per-example pages");
     for m in &metas {
         let out_dir = site.join("examples").join(&m.category);
         fs::create_dir_all(&out_dir).unwrap();
@@ -132,19 +143,36 @@ fn main() {
             continue;
         }
 
-        let mut copied_any = false;
-        for ext in &["html", "js", "wasm", "data"] {
+        // Copy the runtime artifacts emcc produced. We deliberately do NOT
+        // copy `.html` (emcc doesn't emit one — see comment above) and
+        // instead synthesize it from the shell template below.
+        let mut js_copied = false;
+        for ext in &["js", "wasm", "data"] {
             let src = wasm_dir.join(format!("{}.{}", m.name, ext));
             if src.exists() {
                 let dst = out_dir.join(format!("{}.{}", m.name, ext));
                 let _ = fs::copy(src, dst);
-                copied_any = true;
+                if *ext == "js" {
+                    js_copied = true;
+                }
             }
         }
-        // If the wasm build hasn't been run, fall back to a placeholder
-        // (with a note that the wasm artifacts haven't been built yet) so
-        // the gallery tile still resolves to a real page.
-        if !copied_any {
+        if js_copied {
+            // Substitute placeholders in the shell. `{{{ SCRIPT }}}` is the
+            // emscripten loader script tag (defaulted to async to match
+            // emscripten's own default HTML output).
+            let script_tag = format!(
+                "<script async type=\"text/javascript\" src=\"{}.js\"></script>",
+                m.name
+            );
+            let html = shell_template
+                .replace("{{{ EXAMPLE_NAME }}}", &m.name)
+                .replace("{{{ SCRIPT }}}", &script_tag);
+            fs::write(out_dir.join(format!("{}.html", m.name)), html).unwrap();
+        } else {
+            // Fall back to a placeholder noting that the wasm artifacts
+            // haven't been built yet, so the gallery tile still resolves
+            // to a real page.
             let html = render_unbuilt_wasm_placeholder(m);
             fs::write(out_dir.join(format!("{}.html", m.name)), html).unwrap();
         }


### PR DESCRIPTION
## Summary

Two fixes for the deployed showcase gallery at <https://raylib-rs.github.io/raylib-rs/>:

### 1. Every example tile 404'd on click

`pages.yml`'s wasm-build step runs `cargo build --target wasm32-unknown-emscripten --release --example NAME`. Cargo passes a `.js` output path to emcc, so emcc emits `NAME.js` + `NAME.wasm` and never enters HTML-emit mode. The `EMCC_CFLAGS --shell-file ...` added in 466f10f is silently ignored, and no `NAME.html` ever exists in the wasm target dir. `xtask_build_pages` then copied the .js/.wasm but `copied_any=true` short-circuited the unbuilt-placeholder fallback, so every per-tile destination was simply missing on disk.

**Fix:** `xtask_build_pages` now synthesizes the per-example HTML from `index/example_shell.html` after copying runtime artifacts. The shell template's `{{{ EXAMPLE_NAME }}}` and `{{{ SCRIPT }}}` placeholders get replaced with the example name and an async `<script src="NAME.js">` tag (same shape as emscripten's default HTML wrapper). `.html` is no longer in the copy list since emcc never emits one.

Probe before:
```
200  examples/audio/audio_amp_envelope.js
200  examples/audio/audio_amp_envelope.wasm
404  examples/audio/audio_amp_envelope.html  ← never built
```

### 2. Most resource-loading examples had no thumbnails

`gen-thumbnails` spawned `cargo run --example NAME` without setting CWD. The example process inherited the caller's CWD (workspace root in CI), so relative paths like `resources/audio/country.mp3` resolved against `<workspace>/resources/` instead of `<workspace>/showcase/resources/` where the resources are actually vendored. Every resource-loading example silently failed → manifest entry `thumbnail: None` → empty placeholder div in the gallery ("broken thumbnail").

**Fix:** pin the spawned cargo invocation's CWD to `manifest_dir` (the `showcase/` package dir) via `Command::current_dir`. The resources are already vendored at `showcase/resources/<cat>/...` by `xtask-vendor-resources`; this just makes them findable from the example's working directory.

## Out of scope

The deployed wasm runtime resource loading (no `--preload-file` in `EMCC_CFLAGS`) is a pre-existing, separate issue. Even with this PR, examples that load external resources will hit a runtime error in the browser when emscripten's MEMFS can't find them. Tracking-deferred for a follow-up that adds `--preload-file ../showcase/resources/<cat>@resources/<cat>` (or similar) to `xtask_wasm_build`.

## Test plan

- [ ] Once merged + the `pages` workflow runs: `curl -sI https://raylib-rs.github.io/raylib-rs/examples/audio/audio_amp_envelope.html` returns 200
- [ ] Spot-check a few tiles in the gallery: thumbnails for resource-loading examples (audio_music_stream, models_loading, textures_logo_raylib) now render
- [ ] Spot-check a tile click: page loads and the canvas appears (canvas-side rendering may still fail until `--preload-file` lands; that's the out-of-scope wasm runtime issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)