### PR TITLE
feat(showcase): name in placeholder + pin audio category to the bottom

### DIFF
--- a/showcase/index/style.css
+++ b/showcase/index/style.css
@@ -82,7 +82,16 @@ main { padding: 1rem; }
 }
 
 .tile .placeholder {
-  /* No <img>; just shows the placeholder colour. */
+  /* No <img>; show the example name inside the placeholder so the tile
+     is still identifiable when gen-thumbnails couldn't capture it. */
+}
+.tile .placeholder span {
+  padding: 0.4rem 0.6rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem;
+  text-align: center;
+  word-break: break-word;
+  opacity: 0.7;
 }
 
 .tile p {

--- a/showcase/src/bin/xtask_build_pages.rs
+++ b/showcase/src/bin/xtask_build_pages.rs
@@ -74,9 +74,21 @@ fn main() {
     }
 
     // Render the per-category sections that get spliced into the template.
+    // Category ordering: alphabetical, but with `audio` pinned to the end.
+    // Audio examples don't currently run in the web (no audio context wired
+    // through to emscripten yet) and their software_renderer thumbnails fail,
+    // so we push them down so the gallery doesn't lead with broken tiles.
+    let mut ordered_cats: Vec<&String> = by_category.keys().collect();
+    ordered_cats.sort_by(|a, b| match (a.as_str(), b.as_str()) {
+        ("audio", "audio") => std::cmp::Ordering::Equal,
+        ("audio", _) => std::cmp::Ordering::Greater,
+        (_, "audio") => std::cmp::Ordering::Less,
+        _ => a.cmp(b),
+    });
     let mut categories_body = String::new();
     let mut total_tiles = 0usize;
-    for (cat, entries) in &by_category {
+    for cat in &ordered_cats {
+        let entries = &by_category[*cat];
         categories_body.push_str(&format!(
             "    <section class=\"category\" id=\"cat-{}\">\n      <h2>{}</h2>\n      <div class=\"grid\">\n",
             cat, cat,
@@ -88,7 +100,14 @@ fn main() {
                     "<div class=\"thumb\"><img src=\"thumbnails/{}\" alt=\"{}\" loading=\"lazy\" /></div>",
                     file, m.name,
                 ),
-                None => "<div class=\"thumb placeholder\"></div>".to_string(),
+                // No thumbnail captured (gen-thumbnails failed for this
+                // example). Show the name inside the placeholder so the
+                // tile is still identifiable at a glance instead of being
+                // a blank gray box.
+                None => format!(
+                    "<div class=\"thumb placeholder\"><span>{}</span></div>",
+                    m.name,
+                ),
             };
             let badge = if m.wasm_excluded {
                 " <span class=\"badge\">desktop only</span>"


### PR DESCRIPTION
## Summary

Two gallery polish fixes following PR #303:

### 1. Placeholder tiles now show the example name

After PR #303 landed, 18 tiles still render as placeholders because gen-thumbnails couldn't capture them. Most are audio (11/11), plus a handful in other categories with known failure modes (`core_monitor_detector` is the documented `get_monitor_info` SIGABRT under rlsw; the others fail for resource or feature-flag reasons).

Previously these were rendered as a bare `<div class="thumb placeholder"></div>` — an empty gray box with the example name only visible in the small caption below. Now the placeholder embeds a centred monospace `<span>` with the example name, so the user can scan the gallery and read what each placeholder represents without having to fish for the caption.

### 2. Audio category pinned to the bottom

Audio currently has two known issues on the web build:
- Every audio thumbnail fails under the software_renderer pipeline (audio init under `PLATFORM=Memory` doesn't survive).
- The deployed wasm doesn't have an audio context plumbed through emscripten yet.

Leading the gallery with 11 broken-looking tiles is a bad first impression. Custom sort comparator pushes `audio` to the end while keeping every other category alphabetical (so any future new category stays sorted without manual maintenance).

## Test plan

Once merged + the `pages` workflow runs:
- [ ] Gallery starts with `core` (not `audio`); `audio` section is the last on the page
- [ ] Tiles in `audio` and other failure categories now display their example name inside the gray placeholder box rather than being anonymous

## Out of scope

The remaining non-audio thumbnail failures (`core_monitor_detector`, `core_input_gestures_testbed`, `models_skybox_rendering`, `embedded_files_loading`, `shaders_shadowmap_rendering`, `textures_sprite_button`, `textures_sprite_explosion`) each likely need a per-example fix or a `thumbnails.toml` skip entry. Tracked-deferred — separate, narrow PR per failure root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)