### PR TITLE
chore(showcase): clippy cleanup + -D warnings gate

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -50,6 +50,16 @@ jobs:
         run: cargo build -p raylib-showcase --examples
       - name: Build examples (raygui)
         run: cargo build -p raylib-showcase --examples --features raygui
+      # Clippy gate (post-cleanup, 2026-06-03): the example ports are clippy-clean;
+      # C-parity lints carry tightest-scope #[expect(reason = "C-parity: …")]. Deny
+      # warnings so a new port must land warning-free or with a documented #[expect].
+      # The base leg catches default-feature-only warnings; the raygui +
+      # SUPPORT_CUSTOM_FRAME_CONTROL superset leg builds every example (including the
+      # otherwise-skipped feature-gated ones, e.g. core_custom_frame_control).
+      - name: Clippy examples (default features, deny warnings)
+        run: cargo clippy -p raylib-showcase --examples -- -D warnings
+      - name: Clippy examples (raygui + custom frame control, deny warnings)
+        run: cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL -- -D warnings
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Unit tests

--- a/docs/superpowers/notes/post-release-showcase-clippy-cleanup-complete.md
+++ b/docs/superpowers/notes/post-release-showcase-clippy-cleanup-complete.md
@@ -1,0 +1,59 @@
+# Showcase clippy cleanup — done-note (2026-06-03)
+
+**Branch:** `chore/showcase-clippy-cleanup` (off canonical `unstable`)
+**Spec:** `docs/superpowers/specs/2026-06-03-showcase-clippy-cleanup-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-03-showcase-clippy-cleanup.md`
+
+## Outcome
+
+`cargo clippy -p raylib-showcase --examples` is now **zero-warning across all three feature legs**, verified on a clean build:
+
+| Leg | Examples built | Errors | Warnings |
+|-----|---------------:|-------:|---------:|
+| `--features raygui,SUPPORT_CUSTOM_FRAME_CONTROL` (superset — all examples) | 229 | 0 | 0 |
+| default features (base) | 197 | 0 | 0 |
+| `--features software_renderer` | 197 | 0 | 0 |
+
+(197 = the 229 minus the feature-gated examples skipped without `raygui`/`SUPPORT_CUSTOM_FRAME_CONTROL`.)
+
+A `-D warnings` clippy gate was added to `showcase.yml` (see "Gate decision"). The ports were **not restructured** — the F1 source-viewer side-by-side parity is intact. **119 example files** changed (+881/−130); **208 `#[expect(...)]`** attributes added, each carrying a `reason`.
+
+## Warning census (the snapshot that started the sweep)
+
+~225 distinct `(file, line, lint)` post-Bucket-B; the full original set was ~314 sites across ~90 examples. Distribution and disposition:
+
+**Bucket B — Rust-only port artifacts, FIXED (no C counterpart, removal is parity-safe):**
+- `useless_conversion` ×52 — dropped no-op `Vector3::from(x)` / `.into()` to the same type. (commit `656ffbe`)
+- `needless_borrows_for_generic_args` ×26 — dropped redundant `&` (mostly `&format!(…)` into `impl AsRef<str>` gui calls). (commit `eb894d5`)
+- `unused_imports` ×2 + `mem_replace_option_with_none` ×1 — removed redundant `use raylib::rgui::RaylibDrawGui` (already in prelude) + `mem::replace(&mut x, None)` → `x.take()`. (commit `0836fa7`)
+- `unnecessary_cast` ×4 + `explicit_auto_deref` ×2 — removed no-op casts (`RL_*_FRAMEBUFFER as u32` where already `u32`; outer `… as i32) as i32`) and redundant `(*…)` derefs. (folded into commit `469391e`)
+
+**Bucket A — C-parity structural mirrors, `#[expect(reason = "C-parity: …")]`:**
+- `needless_range_loop` ×108, `unused_assignments` ×32 (commit `468c0d6`).
+- `assign_op_pattern` ×17, `collapsible_if` ×15, `manual_clamp` ×13, `too_many_arguments` ×7, `identity_op` ×6, `excessive_precision` ×6, `needless_bool_assign` ×4, plus singles/pairs of `comparison_chain`, `enum_variant_names`, `mixed_case_hex_literals`, `nonminimal_bool`, `neg_cmp_op_on_partial_ord`, `manual_memcpy`, `field_reassign_with_default`, `collapsible_else_if` (commit `469391e`).
+
+**Ambiguous — inspected, defaulted to `#[expect]` per the maintainer's bias-to-allow (commit `1ea4a76`):**
+- `approx_constant` ×1 (`audio_spectrum_visualizer`, the `20/ln(10)` dB literal — raylib-rs original, Web-Audio-derived; **deny-level**, see below) → expect with a Web-Audio reason.
+- `type_complexity` ×1 (`audio_stream_callback` closure storage for C's `AudioCallback` dispatch) → expect.
+- `search_is_some` ×4 (`core_input_gamepad` — mirrors the C `TextFindIndex(...) > -1`) → 2 expects.
+- `dead_code` ×2 (`MAX_LIGHTS` from `rlights.h`; `MODE_DRAW` enum variant) → expect.
+
+## Real-defect fixes (beyond Bucket-B removals)
+
+1. **Three `#[expect]` on bare assignment-expressions broke the build (E0658).** Task 6 placed `#[expect(unused_assignments)]` directly above `gif_recording = false;` and two `anim_blend_factor = 0.0;` — stable Rust rejects attributes on (non-block) expressions. Hoisted to a `fn`-level `#[expect]` (commit `f970bc6`).
+2. **One mis-scoped expect** in `core_input_actions` (on `action_set`, which is actually read → `unfulfilled_lint_expectations`; the real unused init was on `release_action`). Moved to the correct binding (commit `f970bc6`).
+
+## Gotchas worth recording (these cost the most time)
+
+- **A deny-level lint truncates the `--examples` census.** `clippy::approx_constant` is `correctness`/deny-by-default; its one site made `cargo clippy --examples` *error out at that target and stop building the rest* (cargo halts at the first failing target). Every census taken before it was fixed was silently truncated (we saw 150 vs the true 225). The E0658 build-break (above) did the same. **Reliable censusing = `cargo clean -p raylib-showcase` + a single all-features leg with `--keep-going --message-format=json`.** Without `--keep-going`, one error hides everything after it.
+- **Clippy only re-emits diagnostics for targets it recompiles.** A warm-cache run reports a partial census. Always clean the showcase package before a census/verification clippy. (`cargo clean -p raylib-showcase` clears only the examples/lib, ~1–2 min; the expensive `raylib`/`raylib-sys` stay built.)
+- **Attributes are illegal on bare expression-statements and sub-expressions (E0658).** This affects `assign_op_pattern` (always `x = x + y;`), plus `identity_op`/`field_reassign_with_default` sites whose flagged construct is an assignment or a nested sub-expression. The fix is a `fn`-level `#[expect]`, which is **nested-expect-safe**: an inner statement-level `#[expect]` for the same lint stays fulfilled by its own site, and the `fn`-level one is fulfilled only by the sites no inner expect caught. Block-expression statements (`if`/`for`/`while`/`match`/`loop`/`{}`) and `let`/items *do* accept tight attributes — that's why the 108 `needless_range_loop` `for`-loops took tight expects cleanly.
+
+## Gate decision
+
+**Added** `-D warnings` clippy steps to the `build` job of `showcase.yml` (commit `5b324e4`), covering the base leg and the `raygui,SUPPORT_CUSTOM_FRAME_CONTROL` superset (which builds every example, including `core_custom_frame_control` — previously never built in CI). Added as **steps on the existing job**, not a new job, so no new required-check context is created and the `unstable` branch ruleset needs no edit (per `ci-ruleset-required-checks-gotcha`). **Signal change flagged for the maintainer:** every future port must now land warning-free or with a documented `#[expect]`; the showcase CI build job is ~1 clippy-compile slower as a result (sccache is currently disabled for the GHA cache outage, so this is a real wall-clock add until that's restored).
+
+## Follow-up nits (not blocking)
+
+- `shapes_rectangle_scaling.rs` carries a **pre-existing** `#[allow(unused_assignments)]` (no `reason`, and `allow` not `expect`) on `mouse_position` — left as-is since it predates this sweep; a future pass could convert it to `#[expect(reason = …)]` for consistency.
+- `text_unicode_ranges.rs` now has mixed-case-consistent-but-line-inconsistent hex pairs (e.g. `0x2de0, 0x2DFF`) after normalizing only the clippy-flagged literal in each pair. Cosmetic; clippy-clean.

--- a/docs/superpowers/plans/2026-06-03-showcase-clippy-cleanup.md
+++ b/docs/superpowers/plans/2026-06-03-showcase-clippy-cleanup.md
@@ -1,0 +1,488 @@
+# Showcase Clippy Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `cargo clippy -p raylib-showcase --examples` clippy-clean (zero warnings) across all feature sets, without restructuring any port, then gate it in CI.
+
+**Architecture:** Per-*lint-type* triage. Rust-only port artifacts (no C counterpart) get **fixed** (one commit per lint-type). C-parity structural lints get a tightest-scope `#[expect(<lint>, reason = "C-parity: …")]` (preserving the F1 side-by-side). Clippy itself is the test — "red" = current warnings, "green" = zero warnings. A regenerated worksheet (Task 1) drives the mechanical passes.
+
+**Tech Stack:** Rust (edition 2024, MSRV 1.85), cargo clippy, `--message-format=json` for the worksheet, `showcase.yml` GitHub Actions.
+
+---
+
+## File structure
+
+- **Modified (bulk):** `showcase/examples/**/*.rs` — example ports get `#[expect(...)]` attributes (Bucket A) or no-op removals (Bucket B). No structural edits.
+- **Modified:** `.github/workflows/showcase.yml` — add the clippy `-D warnings` gate step.
+- **Created:** `docs/superpowers/notes/post-release-showcase-clippy-cleanup-complete.md` — done-note.
+- **Scratch (not committed):** `target/clippy-worksheet.log`, `target/clippy-worksheet.tsv` — triage worksheet.
+
+The bucket → lint mapping (from the spec's census):
+
+- **Bucket B (fix, remove the no-op):** `clippy::useless_conversion`, `clippy::needless_borrows_for_generic_args`, `unused_imports`, `clippy::mem_replace_option_with_none`.
+- **Bucket A (`#[expect]`):** `clippy::needless_range_loop`, `unused_assignments`, `clippy::collapsible_if`, `clippy::collapsible_else_if`, `clippy::manual_clamp`, `clippy::assign_op_pattern`, `clippy::too_many_arguments`, `clippy::needless_bool_assign`, `clippy::identity_op`, `clippy::unnecessary_cast`, `clippy::enum_variant_names`, `clippy::comparison_chain`, `clippy::nonminimal_bool`, `clippy::neg_cmp_op_on_partial_ord`, `clippy::manual_memcpy`, `clippy::mixed_case_hex_literals`, `clippy::excessive_precision`, `clippy::field_reassign_with_default`.
+- **Inspect (default to Bucket A per bias-to-allow):** `dead_code`, `clippy::search_is_some`, `clippy::explicit_auto_deref`, `clippy::type_complexity`, `clippy::approx_constant`.
+
+> **Authoritative census** (regenerated on this branch via Task 1, `target/clippy-worksheet.tsv`, 314 distinct sites): `needless_range_loop` 128, `useless_conversion` 65, `excessive_precision` 36 (all in `shaders_mandelbrot_set`), `unused_assignments` 34, `needless_borrows_for_generic_args` 26, `collapsible_if` 19, `assign_op_pattern` 18, `manual_clamp` 17, `too_many_arguments` 9, `identity_op` 7, `unnecessary_cast` 6, `search_is_some` 4, `needless_bool_assign` 4, `explicit_auto_deref` 4, then `unused_imports`/`dead_code`/`nonminimal_bool`/`mixed_case_hex_literals`/`enum_variant_names`/`comparison_chain`/`collapsible_else_if`/`approx_constant` at 2 each, `type_complexity`/`neg_cmp_op_on_partial_ord`/`mem_replace_option_with_none`/`manual_memcpy`/`field_reassign_with_default` at 1.
+>
+> **`clippy::approx_constant` is deny-by-default** (a `correctness` lint): the single site `audio_spectrum_visualizer.rs:41` (`20.0 / 2.302_585_1`, i.e. `20/ln(10)`) currently makes `cargo clippy` *error*, not just warn. It must be resolved (Task 5) regardless of the `-D warnings` gate.
+
+---
+
+## Task 1: Regenerate the authoritative triage worksheet
+
+**Files:**
+- Create (scratch): `target/clippy-worksheet.tsv`
+
+- [ ] **Step 1: Run clippy in JSON form across both feature sets, capture to one stream**
+
+The two legs matter because `required-features` examples (raygui, `SUPPORT_CUSTOM_FRAME_CONTROL`) are skipped without their flags. The superset leg `raygui,SUPPORT_CUSTOM_FRAME_CONTROL` covers all gated examples.
+
+Run (from repo root):
+```bash
+{ cargo clippy -p raylib-showcase --examples --message-format=json 2>/dev/null; \
+  cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null; } \
+  > target/clippy-json.log
+```
+Expected: a stream of JSON objects, one per line.
+
+- [ ] **Step 2: Reduce JSON to a `(file, line, lint)` TSV, deduped**
+
+Use the Bash tool with `jq` if available; otherwise a Grep-based reduction. With `jq`:
+```bash
+jq -r 'select(.reason=="compiler-message")
+       | .message as $m
+       | ($m.code.code // "") as $lint
+       | ($m.spans[] | select(.is_primary==true)
+          | [.file_name, (.line_start|tostring), $lint] | @tsv)' \
+   target/clippy-json.log \
+ | grep -E 'showcase/examples/' | sort -u > target/clippy-worksheet.tsv
+wc -l target/clippy-worksheet.tsv
+cut -f3 target/clippy-worksheet.tsv | sort | uniq -c | sort -rn
+```
+Expected: TSV of distinct `file<TAB>line<TAB>lint` rows, plus a per-lint tally. This tally is the census of record for the done-note.
+
+- [ ] **Step 3: Sanity-check every emitted lint is classified**
+
+Confirm the `uniq -c` lint list from Step 2 is a subset of the Bucket-A ∪ Bucket-B ∪ Inspect lists in this plan's File-structure section. If a **new** lint appears (not in any list), stop and classify it: does the C original have the pattern? Yes → Bucket A (`#[expect]`); no → Bucket B (fix). Add it to the worksheet note before proceeding.
+
+- [ ] **Step 4: Commit nothing** (worksheet is scratch under `target/`, which is gitignored). Proceed to Task 2.
+
+---
+
+## Task 2: Fix Bucket-B — `useless_conversion`
+
+These are no-op conversions the porter added (`Vector3::from(x)` where `x: Vector3`, `.into()` to the same type). The C has no such line, so removal is parity-safe and clippy's suggestion is correct here.
+
+**Files:**
+- Modify: every `showcase/examples/**/*.rs` row in `target/clippy-worksheet.tsv` with lint `clippy::useless_conversion` (e.g. `models_animation_blend_custom.rs`, `shaders_mandelbrot_set.rs`, `textures_image_generation.rs`, `models_decals.rs`).
+
+- [ ] **Step 1: List the affected files**
+
+Run:
+```bash
+grep -P '\tclippy::useless_conversion$' target/clippy-worksheet.tsv | cut -f1 | sort -u
+```
+
+- [ ] **Step 2: Apply the removal per occurrence**
+
+For each `(file, line)`: open the file, read the clippy suggestion (re-run `cargo clippy -p raylib-showcase --example <name> [--features …]` for the exact help text), and remove only the conversion wrapper:
+- `Vector3::from(expr)` → `expr`
+- `expr.into()` → `expr`
+- `Quaternion::from(expr)` / `Matrix::from(expr)` → `expr`
+
+Do **not** touch surrounding structure or line grouping. If removing `.into()` leaves a now-redundant temporary, leave it (that's structure).
+
+- [ ] **Step 3: Verify this lint is gone**
+
+Run:
+```bash
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null \
+ | jq -r 'select(.reason=="compiler-message").message.code.code' | grep -c useless_conversion
+```
+Expected: `0`.
+
+- [ ] **Step 4: fmt + commit**
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "fix(showcase): drop no-op useless_conversion calls in ports
+
+Rust-only port artifacts (Vector3::from / .into() to the same type);
+no corresponding C line, so removal is parity-safe.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Fix Bucket-B — `needless_borrows_for_generic_args`
+
+Redundant `&` on an argument to a generic param that takes the value by-ref already / `AsRef`. Rust-only; the C has no `&`.
+
+**Files:**
+- Modify: rows with lint `clippy::needless_borrows_for_generic_args`.
+
+- [ ] **Step 1: List affected files**
+
+```bash
+grep -P '\tclippy::needless_borrows_for_generic_args$' target/clippy-worksheet.tsv | cut -f1 | sort -u
+```
+
+- [ ] **Step 2: Drop the redundant `&`**
+
+Per occurrence, apply clippy's suggestion (remove the leading `&` on the flagged argument). Re-run the per-example clippy for the exact span if ambiguous.
+
+- [ ] **Step 3: Verify gone**
+
+```bash
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null \
+ | jq -r 'select(.reason=="compiler-message").message.code.code' | grep -c needless_borrows_for_generic_args
+```
+Expected: `0`.
+
+- [ ] **Step 4: fmt + commit**
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "fix(showcase): drop needless borrows in ports
+
+Rust-only port artifacts; no corresponding C line.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Fix Bucket-B — `unused_imports` + `mem_replace_option_with_none`
+
+Small. `unused_imports` → remove the import line. `mem_replace_option_with_none` → `std::mem::replace(&mut x, None)` becomes `x.take()`.
+
+**Files:**
+- Modify: rows with lint `unused_imports` or `clippy::mem_replace_option_with_none`.
+
+- [ ] **Step 1: List affected files**
+
+```bash
+grep -P '\t(unused_imports|clippy::mem_replace_option_with_none)$' target/clippy-worksheet.tsv | sort -u
+```
+
+- [ ] **Step 2: Apply fixes**
+
+- `unused_imports`: delete the unused `use` (or the single unused item from a grouped `use`). Confirm it is genuinely unused under **all** feature sets (an import used only under `--features raygui` is not unused — verify before deleting; if feature-conditional, leave it and instead `#[cfg]`-gate or `#[expect]` — but first confirm it isn't a real cross-feature use).
+- `mem_replace_option_with_none`: `mem::replace(&mut opt, None)` → `opt.take()`.
+
+- [ ] **Step 3: Verify gone**
+
+```bash
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null \
+ | jq -r 'select(.reason=="compiler-message").message.code.code' | grep -Ec 'unused_imports|mem_replace_option_with_none'
+```
+Expected: `0`.
+
+- [ ] **Step 4: fmt + commit**
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "fix(showcase): remove unused imports + use Option::take in ports
+
+Rust-only port artifacts.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Inspect ambiguous lints — `dead_code`, `search_is_some`, `explicit_auto_deref`, `type_complexity`, `approx_constant`
+
+For each occurrence, open the C original alongside (`raylib-sys/raylib/examples/<cat>/<name>.c` or `raylib-sys/raygui-examples/examples/<name>.c`) and decide: Rust-only artifact (fix) vs C-parity (expect). Default to `#[expect]` per the bias-to-allow decision. **Some examples are raylib-rs originals with no C counterpart** (e.g. `audio_spectrum_visualizer` references MDN/Web-Audio) — for those, "C-parity" doesn't apply, so prefer the genuinely-correct fix or an `#[expect]` whose reason explains the deliberate literal.
+
+**Files:**
+- Modify: rows with lint `dead_code`, `clippy::search_is_some`, `clippy::explicit_auto_deref`, `clippy::type_complexity`, `clippy::approx_constant`.
+
+- [ ] **Step 1: List affected occurrences**
+
+```bash
+grep -P '\t(dead_code|clippy::search_is_some|clippy::explicit_auto_deref|clippy::type_complexity|clippy::approx_constant)$' target/clippy-worksheet.tsv | sort -u
+```
+
+- [ ] **Step 2: Decide per occurrence**
+
+- `dead_code` (struct field / fn unused): if the C original carries the field/function for structural parity → `#[expect(dead_code, reason = "C-parity: mirrors the C struct/helper, unused in this port")]`. If it is a genuine leftover from porting with no C counterpart → delete it.
+- `search_is_some` (`.iter().find(p).is_some()`): if the C does a literal search loop the Rust mirrors → `#[expect(clippy::search_is_some, reason = "C-parity: mirrors the C search loop")]`. If it is just an idiom slip with no structural meaning → rewrite to `.any(p)` and treat as Bucket B.
+- `explicit_auto_deref` (`*x` clippy says is redundant): usually a Rust-only slip → remove the `*` (Bucket B). Only `#[expect]` if the `*` mirrors a C pointer deref that aids the side-by-side.
+- `type_complexity` (complex type in a signature): `#[expect(clippy::type_complexity, reason = "C-parity: mirrors the C callback/array type")]` on the function.
+- `approx_constant` (**deny-by-default — currently errors `cargo clippy`**): the only site is `audio_spectrum_visualizer.rs:41`, `const DB_TO_LINEAR_SCALE: f32 = 20.0 / 2.302_585_1;` where `2.302_585_1` is `ln(10)`. Check for a C original; this example is Web-Audio-derived (MDN-linked comments), so most likely no C counterpart. Prefer keeping the human-readable dB formula and annotate the constant:
+  ```rust
+  #[expect(clippy::approx_constant, reason = "deliberate ln(10) literal in the 20/ln(10) dB-to-linear formula; keeping the explicit number documents the Web Audio math")]
+  const DB_TO_LINEAR_SCALE: f32 = 20.0 / 2.302_585_1;
+  ```
+  (Alternative, if preferred at execution time: replace with `20.0 / std::f32::consts::LN_10` — clippy's suggestion — which is exactly equal and needs no attribute. Either resolves the error; do not leave it unhandled.)
+
+- [ ] **Step 3: Apply, then verify all five are gone**
+
+```bash
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null \
+ | jq -r 'select(.reason=="compiler-message").message.code.code' \
+ | grep -Ec 'dead_code|search_is_some|explicit_auto_deref|type_complexity|approx_constant'
+```
+Expected: `0`.
+
+- [ ] **Step 4: fmt + commit**
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "chore(showcase): resolve ambiguous clippy lints (fix or C-parity expect)
+
+Per-occurrence: removed genuine artifacts; #[expect]+reason for C-parity cases.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Bucket-A `#[expect]` — dominant lints (`needless_range_loop`, `unused_assignments`)
+
+The bulk. Mechanical: add a tightest-scope `#[expect(<lint>, reason = "C-parity: …")]` directly above each flagged statement.
+
+**Files:**
+- Modify: rows with lint `clippy::needless_range_loop` or `unused_assignments`. These span ~110 examples — chunk by category directory (`audio/`, `core/`, `shapes/`, `models/`, `shaders/`, `text/`, `textures/`, `raygui/`, `others/`) for parallel subagents.
+
+- [ ] **Step 1: List affected files per category**
+
+```bash
+grep -P '\t(clippy::needless_range_loop|unused_assignments)$' target/clippy-worksheet.tsv | cut -f1 | sort -u
+```
+
+- [ ] **Step 2: Add the attribute per occurrence**
+
+For each flagged statement, insert directly above it (matching indentation):
+
+`needless_range_loop` on a `for i in 0..n {`:
+```rust
+#[expect(clippy::needless_range_loop, reason = "C-parity: C indexes with for (i = 0; i < n; i++)")]
+for i in 0..n {
+```
+
+`unused_assignments` (e.g. the documented `let mut time_played: f32 = 0.0;` in audio examples, and init-then-overwrite locals):
+```rust
+#[expect(unused_assignments, reason = "C-parity: C declares + initializes before the loop overwrites it")]
+let mut time_played: f32 = 0.0;
+```
+
+Tailor the `reason` text to the actual C pattern at that site (e.g. "init-then-overwrite", "scratch reused across the frame loop"). Do not remove `mut`, do not reorder, do not merge declarations.
+
+- [ ] **Step 3: Verify both lints gone**
+
+```bash
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null \
+ | jq -r 'select(.reason=="compiler-message").message.code.code' | grep -Ec 'needless_range_loop|unused_assignments'
+```
+Expected: `0`.
+
+- [ ] **Step 4: fmt + commit**
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "chore(showcase): #[expect] C-parity needless_range_loop + unused_assignments
+
+Tightest-scope expects with reasons; ports keep the C structure for the
+F1 side-by-side viewer.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Bucket-A `#[expect]` — remaining structural lints
+
+The rest of Bucket A: `collapsible_if`, `collapsible_else_if`, `manual_clamp`, `assign_op_pattern`, `too_many_arguments`, `needless_bool_assign`, `identity_op`, `unnecessary_cast`, `enum_variant_names`, `comparison_chain`, `nonminimal_bool`, `neg_cmp_op_on_partial_ord`, `manual_memcpy`, `mixed_case_hex_literals`, `excessive_precision`, `field_reassign_with_default`.
+
+**Files:**
+- Modify: rows with any of the above lints.
+
+- [ ] **Step 1: List affected occurrences**
+
+```bash
+grep -P '\tclippy::(collapsible_if|collapsible_else_if|manual_clamp|assign_op_pattern|too_many_arguments|needless_bool_assign|identity_op|unnecessary_cast|enum_variant_names|comparison_chain|nonminimal_bool|neg_cmp_op_on_partial_ord|manual_memcpy|mixed_case_hex_literals|excessive_precision|field_reassign_with_default)$' target/clippy-worksheet.tsv | sort -u
+```
+
+- [ ] **Step 2: Add the attribute per occurrence, scope per lint**
+
+Statement-scope (above the flagged statement), with a `reason` describing the C:
+- `collapsible_if`/`collapsible_else_if` → `reason = "C-parity: C nests the conditionals"`
+- `manual_clamp` → `reason = "C-parity: C clamps with explicit if branches"`
+- `assign_op_pattern` → `reason = "C-parity: C writes x = x + y"`
+- `needless_bool_assign` → `reason = "C-parity: C assigns the bool in if/else"`
+- `identity_op` → `reason = "C-parity: explicit *1 / +0 kept for alignment with the C"`
+- `unnecessary_cast` → `reason = "C-parity: explicit cast mirrors the C"`
+- `comparison_chain` → `reason = "C-parity: C uses if/else-if on </>"`
+- `nonminimal_bool` → `reason = "C-parity: boolean expression mirrors the C"`
+- `neg_cmp_op_on_partial_ord` → `reason = "C-parity: mirrors the C !(a < b)"`
+- `manual_memcpy` → `reason = "C-parity: C copies element-by-element in a loop"`
+- `mixed_case_hex_literals` → `reason = "C-parity: hex literal mirrors the C constant"`
+- `excessive_precision` → `reason = "C-parity: float literal mirrors the C constant"`
+- `field_reassign_with_default` → `reason = "C-parity: C zero-inits then sets fields"`
+
+Function-scope (above the `fn`), since the lint targets the signature:
+- `too_many_arguments` → `reason = "C-parity: mirrors the C function signature"`
+- `enum_variant_names` → on the `enum`, `reason = "C-parity: variant names mirror the C enum prefix"`
+
+- [ ] **Step 3: Verify gone**
+
+```bash
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL --message-format=json 2>/dev/null \
+ | jq -r 'select(.reason=="compiler-message").message.code.code' | sort | uniq -c
+```
+Expected: empty output (no compiler-message lints remain).
+
+- [ ] **Step 4: fmt + commit**
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "chore(showcase): #[expect] remaining C-parity structural lints
+
+Tightest-scope expects with C-parity reasons across clamp/assign-op/
+collapsible-if/too-many-args/etc.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Full zero-warning verification + drop non-firing expects
+
+- [ ] **Step 1: Run both legs in human format, confirm zero warnings**
+
+```bash
+cargo clippy -p raylib-showcase --examples 2>&1 | tail -5
+cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL 2>&1 | tail -5
+```
+Expected: each ends with `Finished` and **no** `warning:` lines (other than the benign `raylib-showcase@…: showcase: N example pair(s) registered` build-script note, which is not a clippy warning).
+
+- [ ] **Step 2: Confirm no `expect` fired falsely**
+
+An `#[expect]` whose lint did **not** fire produces an `unfulfilled_lint_expectations` warning. Step 1 would surface it. If any appear, remove that specific `#[expect]` (the underlying warning was already absent — likely a mis-scoped attribute) and re-run Step 1.
+
+- [ ] **Step 3: Confirm software_renderer leg too (thumbnail build path)**
+
+```bash
+cargo clippy -p raylib-showcase --examples --features software_renderer 2>&1 | tail -5
+```
+Expected: zero warnings. (If this leg surfaces new example warnings, classify + handle them per the same buckets, in a follow-up commit.)
+
+- [ ] **Step 4: No commit if clean** (verification only). If Step 2/3 required edits, fmt + commit:
+
+```bash
+cargo fmt --all
+git add showcase/examples
+git commit -m "chore(showcase): drop unfulfilled lint expectations / fix SR-leg warnings
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Add the CI gate to `showcase.yml`
+
+**Files:**
+- Modify: `.github/workflows/showcase.yml`
+
+- [ ] **Step 1: Read the current workflow to find the examples build step**
+
+```bash
+cat .github/workflows/showcase.yml
+```
+Identify the job/step that runs `cargo build … --examples` for the showcase (per the spec, currently build-only, no `-D warnings`).
+
+- [ ] **Step 2: Add a clippy gate step next to the build step**
+
+Add (matching the file's existing indentation/runner setup) a step that runs clippy with `-D warnings` over the same feature matrix the examples use:
+```yaml
+      - name: Clippy (showcase examples, deny warnings)
+        run: |
+          cargo clippy -p raylib-showcase --examples -- -D warnings
+          cargo clippy -p raylib-showcase --examples --features raygui,SUPPORT_CUSTOM_FRAME_CONTROL -- -D warnings
+```
+Place it so it runs on the same OS leg that already compiles the examples (do not add it to the `wasm-build` leg, which is `continue-on-error`). If the workflow uses a matrix, gate the step to the native (non-wasm) entries.
+
+- [ ] **Step 3: Validate the workflow YAML locally**
+
+```bash
+gh act -W .github/workflows/showcase.yml -n 2>&1 | tail -20   # dry-run/lint if Docker available
+```
+If `act`/Docker is unavailable, at minimum confirm the YAML parses:
+```bash
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/showcase.yml'))" && echo OK
+```
+Expected: `OK` (or a clean `act` dry-run).
+
+- [ ] **Step 4: Check the branch-protection ruleset implication**
+
+Per `[[ci-ruleset-required-checks-gotcha]]`: adding a *new step* to an existing job does not orphan a required context (the job name is unchanged), so no ruleset edit is needed. If this step is instead added as a **new job**, the new check context must be added to the `unstable` ruleset (id 17203815) in the same change, or PRs will hang on "Expected". Prefer adding a step to the existing job to avoid this.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add .github/workflows/showcase.yml
+git commit -m "ci(showcase): gate example clippy with -D warnings
+
+Locks in the post-sweep cleanliness; future ports must land warning-free
+or with a documented #[expect].
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Done-note + PR
+
+**Files:**
+- Create: `docs/superpowers/notes/post-release-showcase-clippy-cleanup-complete.md`
+
+- [ ] **Step 1: Write the done-note**
+
+Capture: the warning census (the `uniq -c` tally from Task 1 Step 2), the Bucket-B fixes (which lints, how many sites, any behavioral note), the ambiguous-lint decisions (Task 5), the gate decision + that it was added to `showcase.yml`, and any unexpected patterns surfaced. Mirror the structure of sibling notes in `docs/superpowers/notes/`.
+
+- [ ] **Step 2: commit the done-note**
+
+```bash
+git add docs/superpowers/notes/post-release-showcase-clippy-cleanup-complete.md
+git commit -m "docs: showcase clippy cleanup done-note
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Push and open the PR against canonical `unstable`**
+
+```bash
+git push -u origin chore/showcase-clippy-cleanup
+gh pr create --base unstable --repo raylib-rs/raylib-rs \
+  --title "chore(showcase): clippy cleanup + -D warnings gate" \
+  --body "<see Step 4>"
+```
+
+- [ ] **Step 4: PR body must include**
+
+- The warning census tally.
+- The Bucket-A/Bucket-B split rationale (C-parity `#[expect]` vs Rust-only fixes), citing the F1 side-by-side / visual-parity rule.
+- The **gate flag**: `showcase.yml` now runs clippy `-D warnings`, so every future port must land warning-free or with a documented `#[expect]` — explicitly called out as a signal change for the maintainer.
+- List of Bucket-B fix commits + any ambiguous-lint decisions.
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** zero-warning both legs (Tasks 6–8), no restructuring (Bucket-A `#[expect]` only, Tasks 6–7), Rust-only fixes isolated per-commit (Tasks 2–4), ambiguous handling (Task 5), tightest-scope + `reason` (Tasks 6–7 step 2), gate (Task 9), done-note + PR with gate flag (Task 10). The three documented audio `unused_assignments` and the `core_custom_frame_control` gated leg are both covered (Task 6 / superset leg in Task 1). ✓
+- **`jq` dependency:** Tasks use `jq` to parse JSON. If unavailable on the runner/host, fall back to the human-format log (`cargo clippy … 2>&1`) and the `#[warn(lint)]` notes for the per-lint tally, and per-example `cargo clippy --example <name>` for exact spans. The worksheet is an execution aid, not a deliverable.
+- **Parallelism:** Tasks 6–7 are embarrassingly parallel by category directory; safe to fan out to subagents since examples never share state. Tasks 2–5 (Bucket B + ambiguous) are smaller and best done in one pass to keep per-lint commits clean.

--- a/docs/superpowers/specs/2026-06-03-showcase-clippy-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-03-showcase-clippy-cleanup-design.md
@@ -1,0 +1,118 @@
+# Showcase clippy cleanup — design
+
+**Date:** 2026-06-03
+**Branch:** `chore/showcase-clippy-cleanup` (off canonical `unstable`)
+**Status:** approved, pre-implementation
+
+## Goal
+
+Make the showcase examples clippy-clean and keep them that way:
+
+- `cargo clippy -p raylib-showcase --examples` → zero warnings
+- `cargo clippy -p raylib-showcase --examples --features raygui` → zero warnings
+- (and the gated legs: `--features SUPPORT_CUSTOM_FRAME_CONTROL`, `--features software_renderer` where they pull in otherwise-skipped examples)
+
+…**without restructuring any port.** The F1 source-viewer side-by-side (C left / Rust right) is the showcase's load-bearing teaching feature; any restructure that breaks the line-by-line correspondence undoes WS9's visual-parity guarantee.
+
+This is post-`rc.2` polish (rc.2 shipped to crates.io 2026-06-03). It makes the released crate clippy-clean for downstream consumers and lays gate-readiness for the eventual 6.0.0 final cut.
+
+## Non-goals
+
+- No port restructuring to silence warnings.
+- No deleting or adding examples.
+- No changes to the F1 source viewer or its registry.
+- No edits to `raylib/` or `raylib-sys/`.
+- **No blind `cargo clippy --fix`** — it would "fix" Bucket-A (collapse C's nested `if`s, rewrite `x = x + y`, etc.) and destroy parity. Triage is applied by hand, per lint type.
+
+## Background — warning census
+
+Captured to `target/clippy-showcase.log` from both clippy legs (2026-06-03, pre-implementation snapshot; non-gated examples appear in both legs so raw note counts are ~2× the distinct `(example, lint)` total). Distinct `(example, lint)` pairs ≈ 150 across ~110 of the 229 examples. Lint distribution (approximate, both legs):
+
+| Lint | ~notes | Bucket |
+|---|---|---|
+| `clippy::needless_range_loop` | 95 | A |
+| `unused_assignments` | 37 | A |
+| `clippy::useless_conversion` | 37 | **B** |
+| `clippy::collapsible_if` (+`collapsible_else_if`) | 26 | A |
+| `clippy::manual_clamp` | 20 | A |
+| `clippy::assign_op_pattern` | 18 | A |
+| `clippy::too_many_arguments` | 13 | A |
+| `clippy::needless_borrows_for_generic_args` | 10 | **B** |
+| `clippy::needless_bool_assign` | 8 | A |
+| `clippy::identity_op` | 6 | A |
+| `clippy::unnecessary_cast` | 5 | A |
+| `clippy::enum_variant_names` | 4 | A |
+| `dead_code` | 3 | ? → inspect |
+| `unused_imports` | 2 | **B** |
+| `clippy::search_is_some` | 2 | ? → inspect |
+| `clippy::explicit_auto_deref` | 2 | ? → inspect |
+| `clippy::type_complexity` | 2 | ? → inspect |
+| `comparison_chain`, `nonminimal_bool`, `neg_cmp_op_on_partial_ord`, `manual_memcpy`, `mixed_case_hex_literals`, `excessive_precision`, `field_reassign_with_default` | 2 each | A |
+| `clippy::mem_replace_option_with_none` | 1 | **B** |
+
+High-warning outliers (post-fix mostly collapse, since they are dominated by Bucket-B `useless_conversion`): `models_decals` (22), `shaders_mandelbrot_set` (18, all auto-fixable), `textures_image_generation` (12, all auto-fixable), `models_animation_blend_custom` (9, all `useless_conversion`), `shaders_spotlight_rendering` (10), `models_animation_blending` (9).
+
+## Triage rule (the core decision)
+
+Decided **per lint type**, then sanity-checked per occurrence:
+
+### Bucket A — C-parity structural → `#[expect(...)]`
+
+The C original has the exact pattern; the port mirrors it for the side-by-side. Annotate, do **not** rewrite:
+
+```rust
+#[expect(clippy::needless_range_loop, reason = "C-parity: C indexes with for (i=0;i<n;i++)")]
+for i in 0..n { /* ... */ }
+```
+
+Bucket A lints: `needless_range_loop`, `unused_assignments`, `collapsible_if`/`collapsible_else_if`, `manual_clamp`, `assign_op_pattern`, `too_many_arguments`, `needless_bool_assign`, `identity_op`, `unnecessary_cast`, `enum_variant_names`, `comparison_chain`, `nonminimal_bool`, `neg_cmp_op_on_partial_ord`, `manual_memcpy`, `mixed_case_hex_literals`, `excessive_precision`, `field_reassign_with_default`.
+
+### Bucket B — Rust-only port artifacts → fix
+
+No corresponding C line, so removing the no-op is parity-safe *and* improves the port. Each lint-type lands as its **own commit** with a reviewer note (so any behavioral drift is easy to spot):
+
+- `useless_conversion` — drop the no-op `.into()` / `Vector3::from(x)` (x already `Vector3`).
+- `needless_borrows_for_generic_args` — drop the redundant `&`.
+- `unused_imports` — remove the import.
+- `mem_replace_option_with_none` — use `.take()`.
+
+### Ambiguous → inspect, default to `#[expect]`
+
+`dead_code`, `search_is_some`, `explicit_auto_deref`, `type_complexity`: open the C original. If it's a genuine Rust-only artifact, fix it (Bucket B). Otherwise `#[expect]` with a C-parity reason (per the approved **bias-to-allow** decision — when in doubt, preserve parity).
+
+## Scope-placement policy
+
+- **Tightest practical scope.** `#[expect]` on the offending statement (loops, assignments) or the function (`too_many_arguments`, `type_complexity`). Module-level `#![expect(...)]` is a code smell — used only if a single lint genuinely pervades one file, documented thoroughly in `reason`. After Bucket-B fixes, the high-count files collapse, so module-level should be unnecessary.
+- **`expect` over `allow`** throughout (MSRV 1.85 / edition 2024): if a lint stops firing later, `expect` errors, so allowlist drift is self-detecting.
+- **Every attribute carries `reason = "..."`**: `"C-parity: <what the C does>"` for Bucket A; Bucket-B fixes need no attribute (the warning is gone).
+- Accept that an inserted `#[expect]` line shifts Rust line numbers vs the C by one. A single, clearly-intentional annotation line reads correctly in the side-by-side; this is preferred over a broad module-level suppression that hides which line is non-idiomatic.
+
+## Execution plan
+
+1. **Worksheet.** Re-run both clippy legs on this branch, capture to `target/clippy-showcase.log`. Build a triage worksheet: every distinct `(file, lint)` → verdict (A-expect / B-fix / inspect) + planned scope. Single source of truth for the implementation pass.
+2. **Bucket-B fixes** first, one commit per lint-type (`useless_conversion`, then `needless_borrows_for_generic_args`, etc.), each with a reviewer-readable summary.
+3. **Bucket-A `#[expect]`** attributes. The per-example sweep is embarrassingly parallel once the worksheet exists; parallel subagents are a candidate, confirmed at plan time.
+4. **`cargo fmt --all`**, then re-run both clippy legs → zero warnings. Any `#[expect]` that does not fire ("this lint isn't actually emitted") gets dropped.
+5. **CI gate.** Add `cargo clippy -p raylib-showcase --examples -D warnings` (both feature sets, plus the gated-feature legs the matrix needs) to `showcase.yml`. Approved by maintainer; flagged in the PR body since it changes the showcase signal — every future port must land warning-free or with a documented attribute.
+6. **Done-note** at `docs/superpowers/notes/post-release-showcase-clippy-cleanup-complete.md`: warning census, Bucket-B fixes, the gate decision, any unexpected patterns. **One PR** to canonical `unstable` (the diff is mechanical).
+
+## Conventions
+
+- Co-author trailer on every commit: `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`.
+- `cargo fmt --all` before any commit touching Rust files (the `#[expect]` attributes trigger fmt).
+- Stage modified files explicitly; no `git add -A`.
+
+## Definition of done
+
+- Both clippy legs (and gated-feature legs) emit zero warnings.
+- Every `#[expect]`/`#[allow]` carries a `reason = "..."`.
+- Bucket-B fixes isolated in their own commits with reviewer summaries.
+- `-D warnings` gate added to `showcase.yml`; decision captured in PR body + done-note.
+- Done-note records the census, the fixes, and any unexpected patterns.
+
+## Pitfalls (from the session prompt / WS9 ledger)
+
+1. Three audio examples carry intentional `unused_assignments` on `let mut time_played: f32 = 0.0;` — documented C-parity, do not remove the `mut`.
+2. The WS9 transmute cases (`core_keyboard_testbed` gated, `textures_blend_modes` documented) are **not** clippy warnings — don't conflate.
+3. `core_custom_frame_control` is skipped without `SUPPORT_CUSTOM_FRAME_CONTROL`; run that leg too or note the clippy gap.
+4. Module-level `#![expect]` smell — prefer per-occurrence; if a file has 18 of one lint, inspect why before blanket-suppressing.

--- a/docs/superpowers/specs/2026-06-03-showcase-clippy-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-03-showcase-clippy-cleanup-design.md
@@ -47,6 +47,7 @@ Captured to `target/clippy-showcase.log` from both clippy legs (2026-06-03, pre-
 | `clippy::search_is_some` | 2 | ? → inspect |
 | `clippy::explicit_auto_deref` | 2 | ? → inspect |
 | `clippy::type_complexity` | 2 | ? → inspect |
+| `clippy::approx_constant` | 1 | ? → inspect (**deny-by-default — errors clippy**) |
 | `comparison_chain`, `nonminimal_bool`, `neg_cmp_op_on_partial_ord`, `manual_memcpy`, `mixed_case_hex_literals`, `excessive_precision`, `field_reassign_with_default` | 2 each | A |
 | `clippy::mem_replace_option_with_none` | 1 | **B** |
 

--- a/showcase/examples/audio/audio_amp_envelope.rs
+++ b/showcase/examples/audio/audio_amp_envelope.rs
@@ -194,6 +194,10 @@ fn main() {
                 }
             } else {
                 // Clear buffer if silent to avoid looping noise
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for i in 0..BUFFER_SIZE {
                     buffer[i] = 0.0;
                 }

--- a/showcase/examples/audio/audio_mixed_processor.rs
+++ b/showcase/examples/audio/audio_mixed_processor.rs
@@ -140,6 +140,10 @@ fn main() {
         );
 
         d.draw_rectangle(199, 199, 402, 34, Color::LIGHTGRAY);
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..400 {
             d.draw_line(
                 201 + i as i32,

--- a/showcase/examples/audio/audio_mixed_processor.rs
+++ b/showcase/examples/audio/audio_mixed_processor.rs
@@ -108,6 +108,10 @@ fn main() {
                 *exp += 0.05;
             }
 
+            #[expect(
+                clippy::manual_clamp,
+                reason = "C-parity: C clamps with explicit if branches"
+            )]
             if *exp <= 0.5 {
                 *exp = 0.5;
             }

--- a/showcase/examples/audio/audio_module_playing.rs
+++ b/showcase/examples/audio/audio_module_playing.rs
@@ -90,6 +90,10 @@ fn main() {
 
     music.play_stream();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C initializes time_played before the playback loop overwrites it"
+    )]
     let mut time_played: f32 = 0.0;
     let mut pause = false;
 

--- a/showcase/examples/audio/audio_music_stream.rs
+++ b/showcase/examples/audio/audio_music_stream.rs
@@ -36,6 +36,10 @@ fn main() {
 
     music.play_stream();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C initializes time_played before the playback loop overwrites it"
+    )]
     let mut time_played: f32 = 0.0; // Time played normalized [0.0f..1.0f]
     let mut pause = false; // Music playing paused
 

--- a/showcase/examples/audio/audio_raw_stream.rs
+++ b/showcase/examples/audio/audio_raw_stream.rs
@@ -95,6 +95,10 @@ fn main() {
         }
 
         if stream.is_processed() {
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..BUFFER_SIZE {
                 let wavelength = SAMPLE_RATE as i32 / sine_frequency;
                 buffer[i] = (2.0 * PI * sine_index as f32 / wavelength as f32).sin();

--- a/showcase/examples/audio/audio_spectrum_visualizer.rs
+++ b/showcase/examples/audio/audio_spectrum_visualizer.rs
@@ -201,7 +201,7 @@ fn main() {
         Image::from_raw(raylib::ffi::GenImageColor(
             BUFFER_SIZE as i32,
             TEXTURE_HEIGHT,
-            Color::WHITE.into(),
+            Color::WHITE,
         ))
     };
     let fft_texture = rl

--- a/showcase/examples/audio/audio_spectrum_visualizer.rs
+++ b/showcase/examples/audio/audio_spectrum_visualizer.rs
@@ -38,6 +38,10 @@ const FFT_HISTORICAL_SMOOTHING_DUR: f32 = 2.0;
 const MIN_DECIBELS: f32 = -100.0; // https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/minDecibels
 const MAX_DECIBELS: f32 = -30.0; // https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/maxDecibels
 const INVERSE_DECIBEL_RANGE: f32 = 1.0 / (MAX_DECIBELS - MIN_DECIBELS);
+#[expect(
+    clippy::approx_constant,
+    reason = "deliberate ln(10) literal in the 20/ln(10) dB-to-linear formula; the explicit number documents the Web Audio math"
+)]
 const DB_TO_LINEAR_SCALE: f32 = 20.0 / 2.302_585_1;
 const SMOOTHING_TIME_CONSTANT: f32 = 0.8; // https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/smoothingTimeConstant
 const TEXTURE_HEIGHT: i32 = 1;

--- a/showcase/examples/audio/audio_spectrum_visualizer.rs
+++ b/showcase/examples/audio/audio_spectrum_visualizer.rs
@@ -125,6 +125,10 @@ fn cooley_tukey_fft_slow(spectrum: &mut [FFTComplex], n: usize) {
 }
 
 fn capture_frame(fft_data: &mut FFTData, audio_samples: &[f32], now: f64) {
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..FFT_WINDOW_SIZE {
         let x = (2.0 * PI * i as f32) / (FFT_WINDOW_SIZE as f32 - 1.0);
         let blackman_weight = 0.42 - 0.5 * x.cos() + 0.08 * (2.0 * x).cos(); // https://en.wikipedia.org/wiki/Window_function#Blackman_window
@@ -139,6 +143,10 @@ fn capture_frame(fft_data: &mut FFTData, audio_samples: &[f32], now: f64) {
 
     let mut smoothed_spectrum = [0.0f32; BUFFER_SIZE];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for bin in 0..BUFFER_SIZE {
         let re = fft_data.work_buffer[bin].real;
         let im = fft_data.work_buffer[bin].imaginary;
@@ -169,6 +177,10 @@ fn render_frame(fft_data: &FFTData, fft_image: &mut Image) {
     }
 
     let amplitude = &fft_data.fft_history[history_position as usize];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for bin in 0..BUFFER_SIZE {
         fft_image.draw_pixel(
             bin as i32,
@@ -278,6 +290,10 @@ fn main() {
         // Update
         //----------------------------------------------------------------------------------
         while audio_stream.is_processed() {
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..AUDIO_STREAM_RING_BUFFER_SIZE {
                 // SAFETY: wav_cursor is wrapped to wav_frame_count below; index lies in [0, frameCount).
                 let (left, right) = unsafe {

--- a/showcase/examples/audio/audio_stream_callback.rs
+++ b/showcase/examples/audio/audio_stream_callback.rs
@@ -95,6 +95,10 @@ fn sine_callback(frames_out: &mut [f32], state: &Mutex<SharedState>) {
 
     // Synthesize the sine wave
     let frame_count = frames_out.len();
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..frame_count {
         frames_out[i] = (2.0 * PI * s.wave_index as f32 / wavelength as f32).sin();
 
@@ -116,6 +120,10 @@ fn square_callback(frames_out: &mut [f32], state: &Mutex<SharedState>) {
 
     // Synthesize the square wave
     let frame_count = frames_out.len();
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..frame_count {
         frames_out[i] = if s.wave_index < wavelength / 2 {
             1.0
@@ -140,6 +148,10 @@ fn triangle_callback(frames_out: &mut [f32], state: &Mutex<SharedState>) {
 
     // Synthesize the triangle wave
     let frame_count = frames_out.len();
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..frame_count {
         frames_out[i] = if s.wave_index < wavelength / 2 {
             -1.0 + 2.0 * s.wave_index as f32 / (wavelength / 2) as f32
@@ -164,6 +176,10 @@ fn sawtooth_callback(frames_out: &mut [f32], state: &Mutex<SharedState>) {
 
     // Synthesize the sawtooth wave
     let frame_count = frames_out.len();
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..frame_count {
         frames_out[i] = -1.0 + 2.0 * s.wave_index as f32 / wavelength as f32;
         s.wave_index += 1;

--- a/showcase/examples/audio/audio_stream_callback.rs
+++ b/showcase/examples/audio/audio_stream_callback.rs
@@ -65,6 +65,10 @@ fn wave_type_as_str(t: WaveType) -> &'static str {
 // callback at a time; cycle wave types by unset + set.
 fn install_callback(stream: &AudioStream, wave_type: WaveType, state: Arc<Mutex<SharedState>>) {
     unset_audio_stream_callback(stream);
+    #[expect(
+        clippy::type_complexity,
+        reason = "Rust closure storage for C's AudioCallback dispatch; explicit type annotation unifies the match arms"
+    )]
     let cb: Box<dyn FnMut(&mut [f32]) + Send + 'static> = match wave_type {
         WaveType::Sine => Box::new(move |frames_out: &mut [f32]| {
             sine_callback(frames_out, &state);

--- a/showcase/examples/audio/audio_stream_effects.rs
+++ b/showcase/examples/audio/audio_stream_effects.rs
@@ -136,6 +136,10 @@ fn main() {
 
     music.play_stream();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C initializes time_played before the playback loop overwrites it"
+    )]
     let mut time_played: f32 = 0.0; // Time played normalized [0.0f..1.0f]
     let mut pause = false; // Music playing paused
 

--- a/showcase/examples/core/core_2d_camera.rs
+++ b/showcase/examples/core/core_2d_camera.rs
@@ -89,6 +89,10 @@ fn main() {
         }
 
         // Limit camera rotation to 80 degrees (-40 to 40)
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if camera.rotation > 40.0 {
             camera.rotation = 40.0;
         } else if camera.rotation < -40.0 {
@@ -99,6 +103,10 @@ fn main() {
         // Uses log scaling to provide consistent zoom speed
         camera.zoom = (camera.zoom.ln() + rl.get_mouse_wheel_move() * 0.1).exp();
 
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if camera.zoom > 3.0 {
             camera.zoom = 3.0;
         } else if camera.zoom < 0.1 {

--- a/showcase/examples/core/core_2d_camera_mouse_zoom.rs
+++ b/showcase/examples/core/core_2d_camera_mouse_zoom.rs
@@ -21,6 +21,10 @@ use raylib_showcase::SourceViewer;
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------

--- a/showcase/examples/core/core_2d_camera_platformer.rs
+++ b/showcase/examples/core/core_2d_camera_platformer.rs
@@ -147,6 +147,10 @@ fn main() {
 
         camera.zoom += rl.get_mouse_wheel_move() * 0.05;
 
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if camera.zoom > 3.0 {
             camera.zoom = 3.0;
         } else if camera.zoom < 0.25 {
@@ -316,6 +320,10 @@ fn update_camera_center_inside_map(
     }
 }
 
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn update_camera_center_smooth_follow(
     camera: &mut Camera2D,
     player: &mut Player,

--- a/showcase/examples/core/core_3d_camera_fps.rs
+++ b/showcase/examples/core/core_3d_camera_fps.rs
@@ -294,6 +294,10 @@ fn update_body(
 }
 
 // Update camera for FPS behaviour
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn update_camera_fps(camera: &mut Camera3D, state: &mut GameState) {
     let up = Vector3::new(0.0, 1.0, 0.0);
     let target_offset = Vector3::new(0.0, 0.0, -1.0);

--- a/showcase/examples/core/core_automation_events.rs
+++ b/showcase/examples/core/core_automation_events.rs
@@ -239,6 +239,10 @@ fn main() {
 
         // WARNING: On event replay, mouse-wheel internal value is set
         camera.zoom += rl.get_mouse_wheel_move() * 0.05;
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if camera.zoom > 3.0 {
             camera.zoom = 3.0;
         } else if camera.zoom < 0.25 {
@@ -274,6 +278,7 @@ fn main() {
         //----------------------------------------------------------------------------------
 
         // Events management
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_pressed(KeyboardKey::KEY_S)
         // Toggle events recording
         {

--- a/showcase/examples/core/core_directory_files.rs
+++ b/showcase/examples/core/core_directory_files.rs
@@ -113,7 +113,7 @@ fn main() {
         unsafe {
             raylib::ffi::GuiListViewEx(
                 Rectangle::new(0.0, 50.0, screen_w as f32, screen_h as f32 - 50.0),
-                path_ptrs.as_mut_ptr() as *mut *const std::os::raw::c_char,
+                path_ptrs.as_mut_ptr(),
                 files.count() as i32,
                 &mut list_scroll_index,
                 &mut list_item_active,

--- a/showcase/examples/core/core_highdpi_testbed.rs
+++ b/showcase/examples/core/core_highdpi_testbed.rs
@@ -40,9 +40,25 @@ fn main() {
         .title("raylib [core] example - highdpi testbed")
         .build();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut scale_dpi = rl.get_window_scale_dpi();
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut mouse_pos = rl.get_mouse_position();
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut current_monitor = get_current_monitor();
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut window_pos = rl.get_window_position();
 
     let grid_spacing: i32 = 40; // Grid spacing in pixels

--- a/showcase/examples/core/core_input_actions.rs
+++ b/showcase/examples/core/core_input_actions.rs
@@ -80,12 +80,12 @@ fn main() {
     };
 
     // Set default actions
+    let mut action_set: i32 = 0;
+    set_actions_default(&mut state);
     #[expect(
         unused_assignments,
         reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
     )]
-    let mut action_set: i32 = 0;
-    set_actions_default(&mut state);
     let mut release_action = false;
 
     let mut position = Vector2::new(400.0, 200.0);

--- a/showcase/examples/core/core_input_actions.rs
+++ b/showcase/examples/core/core_input_actions.rs
@@ -80,6 +80,10 @@ fn main() {
     };
 
     // Set default actions
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut action_set: i32 = 0;
     set_actions_default(&mut state);
     let mut release_action = false;

--- a/showcase/examples/core/core_input_gamepad.rs
+++ b/showcase/examples/core/core_input_gamepad.rs
@@ -60,6 +60,10 @@ fn main() {
     let left_trigger_deadzone = -0.9_f32;
     let right_trigger_deadzone = -0.9_f32;
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut vibrate_button = Rectangle::new(0.0, 0.0, 0.0, 0.0);
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second

--- a/showcase/examples/core/core_input_gamepad.rs
+++ b/showcase/examples/core/core_input_gamepad.rs
@@ -171,8 +171,16 @@ fn main() {
                 Color::BLACK,
             );
 
+            #[expect(
+                clippy::search_is_some,
+                reason = "C-parity: mirrors TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_1) > -1 from the C original"
+            )]
             let is_xbox = gp_name_lower.find(XBOX_ALIAS_1).is_some()
                 || gp_name_lower.find(XBOX_ALIAS_2).is_some();
+            #[expect(
+                clippy::search_is_some,
+                reason = "C-parity: mirrors TextFindIndex(TextToLower(GetGamepadName(gamepad)), PS_ALIAS_1) > -1 from the C original"
+            )]
             let is_ps = gp_name_lower.find(PS_ALIAS_1).is_some()
                 || gp_name_lower.find(PS_ALIAS_2).is_some();
 

--- a/showcase/examples/core/core_input_gestures.rs
+++ b/showcase/examples/core/core_input_gestures.rs
@@ -32,6 +32,10 @@ fn main() {
         .title("raylib [core] example - input gestures")
         .build();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut touch_position = Vector2::new(0.0, 0.0);
     let touch_area = Rectangle::new(
         220.0,
@@ -105,6 +109,10 @@ fn main() {
 
                 // Reset gestures strings
                 if gestures_count >= MAX_GESTURE_STRINGS {
+                    #[expect(
+                        clippy::needless_range_loop,
+                        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                    )]
                     for i in 0..MAX_GESTURE_STRINGS {
                         gesture_strings[i].clear();
                     }
@@ -139,6 +147,10 @@ fn main() {
             Color::GRAY.alpha(0.5),
         );
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..gestures_count {
             if i % 2 == 0 {
                 d.draw_rectangle(10, 30 + 20 * i as i32, 200, 20, Color::LIGHTGRAY.alpha(0.5));

--- a/showcase/examples/core/core_input_gestures.rs
+++ b/showcase/examples/core/core_input_gestures.rs
@@ -66,6 +66,7 @@ fn main() {
         current_gesture = rl.get_gesture_detected();
         touch_position = rl.get_touch_position(0);
 
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if touch_area.check_collision_point_rec(touch_position)
             && (current_gesture != Gesture::GESTURE_NONE)
         {

--- a/showcase/examples/core/core_input_gestures_testbed.rs
+++ b/showcase/examples/core/core_input_gestures_testbed.rs
@@ -102,6 +102,10 @@ fn main() {
     // Protractor variables definitions
     let angle_length: f32 = 90.0;
     let mut current_angle_degrees: f32 = 0.0;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut final_vector = Vector2::new(0.0, 0.0);
     let protractor_position = Vector2::new(266.0, 315.0);
 
@@ -629,6 +633,10 @@ fn main() {
         // GESTURE_NONE
         {
             if touch_count != 0 {
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for i in 0..(touch_count as usize) {
                     d.draw_circle_v(touch_position[i], 50.0, gesture_color.alpha(0.5));
                     d.draw_circle_v(touch_position[i], 5.0, gesture_color);

--- a/showcase/examples/core/core_input_mouse.rs
+++ b/showcase/examples/core/core_input_mouse.rs
@@ -30,6 +30,10 @@ fn main() {
         .title("raylib [core] example - input mouse")
         .build();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut ball_position = Vector2::new(-100.0, -100.0);
     let mut ball_color = Color::DARKBLUE;
 

--- a/showcase/examples/core/core_input_multitouch.rs
+++ b/showcase/examples/core/core_input_multitouch.rs
@@ -54,6 +54,10 @@ fn main() {
             t_count = MAX_TOUCH_POINTS;
         }
         // Get touch points positions
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..t_count {
             touch_positions[i] = rl.get_touch_position(i as u32);
         }
@@ -66,6 +70,10 @@ fn main() {
 
         d.clear_background(Color::RAYWHITE);
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..t_count {
             // Make sure point is not (0, 0) as this means there is no touch for it
             if (touch_positions[i].x > 0.0) && (touch_positions[i].y > 0.0) {

--- a/showcase/examples/core/core_input_virtual_controls.rs
+++ b/showcase/examples/core/core_input_virtual_controls.rs
@@ -84,7 +84,15 @@ fn main() {
         Color::GREEN,  // Down
     ];
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut pressed_button: i32 = BUTTON_NONE;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut input_position = Vector2::new(0.0, 0.0);
 
     let mut player_position = Vector2::new(screen_width as f32 / 2.0, screen_height as f32 / 2.0);
@@ -115,6 +123,10 @@ fn main() {
                 && rl.is_mouse_button_down(MouseButton::MOUSE_BUTTON_LEFT))
         {
             // Find nearest D-Pad button to the input position
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..BUTTON_MAX {
                 let dist_x = (button_positions[i].x - input_position.x).abs();
                 let dist_y = (button_positions[i].y - input_position.y).abs();

--- a/showcase/examples/core/core_keyboard_testbed.rs
+++ b/showcase/examples/core/core_keyboard_testbed.rs
@@ -208,6 +208,10 @@ fn main() {
 
     // Keyboard line 01
     let mut line01_key_widths: [i32; 15] = [0; 15];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..15 {
         line01_key_widths[i] = 45;
     }
@@ -232,6 +236,10 @@ fn main() {
 
     // Keyboard line 02
     let mut line02_key_widths: [i32; 15] = [0; 15];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..15 {
         line02_key_widths[i] = 45;
     }
@@ -257,6 +265,10 @@ fn main() {
 
     // Keyboard line 03
     let mut line03_key_widths: [i32; 15] = [0; 15];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..15 {
         line03_key_widths[i] = 45;
     }
@@ -282,6 +294,10 @@ fn main() {
 
     // Keyboard line 04
     let mut line04_key_widths: [i32; 14] = [0; 14];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..14 {
         line04_key_widths[i] = 45;
     }
@@ -306,6 +322,10 @@ fn main() {
 
     // Keyboard line 05
     let mut line05_key_widths: [i32; 14] = [0; 14];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..14 {
         line05_key_widths[i] = 45;
     }
@@ -330,6 +350,10 @@ fn main() {
 
     // Keyboard line 06
     let mut line06_key_widths: [i32; 11] = [0; 11];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..11 {
         line06_key_widths[i] = 45;
     }

--- a/showcase/examples/core/core_random_sequence.rs
+++ b/showcase/examples/core/core_random_sequence.rs
@@ -150,6 +150,7 @@ fn main() {
             );
         }
 
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_pressed(KeyboardKey::KEY_DOWN) {
             if rect_count >= 4 {
                 rect_count -= 1;

--- a/showcase/examples/core/core_random_sequence.rs
+++ b/showcase/examples/core/core_random_sequence.rs
@@ -175,6 +175,10 @@ fn main() {
 
         d.clear_background(Color::RAYWHITE);
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..(rect_count as usize) {
             d.draw_rectangle_rec(rectangles[i].rect, rectangles[i].color);
 

--- a/showcase/examples/core/core_screen_recording.rs
+++ b/showcase/examples/core/core_screen_recording.rs
@@ -28,6 +28,10 @@ const MAX_SINEWAVE_POINTS: usize = 256;
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    unused_assignments,
+    reason = "C-parity: the gif_recording reset before window close is an assignment-expression (not a let binding), where a statement-scoped attribute is rejected by stable Rust (E0658); it is dead in this RAII port but kept to mirror the C, suppressed at fn scope"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------
@@ -153,10 +157,6 @@ fn main() {
     //--------------------------------------------------------------------------------------
     // If still recording a GIF on close window, just finish (omitted — see top-of-file note)
     if gif_recording {
-        #[expect(
-            unused_assignments,
-            reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
-        )]
         gif_recording = false;
     }
 

--- a/showcase/examples/core/core_screen_recording.rs
+++ b/showcase/examples/core/core_screen_recording.rs
@@ -49,6 +49,10 @@ fn main() {
     // Get sine wave points for line drawing
     let mut sine_points: [Vector2; MAX_SINEWAVE_POINTS] =
         [Vector2::new(0.0, 0.0); MAX_SINEWAVE_POINTS];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_SINEWAVE_POINTS {
         sine_points[i].x = i as f32 * rl.get_screen_width() as f32 / 180.0;
         sine_points[i].y = screen_height as f32 / 2.0
@@ -149,6 +153,10 @@ fn main() {
     //--------------------------------------------------------------------------------------
     // If still recording a GIF on close window, just finish (omitted — see top-of-file note)
     if gif_recording {
+        #[expect(
+            unused_assignments,
+            reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+        )]
         gif_recording = false;
     }
 

--- a/showcase/examples/core/core_text_file_loading.rs
+++ b/showcase/examples/core/core_text_file_loading.rs
@@ -58,6 +58,10 @@ fn main() {
     // Wrap the lines as needed
     // idiomatic: we mirror the C in-place wrap by inserting '\n' characters. Rust strings are
     // UTF-8, but the upstream operates on ASCII spaces — keep working in bytes for parity.
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..line_count {
         let mut bytes: Vec<u8> = lines[i].clone().into_bytes();
         let len = bytes.len();
@@ -108,6 +112,10 @@ fn main() {
     // Calculating the total height so that we can show a scrollbar
     let mut text_height: i32 = 0;
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..line_count {
         let c = std::ffi::CString::new(lines[i].as_str()).unwrap();
         let size = unsafe {
@@ -173,6 +181,10 @@ fn main() {
             let mut m = d.begin_mode2D(cam);
             // Going through all the read lines
             let mut t: i32 = text_top;
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..line_count {
                 // Each time we go through and calculate the height of the text to move the cursor appropriately
                 let size = if !lines[i].is_empty() {

--- a/showcase/examples/core/core_undo_redo.rs
+++ b/showcase/examples/core/core_undo_redo.rs
@@ -266,6 +266,10 @@ fn main() {
     // Init undo buffer to store MAX_UNDO_STATES states
     let mut states: Vec<PlayerState> = vec![PlayerState::default(); MAX_UNDO_STATES];
     // Init all undo states to current state
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_UNDO_STATES {
         states[i] = player;
     }

--- a/showcase/examples/core/core_undo_redo.rs
+++ b/showcase/examples/core/core_undo_redo.rs
@@ -159,6 +159,10 @@ fn draw_undo_buffer(
     }
 
     // Draw occupied slots: firstUndoIndex --> currentUndoIndex
+    #[expect(
+        clippy::comparison_chain,
+        reason = "C-parity: C uses if/else-if on </>"
+    )]
     if first_undo_index < current_undo_index {
         for i in first_undo_index..current_undo_index {
             d.draw_rectangle(
@@ -232,6 +236,10 @@ fn draw_undo_buffer(
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::field_reassign_with_default,
+    reason = "C-parity: C zero-inits then sets fields"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------
@@ -345,6 +353,7 @@ fn main() {
         }
 
         // Recover previous state from buffer: CTRL+Z
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_down(KeyboardKey::KEY_LEFT_CONTROL) && rl.is_key_pressed(KeyboardKey::KEY_Z) {
             if current_undo_index != first_undo_index {
                 current_undo_index -= 1;
@@ -359,6 +368,7 @@ fn main() {
         }
 
         // Recover next state from buffer: CTRL+Y
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_down(KeyboardKey::KEY_LEFT_CONTROL) && rl.is_key_pressed(KeyboardKey::KEY_Y) {
             if current_undo_index != last_undo_index {
                 let mut next_undo_index = current_undo_index + 1;
@@ -395,6 +405,10 @@ fn main() {
         // Draw player visited cells recorded by undo
         // NOTE: Remember we are using a ring buffer approach so,
         // some cells info could start at the end of the array and end at the beginning
+        #[expect(
+            clippy::comparison_chain,
+            reason = "C-parity: C uses if/else-if on </>"
+        )]
         if last_undo_index > first_undo_index {
             for i in first_undo_index..current_undo_index {
                 d.draw_rectangle_rec(

--- a/showcase/examples/core/core_viewport_scaling.rs
+++ b/showcase/examples/core/core_viewport_scaling.rs
@@ -22,6 +22,10 @@ const RESOLUTION_COUNT: usize = 4; // For iteration purposes and teaching exampl
 
 #[derive(Clone, Copy, PartialEq)]
 #[repr(i32)]
+#[expect(
+    clippy::enum_variant_names,
+    reason = "C-parity: variant names mirror the C enum prefix"
+)]
 enum ViewportType {
     // Only upscale, useful for pixel art
     KeepAspectInteger = 0,
@@ -200,6 +204,10 @@ fn keep_width_centered(
     source_rect.height *= -1.0;
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn resize_render_size(
     rl: &mut RaylibHandle,
     thread: &RaylibThread,

--- a/showcase/examples/core/core_window_letterbox.rs
+++ b/showcase/examples/core/core_window_letterbox.rs
@@ -52,6 +52,10 @@ fn main() {
         .set_texture_filter(&thread, TextureFilter::TEXTURE_FILTER_BILINEAR);
 
     let mut colors: [Color; 10] = [Color::new(0, 0, 0, 0); 10];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..10 {
         colors[i] = Color::new(
             rl.get_random_value::<i32>(100..=250) as u8,
@@ -77,6 +81,10 @@ fn main() {
 
         if rl.is_key_pressed(KeyboardKey::KEY_SPACE) {
             // Recalculate random colors for the bars
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..10 {
                 colors[i] = Color::new(
                     rl.get_random_value::<i32>(100..=250) as u8,

--- a/showcase/examples/core/core_world_screen.rs
+++ b/showcase/examples/core/core_world_screen.rs
@@ -39,6 +39,10 @@ fn main() {
     );
 
     let cube_position = Vector3::new(0.0, 0.0, 0.0);
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut cube_screen_position = Vector2::new(0.0, 0.0);
 
     rl.disable_cursor(); // Limit cursor to relative movement inside the window

--- a/showcase/examples/models/models_animation_blend_custom.rs
+++ b/showcase/examples/models/models_animation_blend_custom.rs
@@ -156,19 +156,22 @@ fn update_model_animation_bones(
                 unsafe { &*(*anim1.keyframePoses.offset(frame1 as isize)).offset(bone_index) };
 
             // Blend the transforms
-            let blended_translation = Vector3::from(anim_transform0.translation)
-                .lerp(anim_transform1.translation.into(), bone_blend_factor);
-            let blended_rotation = Quaternion::from(anim_transform0.rotation)
-                .slerp(anim_transform1.rotation.into(), bone_blend_factor);
-            let blended_scale = Vector3::from(anim_transform0.scale)
-                .lerp(anim_transform1.scale.into(), bone_blend_factor);
+            let blended_translation = anim_transform0
+                .translation
+                .lerp(anim_transform1.translation, bone_blend_factor);
+            let blended_rotation = anim_transform0
+                .rotation
+                .slerp(anim_transform1.rotation, bone_blend_factor);
+            let blended_scale = anim_transform0
+                .scale
+                .lerp(anim_transform1.scale, bone_blend_factor);
 
             // Convert bind pose to matrix
             let bind_matrix = Matrix::scale(
                 bind_transform.scale.x,
                 bind_transform.scale.y,
                 bind_transform.scale.z,
-            ) * Quaternion::from(bind_transform.rotation).to_matrix()
+            ) * bind_transform.rotation.to_matrix()
                 * Matrix::translate(
                     bind_transform.translation.x,
                     bind_transform.translation.y,
@@ -187,8 +190,7 @@ fn update_model_animation_bones(
             // Calculate final bone matrix (similar to UpdateModelAnimationBones)
             // SAFETY: boneMatrices is allocated by raylib for boneCount entries.
             unsafe {
-                *model.boneMatrices.offset(bone_index) =
-                    (bind_matrix.invert() * blended_matrix).into();
+                *model.boneMatrices.offset(bone_index) = bind_matrix.invert() * blended_matrix;
             }
         }
 
@@ -247,7 +249,7 @@ fn update_model_animation_bones(
                         unsafe { *mesh.vertices.offset(v_counter + 2) },
                     );
                     // SAFETY: boneMatrices is allocated for skeleton.boneCount entries.
-                    let bone_mat: Matrix = unsafe { *model.boneMatrices.offset(bone_index) }.into();
+                    let bone_mat: Matrix = unsafe { *model.boneMatrices.offset(bone_index) };
                     anim_vertex = anim_vertex.transform(bone_mat);
                     // SAFETY: animVertices was checked non-null and has vertexCount*3 floats.
                     unsafe {

--- a/showcase/examples/models/models_animation_blending.rs
+++ b/showcase/examples/models/models_animation_blending.rs
@@ -26,6 +26,10 @@ const GLSL_VERSION: i32 = 330;
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    unused_assignments,
+    reason = "C-parity: two anim_blend_factor resets are assignment-expressions (not let bindings), where a statement-scoped attribute is rejected by stable Rust (E0658); suppressed at fn scope. The let-binding sites keep their tighter statement-level expects."
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------
@@ -157,10 +161,6 @@ fn main() {
                 // Set animation transition
                 anim_transition = true;
                 anim_blend_time_counter = 0.0;
-                #[expect(
-                    unused_assignments,
-                    reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
-                )]
                 anim_blend_factor = 0.0;
             }
 
@@ -216,10 +216,6 @@ fn main() {
                     }
                     current_anim_playing = next_anim_to_play; // Update current animation playing
 
-                    #[expect(
-                        unused_assignments,
-                        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
-                    )]
                     anim_blend_factor = 0.0; // Reset blend factor
                     anim_transition = false; // Exit transition mode
                     anim_blend_time_counter = 0.0;

--- a/showcase/examples/models/models_animation_blending.rs
+++ b/showcase/examples/models/models_animation_blending.rs
@@ -87,6 +87,10 @@ fn main() {
     let mut anim_current_frame1: f32 = 0.0; // Next animation frame (supporting interpolated frames)
     let mut anim_frame_speed1: f32 = 0.5; // Next animation play speed
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut anim_blend_factor: f32 = 0.0; // Blend factor from anim0[frame0] --> anim1[frame1], [0.0f..1.0f]
     // NOTE: 0.0f results in full anim0[] and 1.0f in full anim1[]
 
@@ -109,7 +113,15 @@ fn main() {
 
     let mut dropdown_edit_mode0 = false;
     let mut dropdown_edit_mode1 = false;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut anim_frame_progress0: f32 = 0.0;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut anim_frame_progress1: f32 = 0.0;
     let mut anim_blend_progress: f32 = 0.0;
 
@@ -145,6 +157,10 @@ fn main() {
                 // Set animation transition
                 anim_transition = true;
                 anim_blend_time_counter = 0.0;
+                #[expect(
+                    unused_assignments,
+                    reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+                )]
                 anim_blend_factor = 0.0;
             }
 
@@ -200,6 +216,10 @@ fn main() {
                     }
                     current_anim_playing = next_anim_to_play; // Update current animation playing
 
+                    #[expect(
+                        unused_assignments,
+                        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+                    )]
                     anim_blend_factor = 0.0; // Reset blend factor
                     anim_transition = false; // Exit transition mode
                     anim_blend_time_counter = 0.0;

--- a/showcase/examples/models/models_animation_blending.rs
+++ b/showcase/examples/models/models_animation_blending.rs
@@ -278,7 +278,7 @@ fn main() {
                 height: 12.0,
             },
             "",
-            &format!("x{:.1}", anim_frame_speed0),
+            format!("x{:.1}", anim_frame_speed0),
             &mut anim_frame_speed0,
             0.1,
             2.0,
@@ -294,7 +294,7 @@ fn main() {
                 width: 160.0,
                 height: 12.0,
             },
-            &format!("{:.1}x", anim_frame_speed1),
+            format!("{:.1}x", anim_frame_speed1),
             "",
             &mut anim_frame_speed1,
             0.1,
@@ -363,7 +363,7 @@ fn main() {
                 height: 20.0,
             },
             "ANIM 0",
-            &format!(
+            format!(
                 "FRAME: {:.2} / {}",
                 anim_frame_progress0, anims[anim_index0 as usize].keyframeCount
             ),
@@ -391,7 +391,7 @@ fn main() {
                 height: 20.0,
             },
             "ANIM 1",
-            &format!(
+            format!(
                 "FRAME: {:.2} / {}",
                 anim_frame_progress1, anims[anim_index1 as usize].keyframeCount
             ),

--- a/showcase/examples/models/models_animation_timing.rs
+++ b/showcase/examples/models/models_animation_timing.rs
@@ -153,7 +153,7 @@ fn main() {
                 height: 24.0,
             },
             "FRAME SPEED: ",
-            &format!("x{:.1}", anim_frame_speed),
+            format!("x{:.1}", anim_frame_speed),
             &mut anim_frame_speed,
             0.1,
             2.0,
@@ -167,7 +167,7 @@ fn main() {
                 width: sw as f32 - 20.0,
                 height: 24.0,
             },
-            &format!(
+            format!(
                 "CURRENT FRAME: {:.2} / {}",
                 anim_frame_progress, anims[anim_index as usize].keyframeCount
             ),

--- a/showcase/examples/models/models_animation_timing.rs
+++ b/showcase/examples/models/models_animation_timing.rs
@@ -69,6 +69,10 @@ fn main() {
     let anim_names_joined = anim_names.join(";");
 
     let mut dropdown_edit_mode = false;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut anim_frame_progress: f32 = 0.0;
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second

--- a/showcase/examples/models/models_basic_voxel.rs
+++ b/showcase/examples/models/models_basic_voxel.rs
@@ -53,6 +53,10 @@ fn main() {
 
     // Initialize voxel world - fill with voxels
     let mut voxels = [[[false; WORLD_SIZE]; WORLD_SIZE]; WORLD_SIZE];
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for x in 0..WORLD_SIZE {
         for y in 0..WORLD_SIZE {
             for z in 0..WORLD_SIZE {
@@ -87,6 +91,10 @@ fn main() {
             let mut closest_distance = 99999.0_f32;
             let mut closest_voxel_position = Vector3::new(-1.0, -1.0, -1.0);
             let mut voxel_found = false;
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for x in 0..WORLD_SIZE {
                 for y in 0..WORLD_SIZE {
                     for z in 0..WORLD_SIZE {
@@ -133,6 +141,10 @@ fn main() {
             c.draw_grid(10, 1.0);
 
             // Draw all voxels
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for x in 0..WORLD_SIZE {
                 for y in 0..WORLD_SIZE {
                     for z in 0..WORLD_SIZE {

--- a/showcase/examples/models/models_bone_socket.rs
+++ b/showcase/examples/models/models_bone_socket.rs
@@ -208,9 +208,8 @@ fn main() {
                         .bindPose
                         .offset(bone_socket_index[i] as isize))
                     .rotation
-                    .into()
                 };
-                let out_rotation: Quaternion = transform.rotation.into();
+                let out_rotation: Quaternion = transform.rotation;
 
                 // Calculate socket rotation (angle between bone in initial pose and same bone in current animation frame)
                 let rotate = out_rotation * in_rotation.invert();

--- a/showcase/examples/models/models_bone_socket.rs
+++ b/showcase/examples/models/models_bone_socket.rs
@@ -27,6 +27,10 @@ const BONE_SOCKET_HAND_L: usize = 2;
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------

--- a/showcase/examples/models/models_bone_socket.rs
+++ b/showcase/examples/models/models_bone_socket.rs
@@ -74,6 +74,10 @@ fn main() {
 
     // Search bones for sockets
     let bones = character_model.bones().unwrap();
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..bones.len() {
         // SAFETY: bones[i].name is a null-terminated inline char[32].
         let name = unsafe {

--- a/showcase/examples/models/models_box_collisions.rs
+++ b/showcase/examples/models/models_box_collisions.rs
@@ -40,6 +40,10 @@ fn main() {
 
     let mut player_position = Vector3::new(0.0, 1.0, 2.0);
     let player_size = Vector3::new(1.0, 2.0, 1.0);
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut player_color = Color::GREEN;
 
     let enemy_box_pos = Vector3::new(-4.0, 1.0, 0.0);

--- a/showcase/examples/models/models_decals.rs
+++ b/showcase/examples/models/models_decals.rs
@@ -390,6 +390,10 @@ fn gui_button<D: RaylibDraw>(
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------

--- a/showcase/examples/models/models_decals.rs
+++ b/showcase/examples/models/models_decals.rs
@@ -323,7 +323,7 @@ fn gui_button<D: RaylibDraw>(
     let mut pressed = false;
 
     // SAFETY: pure raylib FFI taking primitive args; no aliasing or lifetime concerns.
-    if unsafe { ffi::CheckCollisionPointRec(mouse_pos.into(), rec.into()) } {
+    if unsafe { ffi::CheckCollisionPointRec(mouse_pos, rec) } {
         bg_color = Color::LIGHTGRAY;
         if lmb_pressed {
             pressed = true;
@@ -449,8 +449,8 @@ fn main() {
         let mut collision = ffi::RayCollision {
             hit: false,
             distance: f32::MAX,
-            point: Vector3::ZERO.into(),
-            normal: Vector3::ZERO.into(),
+            point: Vector3::ZERO,
+            normal: Vector3::ZERO,
         };
 
         // Get mouse ray
@@ -499,10 +499,8 @@ fn main() {
             && decal_models.len() < MAX_DECALS
         {
             // Create the transformation to project the decal
-            let origin =
-                Vector3::from(collision.point) + Vector3::from(collision.normal).scale(1.0);
-            let mut splat =
-                Matrix::look_at(collision.point.into(), origin, Vector3::new(0.0, 1.0, 0.0));
+            let origin = collision.point + collision.normal.scale(1.0);
+            let mut splat = Matrix::look_at(collision.point, origin, Vector3::new(0.0, 1.0, 0.0));
 
             // Spin the placement around a bit
             splat = splat
@@ -550,10 +548,8 @@ fn main() {
 
             // If we hit the mesh, draw the box for the decal
             if collision.hit {
-                let origin =
-                    Vector3::from(collision.point) + Vector3::from(collision.normal).scale(1.0);
-                let splat =
-                    Matrix::look_at(collision.point.into(), origin, Vector3::new(0.0, 1.0, 0.0));
+                let origin = collision.point + collision.normal.scale(1.0);
+                let splat = Matrix::look_at(collision.point, origin, Vector3::new(0.0, 1.0, 0.0));
                 placement_cube.set_transform(&splat.invert());
                 c.draw_model(&placement_cube, Vector3::ZERO, 1.0, Color::WHITE.alpha(0.5));
             }

--- a/showcase/examples/models/models_decals.rs
+++ b/showcase/examples/models/models_decals.rs
@@ -127,6 +127,10 @@ fn gen_mesh_decal(
             // The way we calculate the vertices of the mesh triangle
             // depend on whether the mesh vertices are indexed or not
             if mesh.indices.is_null() {
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for v in 0..3 {
                     // SAFETY: mesh.vertices is vertexCount*3 floats; tri < triangleCount.
                     vertices[v] = unsafe {
@@ -138,6 +142,10 @@ fn gen_mesh_decal(
                     };
                 }
             } else {
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for v in 0..3 {
                     // SAFETY: indices array is triangleCount*3 u16; vertices is vertexCount*3 floats.
                     vertices[v] = unsafe {
@@ -159,6 +167,10 @@ fn gen_mesh_decal(
             // Transform all 3 vertices of the triangle
             // and check if they are inside our decal box
             let mut inside_count = 0;
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..3 {
                 // To projection space
                 let v = vertices[i].transform(projection);
@@ -188,6 +200,10 @@ fn gen_mesh_decal(
         Vector3::new(0.0, 0.0, -1.0),
     ];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for face in 0..6 {
         // Swap current model builder (so we read from the one we just wrote to)
         mb_index = 1 - mb_index;
@@ -199,9 +215,25 @@ fn gen_mesh_decal(
 
         let mut i = 0;
         while i < in_verts.len() {
+            #[expect(
+                unused_assignments,
+                reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+            )]
             let mut n_v1 = Vector3::ZERO;
+            #[expect(
+                unused_assignments,
+                reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+            )]
             let mut n_v2 = Vector3::ZERO;
+            #[expect(
+                unused_assignments,
+                reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+            )]
             let mut n_v3 = Vector3::ZERO;
+            #[expect(
+                unused_assignments,
+                reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+            )]
             let mut n_v4 = Vector3::ZERO;
 
             let d1 = in_verts[i].dot(planes[face]) - s;
@@ -288,6 +320,10 @@ fn gen_mesh_decal(
     // Allocate room for UVs
     if !the_mesh.vertices.is_empty() {
         let mut uvs = vec![Vector2::ZERO; the_mesh.vertices.len()];
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..the_mesh.vertices.len() {
             // Calculate the UVs based on the projected coords
             // They are clipped to (-decalSize .. decalSize) and we want them (0..1)
@@ -542,6 +578,10 @@ fn main() {
             }
 
             // Draw the decal models
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..decal_models.len() {
                 c.draw_model(&decal_models[i], Vector3::ZERO, 1.0, Color::WHITE);
             }
@@ -592,6 +632,10 @@ fn main() {
         );
         y_pos += 15.0;
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..decal_models.len() {
             if i == 20 {
                 d.draw_text("...", x0 as i32, y_pos as i32, 10, Color::LIME);

--- a/showcase/examples/models/models_first_person_maze.rs
+++ b/showcase/examples/models/models_first_person_maze.rs
@@ -113,15 +113,14 @@ fn main() {
                         // SAFETY: pure raylib FFI taking primitive args; no aliasing or lifetime concerns.
                         && unsafe {
                             raylib::ffi::CheckCollisionCircleRec(
-                                player_pos.into(),
+                                player_pos,
                                 player_radius,
                                 Rectangle {
                                     x: map_position.x - 0.5 + x as f32,
                                     y: map_position.z - 0.5 + y as f32,
                                     width: 1.0,
                                     height: 1.0,
-                                }
-                                .into(),
+                                },
                             )
                         }
                     {

--- a/showcase/examples/models/models_first_person_maze.rs
+++ b/showcase/examples/models/models_first_person_maze.rs
@@ -67,7 +67,15 @@ fn main() {
 
     // playerCellX/Y need to be visible to the HUD; declare here so we can read
     // them again after the borrow of `rl` ends.
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut player_cell_x: i32 = 0;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut player_cell_y: i32 = 0;
     //--------------------------------------------------------------------------------------
 

--- a/showcase/examples/models/models_loading_vox.rs
+++ b/showcase/examples/models/models_loading_vox.rs
@@ -130,6 +130,10 @@ fn main() {
     // Load MagicaVoxel files
     let mut models: Vec<Model> = Vec::with_capacity(MAX_VOX_FILES);
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_VOX_FILES {
         // Load VOX file and measure time
         let t0 = rl.get_time() * 1000.0;
@@ -187,6 +191,10 @@ fn main() {
     shader.set_shader_value(ambient_loc, Vector4::new(0.1, 0.1, 0.1, 1.0));
 
     // Assign out lighting shader to model
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_VOX_FILES {
         let mat_count = models[i].materials().len();
         for j in 0..mat_count {
@@ -287,6 +295,10 @@ fn main() {
         shader.set_shader_value(view_loc_now, camera_pos);
 
         // Update light values (actually, only enable/disable them)
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_LIGHTS {
             update_light_values(&mut shader, &mut lights[i]);
         }
@@ -306,6 +318,10 @@ fn main() {
             c.draw_grid(10, 1.0);
 
             // Draw spheres to show where the lights are
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..MAX_LIGHTS {
                 if lights[i].enabled != 0 {
                     c.draw_sphere_ex(lights[i].position, 0.2, 8, 8, lights[i].color);

--- a/showcase/examples/models/models_mesh_generation.rs
+++ b/showcase/examples/models/models_mesh_generation.rs
@@ -97,16 +97,8 @@ fn main() {
     // We generate a checked image for texturing
     // SAFETY: GenImageChecked returns a freshly-allocated raylib Image; wrap in the safe Image
     // RAII so it gets UnloadImage'd on Drop.
-    let checked = unsafe {
-        Image::from_raw(ffi::GenImageChecked(
-            2,
-            2,
-            1,
-            1,
-            Color::RED.into(),
-            Color::GREEN.into(),
-        ))
-    };
+    let checked =
+        unsafe { Image::from_raw(ffi::GenImageChecked(2, 2, 1, 1, Color::RED, Color::GREEN)) };
     let texture = rl.load_texture_from_image(&thread, &checked).unwrap();
     drop(checked);
 

--- a/showcase/examples/models/models_mesh_generation.rs
+++ b/showcase/examples/models/models_mesh_generation.rs
@@ -167,6 +167,10 @@ fn main() {
     // NOTE: Generated meshes could be exported using ExportMesh()
 
     // Set checked texture as default diffuse component for all models material
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..NUM_MODELS {
         models[i].materials_mut()[0].set_material_texture(MATERIAL_MAP_ALBEDO, &texture);
     }

--- a/showcase/examples/models/models_mesh_picking.rs
+++ b/showcase/examples/models/models_mesh_picking.rs
@@ -135,8 +135,7 @@ fn main() {
             cursor_color = Color::PURPLE;
             hit_object_name = "Triangle";
 
-            bary =
-                Vector3::barycenter(collision.point.into(), ta.into(), tb.into(), tc.into()).into();
+            bary = Vector3::barycenter(collision.point, ta, tb, tc);
         }
 
         // Check ray collision against test sphere

--- a/showcase/examples/models/models_point_rendering.rs
+++ b/showcase/examples/models/models_point_rendering.rs
@@ -26,6 +26,10 @@ const MIN_POINTS: i32 = 1_000; // 1 thousand
 // Module Functions Declaration
 //------------------------------------------------------------------------------------
 // Generate mesh using points (a spherical point cloud)
+#[expect(
+    clippy::identity_op,
+    reason = "C-parity: explicit +0/*1//1 kept to align with the sibling index expressions in the C"
+)]
 fn gen_mesh_points(num_points: i32) -> ffi::Mesh {
     // SAFETY: zeroed ffi::Mesh; we populate fields and call UploadMesh before returning.
     let mut mesh: ffi::Mesh = unsafe { std::mem::zeroed() };
@@ -97,6 +101,10 @@ fn draw_model_points<D: RaylibDraw3D>(
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::identity_op,
+    reason = "C-parity: explicit +0/*1//1 kept to align with the sibling index expressions in the C"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------

--- a/showcase/examples/models/models_skybox_rendering.rs
+++ b/showcase/examples/models/models_skybox_rendering.rs
@@ -154,13 +154,14 @@ fn main() {
                 // call UnloadTexture explicitly via ffi to free the GL handle before replacing.
                 unsafe {
                     ffi::UnloadTexture(
-                        (*skybox.materials_mut()[0].maps_mut()
+                        skybox.materials_mut()[0].maps_mut()
                             [ffi::MaterialMapIndex::MATERIAL_MAP_CUBEMAP as usize]
-                            .as_mut())
-                        .texture,
+                            .as_mut()
+                            .texture,
                     );
                 }
 
+                #[expect(clippy::collapsible_else_if, reason = "C-parity: C nests the else-if")]
                 if use_hdr {
                     // HDR drop path: not exercised in this port (rlgl-level cubemap generation
                     // is not exposed by the safe wrapper). Keep visual parity with the C.
@@ -246,10 +247,10 @@ fn main() {
     // its handle but the Model RAII is about to free the model materials anyway.
     unsafe {
         ffi::UnloadTexture(
-            (*skybox.materials_mut()[0].maps_mut()
+            skybox.materials_mut()[0].maps_mut()
                 [ffi::MaterialMapIndex::MATERIAL_MAP_CUBEMAP as usize]
-                .as_mut())
-            .texture,
+                .as_mut()
+                .texture,
         );
     }
     // UnloadShader / UnloadModel / CloseWindow are handled by RAII drops.

--- a/showcase/examples/models/models_tesseract_view.rs
+++ b/showcase/examples/models/models_tesseract_view.rs
@@ -24,6 +24,10 @@ use raylib_showcase::SourceViewer;
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------

--- a/showcase/examples/models/models_textured_cube.rs
+++ b/showcase/examples/models/models_textured_cube.rs
@@ -118,6 +118,10 @@ fn draw_cube_texture<D: RaylibDraw3D + raylib::rlgl::RaylibRlgl>(
 }
 
 // Draw cube with texture piece applied to all faces
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn draw_cube_texture_rec<D: RaylibDraw3D + raylib::rlgl::RaylibRlgl>(
     d: &mut D,
     texture: &Texture2D,

--- a/showcase/examples/others/raylib_opengl_interop.rs
+++ b/showcase/examples/others/raylib_opengl_interop.rs
@@ -106,6 +106,10 @@ fn main() {
     // Initialize the vertex buffer for the particles and assign each particle random values
     let mut particles = [Particle::default(); MAX_PARTICLES];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_PARTICLES {
         particles[i].x = rl.get_random_value::<i32>(20..=(screen_width - 20)) as f32;
         particles[i].y = rl.get_random_value::<i32>(50..=(screen_height - 20)) as f32;

--- a/showcase/examples/raygui/animation_curve.rs
+++ b/showcase/examples/raygui/animation_curve.rs
@@ -341,7 +341,7 @@ fn main() {
                 time_line_rect.width,
                 2.0 * font_size,
             ),
-            &format!("Normalized Time: {:.3}", t),
+            format!("Normalized Time: {:.3}", t),
         );
         if d.gui_button(
             Rectangle::new(

--- a/showcase/examples/raygui/controls_test_suite.rs
+++ b/showcase/examples/raygui/controls_test_suite.rs
@@ -198,6 +198,10 @@ fn main() {
         } else if rl.is_key_pressed(KeyboardKey::KEY_RIGHT) {
             progress_value += 0.1;
         }
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if progress_value > 1.0 {
             progress_value = 1.0;
         } else if progress_value < 0.0 {

--- a/showcase/examples/raygui/custom_file_dialog.rs
+++ b/showcase/examples/raygui/custom_file_dialog.rs
@@ -151,7 +151,7 @@ fn main() {
                 if file_name_input.to_lowercase().ends_with(".png") {
                     // texture must be dropped before reassignment — let it.
                     // RAII: prior texture is dropped on assignment.
-                    let _ = std::mem::replace(&mut texture, None);
+                    let _ = texture.take();
                     // Note: we cannot call `load_texture` here because `rl` is borrowed by `d`;
                     // store the path and load on the next frame's update pass.
                     file_name_to_load = file_name_input.clone();

--- a/showcase/examples/raygui/floating_window.rs
+++ b/showcase/examples/raygui/floating_window.rs
@@ -25,6 +25,10 @@ struct FloatingWindowState {
     scroll: Vector2,
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn gui_window_floating<D: RaylibDraw + RaylibDrawGui>(
     d: &mut D,
     state: &mut FloatingWindowState,

--- a/showcase/examples/raygui/image_exporter.rs
+++ b/showcase/examples/raygui/image_exporter.rs
@@ -157,6 +157,10 @@ fn main() {
 
         if image_loaded {
             image_scale += rl.get_mouse_wheel_move() * 0.05; // Image scale control
+            #[expect(
+                clippy::manual_clamp,
+                reason = "C-parity: C clamps with explicit if branches"
+            )]
             if image_scale <= 0.1 {
                 image_scale = 0.1;
             } else if image_scale >= 5.0 {

--- a/showcase/examples/raygui/image_importer_raw.rs
+++ b/showcase/examples/raygui/image_importer_raw.rs
@@ -277,7 +277,7 @@ fn main() {
             );
             d.gui_label(
                 Rectangle::new(window_offset.x + 85.0, window_offset.y + 50.0, 75.0, 20.0),
-                &format!("{} bytes", data_size),
+                format!("{} bytes", data_size),
             );
             d.gui_group_box(
                 Rectangle::new(window_offset.x + 10.0, window_offset.y + 85.0, 180.0, 80.0),

--- a/showcase/examples/raygui/portable_window.rs
+++ b/showcase/examples/raygui/portable_window.rs
@@ -55,6 +55,7 @@ fn main() {
         //----------------------------------------------------------------------------------
         mouse_position = rl.get_mouse_position();
 
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_mouse_button_pressed(MouseButton::MOUSE_BUTTON_LEFT) && !drag_window {
             if Rectangle::new(0.0, 0.0, screen_width as f32, 20.0)
                 .check_collision_point_rec(mouse_position)

--- a/showcase/examples/shaders/shaders_basic_lighting.rs
+++ b/showcase/examples/shaders/shaders_basic_lighting.rs
@@ -226,6 +226,10 @@ fn main() {
         }
 
         // Update light values (actually, only enable/disable them)
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_LIGHTS {
             update_light_values(&mut shader, &mut lights[i]);
         }
@@ -249,6 +253,10 @@ fn main() {
             }
 
             // Draw spheres to show where the lights are
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..MAX_LIGHTS {
                 if lights[i].enabled != 0 {
                     c.draw_sphere_ex(lights[i].position, 0.2, 8, 8, lights[i].color);

--- a/showcase/examples/shaders/shaders_basic_pbr.rs
+++ b/showcase/examples/shaders/shaders_basic_pbr.rs
@@ -472,6 +472,10 @@ fn main() {
         }
 
         // Update light values on shader (actually, only enable/disable them)
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_LIGHTS {
             update_light(&mut shader, &lights[i]);
         }
@@ -558,6 +562,10 @@ fn main() {
             c.draw_model(&car, Vector3::new(0.0, 0.0, 0.0), 0.25, Color::WHITE); // Draw car model
 
             // Draw spheres to show the lights positions
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..MAX_LIGHTS {
                 let light_color = Color::new(
                     (lights[i].color[0] * 255.0) as u8,

--- a/showcase/examples/shaders/shaders_cel_shading.rs
+++ b/showcase/examples/shaders/shaders_cel_shading.rs
@@ -230,6 +230,10 @@ fn main() {
             l.position = Vector3::new((-t * 0.3).sin() * 5.0, 5.0, (-t * 0.3).cos() * 5.0);
         }
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_LIGHTS {
             if let Some(l) = &mut lights[i] {
                 update_light_values(&mut cel_shader, l);

--- a/showcase/examples/shaders/shaders_color_correction.rs
+++ b/showcase/examples/shaders/shaders_color_correction.rs
@@ -21,7 +21,6 @@
 use raylib::core::shaders::RaylibShader;
 use raylib::core::texture::RaylibTexture2D;
 use raylib::prelude::*;
-use raylib::rgui::RaylibDrawGui;
 use raylib_showcase::SourceViewer;
 
 const MAX_TEXTURES: usize = 4;

--- a/showcase/examples/shaders/shaders_deferred_rendering.rs
+++ b/showcase/examples/shaders/shaders_deferred_rendering.rs
@@ -486,11 +486,8 @@ fn main() {
 
                 // SAFETY: copy depth buffer from g-buffer to default framebuffer.
                 unsafe {
-                    ffi::rlBindFramebuffer(
-                        ffi::RL_READ_FRAMEBUFFER as u32,
-                        g_buffer.framebuffer_id,
-                    );
-                    ffi::rlBindFramebuffer(ffi::RL_DRAW_FRAMEBUFFER as u32, 0);
+                    ffi::rlBindFramebuffer(ffi::RL_READ_FRAMEBUFFER, g_buffer.framebuffer_id);
+                    ffi::rlBindFramebuffer(ffi::RL_DRAW_FRAMEBUFFER, 0);
                     ffi::rlBlitFramebuffer(
                         0,
                         0,

--- a/showcase/examples/shaders/shaders_deferred_rendering.rs
+++ b/showcase/examples/shaders/shaders_deferred_rendering.rs
@@ -398,6 +398,10 @@ fn main() {
         }
 
         // Update light values (actually, only enable/disable them)
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_LIGHTS {
             update_light_values(&mut deferred_shader, &mut lights[i]);
         }
@@ -509,6 +513,10 @@ fn main() {
                     unsafe {
                         ffi::rlEnableShader(ffi::rlGetShaderIdDefault());
                     }
+                    #[expect(
+                        clippy::needless_range_loop,
+                        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                    )]
                     for i in 0..MAX_LIGHTS {
                         if lights[i].enabled != 0 {
                             c.draw_sphere_ex(lights[i].position, 0.2, 8, 8, lights[i].color);

--- a/showcase/examples/shaders/shaders_fog_rendering.rs
+++ b/showcase/examples/shaders/shaders_fog_rendering.rs
@@ -25,6 +25,10 @@ use raylib::ffi;
 use raylib::prelude::*;
 use raylib_showcase::SourceViewer;
 
+#[expect(
+    dead_code,
+    reason = "C-parity: mirrors #define MAX_LIGHTS 4 from rlights.h included by the C original; kept for structural parity"
+)]
 const MAX_LIGHTS: usize = 4;
 
 #[cfg(target_family = "wasm")]

--- a/showcase/examples/shaders/shaders_game_of_life.rs
+++ b/showcase/examples/shaders/shaders_game_of_life.rs
@@ -34,6 +34,10 @@ const GLSL_VERSION: i32 = 330;
 // Interaction mode (matches MODE_RUN, MODE_PAUSE, MODE_DRAW in the C source)
 const MODE_RUN: i32 = 0;
 const MODE_PAUSE: i32 = 1;
+#[expect(
+    dead_code,
+    reason = "C-parity: mirrors MODE_DRAW in the C InteractionMode enum; present in both C and Rust for completeness though the mode is reached via an implicit else"
+)]
 const MODE_DRAW: i32 = 2;
 
 // Struct to store example preset patterns

--- a/showcase/examples/shaders/shaders_game_of_life.rs
+++ b/showcase/examples/shaders/shaders_game_of_life.rs
@@ -21,7 +21,6 @@
 use raylib::core::shaders::RaylibShader;
 use raylib::core::texture::RaylibTexture2D;
 use raylib::prelude::*;
-use raylib::rgui::RaylibDrawGui;
 use raylib_showcase::SourceViewer;
 
 #[cfg(target_family = "wasm")]

--- a/showcase/examples/shaders/shaders_game_of_life.rs
+++ b/showcase/examples/shaders/shaders_game_of_life.rs
@@ -400,7 +400,7 @@ fn main() {
                     Image::from_raw(raylib::ffi::GenImageColor(
                         world_width / random_tiles,
                         world_height / random_tiles,
-                        Color::RAYWHITE.into(),
+                        Color::RAYWHITE,
                     ))
                 };
                 for i in 0..random_tiles {

--- a/showcase/examples/shaders/shaders_lightmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_lightmap_rendering.rs
@@ -84,7 +84,7 @@ fn main() {
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VERTEX_TEXCOORD02 as isize) =
             ffi::rlLoadVertexBuffer(
                 ptr as *const std::os::raw::c_void,
-                (mesh_ref.vertexCount * 2 * std::mem::size_of::<f32>() as i32) as i32,
+                mesh_ref.vertexCount * 2 * std::mem::size_of::<f32>() as i32,
                 false,
             );
         ffi::rlEnableVertexArray(mesh_ref.vaoId);

--- a/showcase/examples/shaders/shaders_mandelbrot_set.rs
+++ b/showcase/examples/shaders/shaders_mandelbrot_set.rs
@@ -31,6 +31,10 @@ const GLSL_VERSION: i32 = 100;
 const GLSL_VERSION: i32 = 330;
 
 // A few good interesting places
+#[expect(
+    clippy::excessive_precision,
+    reason = "C-parity: float literals mirror the C constants"
+)]
 const POINTS_OF_INTEREST: [[f32; 3]; 6] = [
     [-1.76826775, -0.00422996283, 28435.9238],
     [0.322004497, -0.0357099883, 56499.7266],

--- a/showcase/examples/shaders/shaders_mesh_instancing.rs
+++ b/showcase/examples/shaders/shaders_mesh_instancing.rs
@@ -190,7 +190,7 @@ fn main() {
             .as_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .color = Color::RED.into();
+        .color = Color::RED;
     }
 
     // Load default material (using raylib intenral default shader) for non-instanced mesh drawing
@@ -203,7 +203,7 @@ fn main() {
             .as_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .color = Color::BLUE.into();
+        .color = Color::BLUE;
     }
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second

--- a/showcase/examples/shaders/shaders_multi_sample2d.rs
+++ b/showcase/examples/shaders/shaders_multi_sample2d.rs
@@ -48,7 +48,7 @@ fn main() {
         Image::from_raw(raylib::ffi::GenImageColor(
             800,
             450,
-            Color::new(255, 0, 0, 255).into(),
+            Color::new(255, 0, 0, 255),
         ))
     };
     let tex_red = rl.load_texture_from_image(&thread, &im_red).unwrap();
@@ -59,7 +59,7 @@ fn main() {
         Image::from_raw(raylib::ffi::GenImageColor(
             800,
             450,
-            Color::new(0, 0, 255, 255).into(),
+            Color::new(0, 0, 255, 255),
         ))
     };
     let tex_blue = rl.load_texture_from_image(&thread, &im_blue).unwrap();

--- a/showcase/examples/shaders/shaders_multi_sample2d.rs
+++ b/showcase/examples/shaders/shaders_multi_sample2d.rs
@@ -97,6 +97,10 @@ fn main() {
             divider_value -= 0.01;
         }
 
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if divider_value < 0.0 {
             divider_value = 0.0;
         } else if divider_value > 1.0 {

--- a/showcase/examples/shaders/shaders_normalmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_normalmap_rendering.rs
@@ -32,6 +32,14 @@ const GLSL_VERSION: i32 = 330;
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
+#[expect(
+    clippy::identity_op,
+    reason = "C-parity: explicit +0/*1//1 kept to align with the sibling index expressions in the C"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------

--- a/showcase/examples/shaders/shaders_postprocessing.rs
+++ b/showcase/examples/shaders/shaders_postprocessing.rs
@@ -35,6 +35,10 @@ const MAX_POSTPRO_SHADERS: usize = 12;
 #[repr(i32)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
+#[expect(
+    clippy::enum_variant_names,
+    reason = "C-parity: variant names mirror the C enum prefix"
+)]
 enum PostproShader {
     FxGrayscale = 0,
     FxPosterization,

--- a/showcase/examples/shaders/shaders_rlgl_compute.rs
+++ b/showcase/examples/shaders/shaders_rlgl_compute.rs
@@ -131,13 +131,8 @@ fn main() {
     // Create a white texture of the size of the window to update
     // each pixel of the window using the fragment shader: golRenderShader
     // SAFETY: ffi::GenImageColor returns an owned Image; wrap with RAII guard.
-    let white_image = unsafe {
-        Image::from_raw(ffi::GenImageColor(
-            GOL_WIDTH,
-            GOL_WIDTH,
-            Color::WHITE.into(),
-        ))
-    };
+    let white_image =
+        unsafe { Image::from_raw(ffi::GenImageColor(GOL_WIDTH, GOL_WIDTH, Color::WHITE)) };
     let white_tex = rl.load_texture_from_image(&thread, &white_image).unwrap();
     drop(white_image);
     let mut viewer = SourceViewer::for_current_example();

--- a/showcase/examples/shaders/shaders_spotlight_rendering.rs
+++ b/showcase/examples/shaders/shaders_spotlight_rendering.rs
@@ -119,12 +119,20 @@ fn main() {
         speed: Vector2::zero(),
     }; MAX_STARS];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for n in 0..MAX_STARS {
         reset_star(&mut stars[n], screen_width, screen_height, &mut rl);
     }
 
     // Progress all the stars on, so they don't all start in the centre
     for _m in 0..(screen_width / 2) {
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for n in 0..MAX_STARS {
             update_star(&mut stars[n], screen_width, screen_height, &mut rl);
         }
@@ -153,6 +161,10 @@ fn main() {
         radius_loc: 0,
     }; MAX_SPOTS];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_SPOTS {
         let pos_name = format!("spots[{}].pos", i);
         let inner_name = format!("spots[{}].inner", i);
@@ -171,6 +183,10 @@ fn main() {
 
     // Randomize the locations and velocities of the spotlights
     // and initialize the shader locations
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_SPOTS {
         spots[i].position.x = rl.get_random_value::<i32>(64..=screen_width - 64) as f32;
         spots[i].position.y = rl.get_random_value::<i32>(64..=screen_height - 64) as f32;
@@ -202,11 +218,19 @@ fn main() {
         frame_counter += 1;
 
         // Move the stars, resetting them if the go offscreen
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for n in 0..MAX_STARS {
             update_star(&mut stars[n], screen_width, screen_height, &mut rl);
         }
 
         // Update the spots, send them to the shader
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_SPOTS {
             if i == 0 {
                 let mp = rl.get_mouse_position();
@@ -241,6 +265,10 @@ fn main() {
         d.clear_background(Color::DARKBLUE);
 
         // Draw stars and bobs
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for n in 0..MAX_STARS {
             // Single pixel is just too small these days!
             d.draw_rectangle(

--- a/showcase/examples/shaders/shaders_spotlight_rendering.rs
+++ b/showcase/examples/shaders/shaders_spotlight_rendering.rs
@@ -69,12 +69,20 @@ struct Star {
 //--------------------------------------------------------------------------------------
 // Module Functions Definition
 //--------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn reset_star(star: &mut Star, screen_width: i32, screen_height: i32, rl: &mut RaylibHandle) {
     star.position = Vector2::new(screen_width as f32 / 2.0, screen_height as f32 / 2.0);
 
     star.speed.x = rl.get_random_value::<i32>(-1000..=1000) as f32 / 100.0;
     star.speed.y = rl.get_random_value::<i32>(-1000..=1000) as f32 / 100.0;
 
+    #[expect(
+        clippy::neg_cmp_op_on_partial_ord,
+        reason = "C-parity: mirrors the C !(a < b)"
+    )]
     while !(star.speed.x.abs() + (star.speed.y.abs() > 1.0) as i32 as f32 > 0.0) {
         star.speed.x = rl.get_random_value::<i32>(-1000..=1000) as f32 / 100.0;
         star.speed.y = rl.get_random_value::<i32>(-1000..=1000) as f32 / 100.0;
@@ -83,6 +91,10 @@ fn reset_star(star: &mut Star, screen_width: i32, screen_height: i32, rl: &mut R
     star.position = star.position + star.speed * Vector2::new(8.0, 8.0);
 }
 
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn update_star(star: &mut Star, screen_width: i32, screen_height: i32, rl: &mut RaylibHandle) {
     star.position = star.position + star.speed;
 

--- a/showcase/examples/shaders/shaders_texture_rendering.rs
+++ b/showcase/examples/shaders/shaders_texture_rendering.rs
@@ -39,8 +39,7 @@ fn main() {
         .build();
 
     // SAFETY: ffi::GenImageColor returns an owned Image; wrap into our RAII Image.
-    let im_blank =
-        unsafe { Image::from_raw(raylib::ffi::GenImageColor(1024, 1024, Color::BLANK.into())) };
+    let im_blank = unsafe { Image::from_raw(raylib::ffi::GenImageColor(1024, 1024, Color::BLANK)) };
     let texture = rl.load_texture_from_image(&thread, &im_blank).unwrap(); // Load blank texture to fill on shader
     drop(im_blank);
 

--- a/showcase/examples/shapes/shapes_ball_physics.rs
+++ b/showcase/examples/shapes/shapes_ball_physics.rs
@@ -39,6 +39,10 @@ struct Ball {
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
+#[expect(
+    clippy::assign_op_pattern,
+    reason = "C-parity: C writes x = x + y rather than the compound form; a statement-scoped attribute is rejected on the bare assignment expression by stable Rust (E0658), so suppressed at fn scope"
+)]
 fn main() {
     // Initialization
     //--------------------------------------------------------------------------------------
@@ -110,6 +114,7 @@ fn main() {
         }
 
         // Creates a new ball
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_mouse_button_pressed(MouseButton::MOUSE_BUTTON_RIGHT)
             || (rl.is_key_down(KeyboardKey::KEY_LEFT_CONTROL)
                 && rl.is_mouse_button_down(MouseButton::MOUSE_BUTTON_RIGHT))

--- a/showcase/examples/shapes/shapes_bullet_hell.rs
+++ b/showcase/examples/shapes/shapes_bullet_hell.rs
@@ -137,6 +137,10 @@ fn main() {
         }
 
         // Update bullets position based on its acceleration
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..bullet_count {
             // Only update bullet if inside the screen
             if !bullets[i].disabled {
@@ -235,6 +239,10 @@ fn main() {
         // Draw bullets
         if draw_in_performance_mode {
             // Draw bullets using pre-rendered texture containing circle
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..bullet_count {
                 // Do not draw disabled bullets (out of screen)
                 if !bullets[i].disabled {
@@ -248,6 +256,10 @@ fn main() {
             }
         } else {
             // Draw bullets using DrawCircle(), less performant
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..bullet_count {
                 // Do not draw disabled bullets (out of screen)
                 if !bullets[i].disabled {

--- a/showcase/examples/shapes/shapes_clock_of_clocks.rs
+++ b/showcase/examples/shapes/shapes_clock_of_clocks.rs
@@ -215,6 +215,10 @@ fn main() {
 
         let mut x_offset: f32 = 4.0;
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for digit in 0..6 {
             for row in 0..6 {
                 for col in 0..4 {

--- a/showcase/examples/shapes/shapes_colors_palette.rs
+++ b/showcase/examples/shapes/shapes_colors_palette.rs
@@ -84,6 +84,10 @@ fn main() {
         [Rectangle::new(0.0, 0.0, 0.0, 0.0); MAX_COLORS_COUNT]; // Rectangles array
 
     // Fills colorsRecs data (for every rectangle)
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_COLORS_COUNT {
         colors_recs[i].x = 20.0 + 100.0 * (i % 7) as f32 + 10.0 * (i % 7) as f32;
         colors_recs[i].y = 80.0 + 100.0 * (i / 7) as f32 + 10.0 * (i as f32 / 7.0);

--- a/showcase/examples/shapes/shapes_easings_ball.rs
+++ b/showcase/examples/shapes/shapes_easings_ball.rs
@@ -49,6 +49,7 @@ fn main() {
     {
         // Update
         //----------------------------------------------------------------------------------
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if state == 0
         // Move ball position X with easing
         {

--- a/showcase/examples/shapes/shapes_easings_rectangles.rs
+++ b/showcase/examples/shapes/shapes_easings_rectangles.rs
@@ -72,6 +72,10 @@ fn main() {
         if state == 0 {
             frames_counter += 1;
 
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..(MAX_RECS_X * MAX_RECS_Y) as usize {
                 recs[i].height = ease::circ_out(
                     frames_counter as f32,
@@ -108,6 +112,10 @@ fn main() {
             // When animation has finished, press space to restart
             frames_counter = 0;
 
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..(MAX_RECS_X * MAX_RECS_Y) as usize {
                 recs[i].height = RECS_HEIGHT as f32;
                 recs[i].width = RECS_WIDTH as f32;
@@ -125,6 +133,10 @@ fn main() {
         d.clear_background(Color::RAYWHITE);
 
         if state == 0 {
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..(MAX_RECS_X * MAX_RECS_Y) as usize {
                 d.draw_rectangle_pro(
                     recs[i],

--- a/showcase/examples/shapes/shapes_easings_testbed.rs
+++ b/showcase/examples/shapes/shapes_easings_testbed.rs
@@ -276,6 +276,10 @@ fn main() {
         }
 
         // Movement computation
+        #[expect(
+            clippy::nonminimal_bool,
+            reason = "C-parity: boolean expression mirrors the C"
+        )]
         if !paused && ((bounded_t && t < d) || !bounded_t) {
             ball_position.x = (easings[easing_x].func)(t, 100.0, 700.0 - 170.0, d);
             ball_position.y = (easings[easing_y].func)(t, 100.0, 400.0 - 170.0, d);

--- a/showcase/examples/shapes/shapes_hilbert_curve.rs
+++ b/showcase/examples/shapes/shapes_hilbert_curve.rs
@@ -75,6 +75,10 @@ fn load_hilbert_path(order: i32, size: f32) -> Vec<Vector2> {
 
     let mut hilbert_path = vec![Vector2::new(0.0, 0.0); stroke_count];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..stroke_count {
         hilbert_path[i] = compute_hilbert_step(order, i as i32);
         hilbert_path[i].x = hilbert_path[i].x * len + len / 2.0;

--- a/showcase/examples/shapes/shapes_logo_raylib_anim.rs
+++ b/showcase/examples/shapes/shapes_logo_raylib_anim.rs
@@ -55,6 +55,7 @@ fn main() {
     {
         // Update
         //----------------------------------------------------------------------------------
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if state == 0
         // State 0: Small box blinking
         {

--- a/showcase/examples/shapes/shapes_math_angle_rotation.rs
+++ b/showcase/examples/shapes/shapes_math_angle_rotation.rs
@@ -63,6 +63,10 @@ fn main() {
         d.draw_text("Fixed angles + rotating line", 10, 10, 20, Color::LIGHTGRAY);
 
         // Draw fixed-angle lines with colorful gradient
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..num_angles {
             let rad = angles[i] as f32 * ffi::DEG2RAD as f32;
             let end = Vector2::new(

--- a/showcase/examples/shapes/shapes_math_sine_cosine.rs
+++ b/showcase/examples/shapes/shapes_math_sine_cosine.rs
@@ -319,7 +319,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 40.0, 120.0, 20.0),
             "Angle",
-            &format!("{:.0}\u{00B0}", angle),
+            format!("{:.0}\u{00B0}", angle),
             &mut angle,
             0.0,
             360.0,

--- a/showcase/examples/shapes/shapes_mouse_trail.rs
+++ b/showcase/examples/shapes/shapes_mouse_trail.rs
@@ -68,6 +68,10 @@ fn main() {
         d.clear_background(Color::BLACK);
 
         // Draw the trail by looping through the history array
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_TRAIL_LENGTH {
             // Ensure we skip drawing if the array hasn't been fully filled on startup
             if (trail_positions[i].x != 0.0) || (trail_positions[i].y != 0.0) {

--- a/showcase/examples/shapes/shapes_penrose_tile.rs
+++ b/showcase/examples/shapes/shapes_penrose_tile.rs
@@ -272,6 +272,10 @@ fn draw_penrose_l_system<D: RaylibDraw>(
     }
 
     let bytes = ls.production.as_bytes();
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..(ls.steps as usize) {
         let step = bytes[i] as char;
         if step == 'F' {

--- a/showcase/examples/shapes/shapes_penrose_tile.rs
+++ b/showcase/examples/shapes/shapes_penrose_tile.rs
@@ -98,6 +98,7 @@ fn main() {
         // Update
         //----------------------------------------------------------------------------------
         let mut rebuild = false;
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_pressed(KeyboardKey::KEY_UP) {
             if generations < max_generations {
                 generations += 1;

--- a/showcase/examples/shapes/shapes_pie_chart.rs
+++ b/showcase/examples/shapes/shapes_pie_chart.rs
@@ -51,6 +51,10 @@ fn main() {
     let mut show_values = true;
     let mut show_percentages = false;
     let mut show_donut = false;
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut hovered_slice: i32 = -1;
     let mut scroll_content_offset = Vector2::zero();
     let mut view = Rectangle::new(0.0, 0.0, 0.0, 0.0);
@@ -91,6 +95,10 @@ fn main() {
         //----------------------------------------------------------------------------------
         // Calculate total value for percentage calculations
         total_value = 0.0;
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..(slice_count as usize) {
             total_value += values[i];
         }
@@ -114,6 +122,10 @@ fn main() {
                 }
 
                 let mut current_angle = 0.0;
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for i in 0..(slice_count as usize) {
                     let sweep = if total_value > 0.0 {
                         (values[i] / total_value) * 360.0
@@ -141,6 +153,10 @@ fn main() {
 
         // Draw the pie chart on the canvas
         let mut start_angle = 0.0;
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..(slice_count as usize) {
             let sweep_angle = if total_value > 0.0 {
                 (values[i] / total_value) * 360.0

--- a/showcase/examples/shapes/shapes_rectangle_scaling.rs
+++ b/showcase/examples/shapes/shapes_rectangle_scaling.rs
@@ -39,6 +39,10 @@ fn main() {
     #[allow(unused_assignments)]
     let mut mouse_position = Vector2::zero();
 
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut mouse_scale_ready = false;
     let mut mouse_scale_mode = false;
 

--- a/showcase/examples/shapes/shapes_recursive_tree.rs
+++ b/showcase/examples/shapes/shapes_recursive_tree.rs
@@ -147,7 +147,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 40.0, 120.0, 20.0),
             "Angle",
-            &format!("{:.0}", angle),
+            format!("{:.0}", angle),
             &mut angle,
             0.0,
             180.0,
@@ -155,7 +155,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 70.0, 120.0, 20.0),
             "Length",
-            &format!("{:.0}", length),
+            format!("{:.0}", length),
             &mut length,
             12.0,
             240.0,
@@ -163,7 +163,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 100.0, 120.0, 20.0),
             "Decay",
-            &format!("{:.2}", branch_decay),
+            format!("{:.2}", branch_decay),
             &mut branch_decay,
             0.1,
             0.78,
@@ -171,7 +171,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 130.0, 120.0, 20.0),
             "Depth",
-            &format!("{:.0}", tree_depth),
+            format!("{:.0}", tree_depth),
             &mut tree_depth,
             1.0,
             10.0,
@@ -179,7 +179,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 160.0, 120.0, 20.0),
             "Thick",
-            &format!("{:.0}", thick),
+            format!("{:.0}", thick),
             &mut thick,
             1.0,
             8.0,

--- a/showcase/examples/shapes/shapes_recursive_tree.rs
+++ b/showcase/examples/shapes/shapes_recursive_tree.rs
@@ -128,6 +128,10 @@ fn main() {
 
         d.clear_background(Color::RAYWHITE);
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..count {
             let branch = branches[i];
             if branch.length >= 2.0 {

--- a/showcase/examples/shapes/shapes_ring_drawing.rs
+++ b/showcase/examples/shapes/shapes_ring_drawing.rs
@@ -117,7 +117,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(600.0, 40.0, 120.0, 20.0),
             "StartAngle",
-            &format!("{:.2}", start_angle),
+            format!("{:.2}", start_angle),
             &mut start_angle,
             -450.0,
             450.0,
@@ -125,7 +125,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(600.0, 70.0, 120.0, 20.0),
             "EndAngle",
-            &format!("{:.2}", end_angle),
+            format!("{:.2}", end_angle),
             &mut end_angle,
             -450.0,
             450.0,
@@ -134,7 +134,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(600.0, 140.0, 120.0, 20.0),
             "InnerRadius",
-            &format!("{:.2}", inner_radius),
+            format!("{:.2}", inner_radius),
             &mut inner_radius,
             0.0,
             100.0,
@@ -142,7 +142,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(600.0, 170.0, 120.0, 20.0),
             "OuterRadius",
-            &format!("{:.2}", outer_radius),
+            format!("{:.2}", outer_radius),
             &mut outer_radius,
             0.0,
             200.0,
@@ -151,7 +151,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(600.0, 240.0, 120.0, 20.0),
             "Segments",
-            &format!("{:.2}", segments),
+            format!("{:.2}", segments),
             &mut segments,
             0.0,
             100.0,

--- a/showcase/examples/shapes/shapes_rlgl_color_wheel.rs
+++ b/showcase/examples/shapes/shapes_rlgl_color_wheel.rs
@@ -85,6 +85,7 @@ fn main() {
             && mouse_position.y < slider_rectangle.y + slider_rectangle.height;
 
         // Copy color as hex
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_down(KeyboardKey::KEY_LEFT_CONTROL) && rl.is_key_down(KeyboardKey::KEY_C) {
             if rl.is_key_pressed(KeyboardKey::KEY_C) {
                 let _ = rl

--- a/showcase/examples/shapes/shapes_rounded_rectangle_drawing.rs
+++ b/showcase/examples/shapes/shapes_rounded_rectangle_drawing.rs
@@ -99,7 +99,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 40.0, 105.0, 20.0),
             "Width",
-            &format!("{:.2}", width),
+            format!("{:.2}", width),
             &mut width,
             0.0,
             screen_w as f32 - 300.0,
@@ -107,7 +107,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 70.0, 105.0, 20.0),
             "Height",
-            &format!("{:.2}", height),
+            format!("{:.2}", height),
             &mut height,
             0.0,
             screen_h as f32 - 50.0,
@@ -115,7 +115,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 140.0, 105.0, 20.0),
             "Roundness",
-            &format!("{:.2}", roundness),
+            format!("{:.2}", roundness),
             &mut roundness,
             0.0,
             1.0,
@@ -123,7 +123,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 170.0, 105.0, 20.0),
             "Thickness",
-            &format!("{:.2}", line_thick),
+            format!("{:.2}", line_thick),
             &mut line_thick,
             0.0,
             20.0,
@@ -131,7 +131,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 240.0, 105.0, 20.0),
             "Segments",
-            &format!("{:.2}", segments),
+            format!("{:.2}", segments),
             &mut segments,
             0.0,
             60.0,

--- a/showcase/examples/shapes/shapes_splines_drawing.rs
+++ b/showcase/examples/shapes/shapes_splines_drawing.rs
@@ -140,6 +140,10 @@ fn main() {
             // Spline control point focus and selection logic
             if selected_control_point.is_none() {
                 focused_control_point = None;
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for i in 0..(point_count as usize - 1) {
                     if check_collision_point_circle(rl.get_mouse_position(), control[i].start, 6.0)
                     {

--- a/showcase/examples/shapes/shapes_splines_drawing.rs
+++ b/showcase/examples/shapes/shapes_splines_drawing.rs
@@ -302,7 +302,7 @@ fn main() {
         // Draw spline config
         d.gui_label(
             Rectangle::new(12.0, 62.0, 140.0, 24.0),
-            &format!("Spline thickness: {}", spline_thickness as i32),
+            format!("Spline thickness: {}", spline_thickness as i32),
         );
         d.gui_slider_bar(
             Rectangle::new(12.0, 60.0 + 24.0, 140.0, 16.0),

--- a/showcase/examples/shapes/shapes_starfield_effect.rs
+++ b/showcase/examples/shapes/shapes_starfield_effect.rs
@@ -46,6 +46,10 @@ fn main() {
     let mut stars_screen_pos: [Vector2; STAR_COUNT] = [Vector2::zero(); STAR_COUNT];
 
     // Setup the stars with a random position
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..STAR_COUNT {
         stars[i].x = rl.get_random_value::<i32>(-screen_width / 2..=screen_width / 2) as f32;
         stars[i].y = rl.get_random_value::<i32>(-screen_height / 2..=screen_height / 2) as f32;

--- a/showcase/examples/shapes/shapes_top_down_lights.rs
+++ b/showcase/examples/shapes/shapes_top_down_lights.rs
@@ -105,14 +105,7 @@ fn main() {
     // SAFETY: GenImageChecked allocates an Image owned by raylib; we hand ownership to the
     // `Image` newtype which calls UnloadImage on drop (matches the C example's UnloadImage(img)).
     let img = unsafe {
-        let raw = ffi::GenImageChecked(
-            64,
-            64,
-            32,
-            32,
-            Color::DARKBROWN.into(),
-            Color::DARKGRAY.into(),
-        );
+        let raw = ffi::GenImageChecked(64, 64, 32, 32, Color::DARKBROWN, Color::DARKGRAY);
         Image::from_raw(raw)
     };
     let background_texture = rl

--- a/showcase/examples/shapes/shapes_top_down_lights.rs
+++ b/showcase/examples/shapes/shapes_top_down_lights.rs
@@ -179,6 +179,10 @@ fn main() {
                 }
 
                 // Merge in all the light masks
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for i in 0..MAX_LIGHTS {
                     if lights[i].active {
                         if let Some(mask) = lights[i].mask.as_ref() {
@@ -232,6 +236,10 @@ fn main() {
         );
 
         // Draw the lights
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_LIGHTS {
             if lights[i].active {
                 d.draw_circle(
@@ -248,6 +256,10 @@ fn main() {
                 d.draw_triangle_fan(&lights[0].shadows[s].vertices, Color::DARKPURPLE);
             }
 
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for b in 0..box_count {
                 if boxes[b].check_collision_recs(lights[0].bounds) {
                     d.draw_rectangle_rec(boxes[b], Color::PURPLE);
@@ -368,6 +380,10 @@ fn update_light(
     lights[slot].shadow_count = 0;
     lights[slot].valid = false;
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..count {
         // Are we in a box? if so we are not valid
         if boxes[i].check_collision_point_rec(lights[slot].position) {
@@ -496,6 +512,10 @@ fn setup_boxes(rl: &RaylibHandle, boxes: &mut [Rectangle], count: &mut usize) {
     boxes[3] = Rectangle::new(1000.0, 50.0, 40.0, 40.0);
     boxes[4] = Rectangle::new(500.0, 350.0, 40.0, 40.0);
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 5..MAX_BOXES {
         boxes[i] = Rectangle::new(
             rl.get_random_value::<i32>(0..=rl.get_screen_width()) as f32,

--- a/showcase/examples/shapes/shapes_triangle_strip.rs
+++ b/showcase/examples/shapes/shapes_triangle_strip.rs
@@ -117,7 +117,7 @@ fn main() {
         d.gui_slider_bar(
             Rectangle::new(640.0, 40.0, 120.0, 20.0),
             "Segments",
-            &format!("{:.0}", segments),
+            format!("{:.0}", segments),
             &mut segments,
             6.0,
             60.0,

--- a/showcase/examples/shapes/shapes_vector_angle.rs
+++ b/showcase/examples/shapes/shapes_vector_angle.rs
@@ -33,6 +33,10 @@ fn main() {
 
     let v0 = Vector2::new(screen_width as f32 / 2.0, screen_height as f32 / 2.0);
     let mut v1 = v0 + Vector2::new(100.0, 80.0);
+    #[expect(
+        unused_assignments,
+        reason = "C-parity: C declares and initializes this before the loop/branch overwrites it"
+    )]
     let mut v2 = Vector2::zero(); // Updated with mouse position
 
     let mut angle: f32 = 0.0; // Angle in degrees

--- a/showcase/examples/text/text_3d_drawing.rs
+++ b/showcase/examples/text/text_3d_drawing.rs
@@ -641,6 +641,10 @@ fn main() {
 
             if multicolor {
                 // Fill color array with random colors
+                #[expect(
+                    clippy::needless_range_loop,
+                    reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+                )]
                 for i in 0..TEXT_MAX_LAYERS {
                     multi[i] = generate_random_color(0.5, 0.8, &mut rl);
                     multi[i].a = rl.get_random_value::<i32>(0..=255) as u8;

--- a/showcase/examples/text/text_3d_drawing.rs
+++ b/showcase/examples/text/text_3d_drawing.rs
@@ -177,6 +177,10 @@ fn draw_text_codepoint_3d<D: RaylibDraw + RaylibDraw3D + RaylibRlgl>(
 }
 
 // Draw a 2D text in 3D space
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn draw_text_3d<D: RaylibDraw + RaylibDraw3D + RaylibRlgl>(
     d: &mut D,
     font: &WeakFont,
@@ -609,6 +613,7 @@ fn main() {
         }
 
         // Handle text layers changes
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_pressed(KeyboardKey::KEY_HOME) {
             if layers > 1 {
                 layers -= 1;

--- a/showcase/examples/text/text_font_loading.rs
+++ b/showcase/examples/text/text_font_loading.rs
@@ -72,6 +72,10 @@ fn main() {
     {
         // Update
         //----------------------------------------------------------------------------------
+        #[expect(
+            clippy::needless_bool_assign,
+            reason = "C-parity: C assigns the bool in if/else"
+        )]
         if rl.is_key_down(KeyboardKey::KEY_SPACE) {
             use_ttf = true;
         } else {

--- a/showcase/examples/text/text_input_box.rs
+++ b/showcase/examples/text/text_input_box.rs
@@ -52,6 +52,10 @@ fn main() {
     {
         // Update
         //----------------------------------------------------------------------------------
+        #[expect(
+            clippy::needless_bool_assign,
+            reason = "C-parity: C assigns the bool in if/else"
+        )]
         if text_box.check_collision_point_rec(rl.get_mouse_position()) {
             mouse_on_text = true;
         } else {

--- a/showcase/examples/text/text_rectangle_bounds.rs
+++ b/showcase/examples/text/text_rectangle_bounds.rs
@@ -24,6 +24,10 @@ use raylib_showcase::SourceViewer;
 // Module Functions Declaration
 //----------------------------------------------------------------------------------
 // Draw text using font inside rectangle limits
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn draw_text_boxed<D: RaylibDraw>(
     d: &mut D,
     font: &WeakFont,

--- a/showcase/examples/text/text_strings_management.rs
+++ b/showcase/examples/text/text_strings_management.rs
@@ -412,6 +412,10 @@ fn main() {
                 if is_ctrl_down {
                     let grabbed_rect = text_particles[i].rect;
                     for j in 0..text_particles.len() {
+                        #[expect(
+                            clippy::collapsible_if,
+                            reason = "C-parity: C nests the conditionals"
+                        )]
                         if j != i && text_particles[i].grabbed {
                             if grabbed_rect.check_collision_recs(text_particles[j].rect) {
                                 let new = glue_text_particles(i, j, &mut text_particles, &mut rl);

--- a/showcase/examples/text/text_unicode_emojis.rs
+++ b/showcase/examples/text/text_unicode_emojis.rs
@@ -251,6 +251,10 @@ fn randomize_emoji(
     *selected = -1;
     let start = rl.get_random_value::<i32>(45..=360);
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..EMOJI_COUNT {
         // 0-179 emoji codepoints (from emoji char array) each 4bytes + null char
         emoji[i].index = rl.get_random_value::<i32>(0..=179) * 5;
@@ -572,6 +576,10 @@ fn main() {
 
         // Draw random emojis in the background
         //------------------------------------------------------------------------------
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..EMOJI_COUNT {
             let txt = emoji_token(emoji[i].index as usize);
             let emoji_rect = Rectangle::new(

--- a/showcase/examples/text/text_unicode_emojis.rs
+++ b/showcase/examples/text/text_unicode_emojis.rs
@@ -269,6 +269,10 @@ fn randomize_emoji(
 }
 
 // Draw text using font inside rectangle limits
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn draw_text_boxed<D: RaylibDraw>(
     d: &mut D,
     font: &Font,

--- a/showcase/examples/text/text_unicode_ranges.rs
+++ b/showcase/examples/text/text_unicode_ranges.rs
@@ -134,8 +134,8 @@ fn main() {
                 // Unicode range: Cyrillic
                 font = add_codepoint_range(font, FONT_PATH, 0x400, 0x4ff);
                 font = add_codepoint_range(font, FONT_PATH, 0x500, 0x52f);
-                font = add_codepoint_range(font, FONT_PATH, 0x2de0, 0x2Dff);
-                font = add_codepoint_range(font, FONT_PATH, 0xa640, 0xA69f);
+                font = add_codepoint_range(font, FONT_PATH, 0x2de0, 0x2DFF);
+                font = add_codepoint_range(font, FONT_PATH, 0xa640, 0xA69F);
             }
             if unicode_range >= 2 {
                 // Unicode range: Greek

--- a/showcase/examples/text/text_unicode_ranges.rs
+++ b/showcase/examples/text/text_unicode_ranges.rs
@@ -47,6 +47,10 @@ fn add_codepoint_range(font: Font, font_path: &str, start: i32, stop: i32) -> Fo
     }
 
     // Add new codepoints to list (provided range)
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in (current_range_size as usize)..(updated_codepoint_count as usize) {
         updated_codepoints[i] = start + (i as i32 - current_range_size);
     }

--- a/showcase/examples/text/text_words_alignment.rs
+++ b/showcase/examples/text/text_words_alignment.rs
@@ -86,6 +86,7 @@ fn main() {
     {
         // Update
         //----------------------------------------------------------------------------------
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_pressed(KeyboardKey::KEY_LEFT) {
             if h_align > 0 {
                 h_align -= 1;
@@ -99,6 +100,7 @@ fn main() {
             }
         }
 
+        #[expect(clippy::collapsible_if, reason = "C-parity: C nests the conditionals")]
         if rl.is_key_pressed(KeyboardKey::KEY_UP) {
             if v_align > 0 {
                 v_align -= 1;

--- a/showcase/examples/textures/textures_bunnymark.rs
+++ b/showcase/examples/textures/textures_bunnymark.rs
@@ -99,6 +99,10 @@ fn main() {
             let frame_time = rl.get_frame_time();
             let screen_w = rl.get_screen_width();
             let screen_h = rl.get_screen_height();
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..bunnies_count {
                 bunnies[i].position.x += bunnies[i].speed.x * frame_time;
                 bunnies[i].position.y += bunnies[i].speed.y * frame_time;
@@ -124,6 +128,10 @@ fn main() {
 
         d.clear_background(Color::RAYWHITE);
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..bunnies_count {
             // NOTE: When internal batch buffer limit is reached (MAX_BATCH_ELEMENTS),
             // a draw call is launched and buffer starts being filled again;

--- a/showcase/examples/textures/textures_cellular_automata.rs
+++ b/showcase/examples/textures/textures_cellular_automata.rs
@@ -83,7 +83,7 @@ fn main() {
         Image::from_raw(raylib::ffi::GenImageColor(
             IMAGE_WIDTH,
             IMAGE_HEIGHT,
-            Color::RAYWHITE.into(),
+            Color::RAYWHITE,
         ))
     };
     // The top central pixel set as black
@@ -155,7 +155,7 @@ fn main() {
             // SAFETY: ImageClearBackground takes the image by pointer. We have exclusive
             // access via `&mut image` (raylib reads no other state); single-threaded use.
             unsafe {
-                raylib::ffi::ImageClearBackground(&mut *image, Color::RAYWHITE.into());
+                raylib::ffi::ImageClearBackground(&mut *image, Color::RAYWHITE);
             }
             image.draw_pixel(IMAGE_WIDTH / 2, 0, Color::BLACK);
             line = 1;

--- a/showcase/examples/textures/textures_clipboard_image.rs
+++ b/showcase/examples/textures/textures_clipboard_image.rs
@@ -105,6 +105,10 @@ fn main() {
 
         d.clear_background(Color::RAYWHITE);
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..current_collection_index {
             if let Some(ref tex) = collection[i].texture {
                 if tex.is_texture_valid() {

--- a/showcase/examples/textures/textures_framebuffer_rendering.rs
+++ b/showcase/examples/textures/textures_framebuffer_rendering.rs
@@ -276,6 +276,10 @@ fn draw_camera_prism<D: RaylibDraw3D>(d: &mut D, camera: Camera3D, aspect: f32, 
     d.draw_line3D(corners[3], corners[0], color);
 
     // Draw the prism lines from the far plane to the camera position
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..4 {
         d.draw_line3D(camera.position, corners[i], color);
     }

--- a/showcase/examples/textures/textures_gif_player.rs
+++ b/showcase/examples/textures/textures_gif_player.rs
@@ -102,6 +102,10 @@ fn main() {
             frame_delay -= 1;
         }
 
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if frame_delay > MAX_FRAME_DELAY {
             frame_delay = MAX_FRAME_DELAY;
         } else if frame_delay < MIN_FRAME_DELAY {

--- a/showcase/examples/textures/textures_image_channel.rs
+++ b/showcase/examples/textures/textures_image_channel.rs
@@ -58,8 +58,8 @@ fn main() {
             screen_height,
             screen_width / 20,
             screen_height / 20,
-            Color::ORANGE.into(),
-            Color::YELLOW.into(),
+            Color::ORANGE,
+            Color::YELLOW,
         ))
     };
 

--- a/showcase/examples/textures/textures_image_generation.rs
+++ b/showcase/examples/textures/textures_image_generation.rs
@@ -45,8 +45,8 @@ fn main() {
             screen_width,
             screen_height,
             0,
-            Color::RED.into(),
-            Color::BLUE.into(),
+            Color::RED,
+            Color::BLUE,
         ))
     };
     let horizontal_gradient = unsafe {
@@ -54,8 +54,8 @@ fn main() {
             screen_width,
             screen_height,
             90,
-            Color::RED.into(),
-            Color::BLUE.into(),
+            Color::RED,
+            Color::BLUE,
         ))
     };
     let diagonal_gradient = unsafe {
@@ -63,8 +63,8 @@ fn main() {
             screen_width,
             screen_height,
             45,
-            Color::RED.into(),
-            Color::BLUE.into(),
+            Color::RED,
+            Color::BLUE,
         ))
     };
     let radial_gradient = unsafe {
@@ -72,8 +72,8 @@ fn main() {
             screen_width,
             screen_height,
             0.0,
-            Color::WHITE.into(),
-            Color::BLACK.into(),
+            Color::WHITE,
+            Color::BLACK,
         ))
     };
     let square_gradient = unsafe {
@@ -81,8 +81,8 @@ fn main() {
             screen_width,
             screen_height,
             0.0,
-            Color::WHITE.into(),
-            Color::BLACK.into(),
+            Color::WHITE,
+            Color::BLACK,
         ))
     };
     let checked = unsafe {
@@ -91,8 +91,8 @@ fn main() {
             screen_height,
             32,
             32,
-            Color::RED.into(),
-            Color::BLUE.into(),
+            Color::RED,
+            Color::BLUE,
         ))
     };
     let white_noise = unsafe {

--- a/showcase/examples/textures/textures_image_processing.rs
+++ b/showcase/examples/textures/textures_image_processing.rs
@@ -75,6 +75,10 @@ fn main() {
         [Rectangle::new(0.0, 0.0, 0.0, 0.0); NUM_PROCESSES];
     let mut mouse_hover_rec: i32 = -1;
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..NUM_PROCESSES {
         toggle_recs[i] = Rectangle::new(40.0, 50.0 + 32.0 * i as f32, 150.0, 30.0);
     }
@@ -91,6 +95,10 @@ fn main() {
         //----------------------------------------------------------------------------------
 
         // Mouse toggle group logic
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..NUM_PROCESSES {
             if toggle_recs[i].check_collision_point_rec(rl.get_mouse_position()) {
                 mouse_hover_rec = i as i32;

--- a/showcase/examples/textures/textures_image_text.rs
+++ b/showcase/examples/textures/textures_image_text.rs
@@ -67,6 +67,10 @@ fn main() {
     {
         // Update
         //----------------------------------------------------------------------------------
+        #[expect(
+            clippy::needless_bool_assign,
+            reason = "C-parity: C assigns the bool in if/else"
+        )]
         if rl.is_key_down(KeyboardKey::KEY_SPACE) {
             show_font = true;
         } else {

--- a/showcase/examples/textures/textures_magnifying_glass.rs
+++ b/showcase/examples/textures/textures_magnifying_glass.rs
@@ -44,7 +44,7 @@ fn main() {
     // UnloadImage; Image::from_raw ties that to Drop. Image::gen_image_color wraps the
     // same call but is gated behind SUPPORT_IMAGE_GENERATION, which isn't propagated
     // through the showcase crate.
-    let mut circle = unsafe { Image::from_raw(ffi::GenImageColor(256, 256, Color::BLANK.into())) };
+    let mut circle = unsafe { Image::from_raw(ffi::GenImageColor(256, 256, Color::BLANK)) };
     circle.draw_circle(128, 128, 128, Color::WHITE);
     let mask = rl.load_texture_from_image(&thread, &circle).unwrap(); // Copy the mask image from RAM to VRAM
     drop(circle); // Unload the image from RAM

--- a/showcase/examples/textures/textures_mouse_painting.rs
+++ b/showcase/examples/textures/textures_mouse_painting.rs
@@ -65,6 +65,10 @@ fn main() {
     let mut colors_recs: [Rectangle; MAX_COLORS_COUNT] =
         [Rectangle::new(0.0, 0.0, 0.0, 0.0); MAX_COLORS_COUNT];
 
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_COLORS_COUNT {
         colors_recs[i].x = 10.0 + 30.0 * i as f32 + 2.0 * i as f32;
         colors_recs[i].y = 10.0;
@@ -122,6 +126,10 @@ fn main() {
         }
 
         // Choose color with mouse
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_COLORS_COUNT {
             if colors_recs[i].check_collision_point_rec(mouse_pos) {
                 color_mouse_hover = i as i32;

--- a/showcase/examples/textures/textures_mouse_painting.rs
+++ b/showcase/examples/textures/textures_mouse_painting.rs
@@ -146,6 +146,10 @@ fn main() {
 
         // Change brush size
         brush_size += rl.get_mouse_wheel_move() * 5.0;
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if brush_size < 2.0 {
             brush_size = 2.0;
         }
@@ -204,6 +208,10 @@ fn main() {
         }
 
         // Check mouse hover save button
+        #[expect(
+            clippy::needless_bool_assign,
+            reason = "C-parity: C assigns the bool in if/else"
+        )]
         if btn_save_rec.check_collision_point_rec(mouse_pos) {
             btn_save_mouse_hover = true;
         } else {

--- a/showcase/examples/textures/textures_npatch_drawing.rs
+++ b/showcase/examples/textures/textures_npatch_drawing.rs
@@ -107,6 +107,10 @@ fn main() {
         dst_rec_v.height = mouse_position.y - dst_rec_v.y;
 
         // Set a minimum width and/or height
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if dst_rec1.width < 1.0 {
             dst_rec1.width = 1.0;
         }
@@ -116,6 +120,10 @@ fn main() {
         if dst_rec1.height < 1.0 {
             dst_rec1.height = 1.0;
         }
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if dst_rec2.width < 1.0 {
             dst_rec2.width = 1.0;
         }

--- a/showcase/examples/textures/textures_particles_blending.rs
+++ b/showcase/examples/textures/textures_particles_blending.rs
@@ -57,6 +57,10 @@ fn main() {
     }; MAX_PARTICLES];
 
     // Initialize particles
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_PARTICLES {
         mouse_tail[i].position = Vector2::new(0.0, 0.0);
         mouse_tail[i].color = Color::new(
@@ -94,6 +98,10 @@ fn main() {
         // NOTE: Particles initial position should be mouse position when activated
         // NOTE: Particles fall down with gravity and rotation... and disappear after 2 seconds (alpha = 0)
         // NOTE: When a particle disappears, active = false and it can be reused
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_PARTICLES {
             if !mouse_tail[i].active {
                 mouse_tail[i].active = true;
@@ -103,6 +111,10 @@ fn main() {
             }
         }
 
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_PARTICLES {
             if mouse_tail[i].active {
                 mouse_tail[i].position.y += gravity / 2.0;
@@ -136,6 +148,10 @@ fn main() {
             let mut b = d.begin_blend_mode(blending);
 
             // Draw active particles
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..MAX_PARTICLES {
                 if mouse_tail[i].active {
                     b.draw_texture_pro(

--- a/showcase/examples/textures/textures_polygon_drawing.rs
+++ b/showcase/examples/textures/textures_polygon_drawing.rs
@@ -94,6 +94,10 @@ fn main() {
     // Define the vertices drawing position
     // NOTE: Initially same as points but updated every frame
     let mut positions: [Vector2; MAX_POINTS] = [Vector2::new(0.0, 0.0); MAX_POINTS];
+    #[expect(
+        clippy::manual_memcpy,
+        reason = "C-parity: C copies element-by-element in a loop"
+    )]
     for i in 0..MAX_POINTS {
         positions[i] = points[i];
     }

--- a/showcase/examples/textures/textures_raw_data.rs
+++ b/showcase/examples/textures/textures_raw_data.rs
@@ -62,6 +62,10 @@ fn main() {
 
     for y in 0..im_height {
         for x in 0..im_width {
+            #[expect(
+                clippy::identity_op,
+                reason = "C-parity: explicit +0/*1//1 kept to align with the sibling index expressions in the C"
+            )]
             if ((x / 32 + y / 32) / 1) % 2 == 0 {
                 checked_im.draw_pixel(x, y, Color::ORANGE);
             } else {

--- a/showcase/examples/textures/textures_raw_data.rs
+++ b/showcase/examples/textures/textures_raw_data.rs
@@ -58,7 +58,7 @@ fn main() {
     // same call but is gated behind SUPPORT_IMAGE_GENERATION, which isn't propagated
     // through the showcase crate.
     let mut checked_im =
-        unsafe { Image::from_raw(ffi::GenImageColor(im_width, im_height, Color::BLACK.into())) };
+        unsafe { Image::from_raw(ffi::GenImageColor(im_width, im_height, Color::BLACK)) };
 
     for y in 0..im_height {
         for x in 0..im_width {

--- a/showcase/examples/textures/textures_screen_buffer.rs
+++ b/showcase/examples/textures/textures_screen_buffer.rs
@@ -48,13 +48,8 @@ fn main() {
     // UnloadImage; Image::from_raw ties that to Drop. Image::gen_image_color wraps the
     // same call but is gated behind SUPPORT_IMAGE_GENERATION, which isn't propagated
     // through the showcase crate.
-    let mut screen_image = unsafe {
-        Image::from_raw(ffi::GenImageColor(
-            image_width,
-            image_height,
-            Color::BLACK.into(),
-        ))
-    };
+    let mut screen_image =
+        unsafe { Image::from_raw(ffi::GenImageColor(image_width, image_height, Color::BLACK)) };
     let mut screen_texture = rl.load_texture_from_image(&thread, &screen_image).unwrap();
 
     // Generate flame color palette

--- a/showcase/examples/textures/textures_screen_buffer.rs
+++ b/showcase/examples/textures/textures_screen_buffer.rs
@@ -53,6 +53,10 @@ fn main() {
     let mut screen_texture = rl.load_texture_from_image(&thread, &screen_image).unwrap();
 
     // Generate flame color palette
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+    )]
     for i in 0..MAX_COLORS {
         let t = i as f32 / (MAX_COLORS - 1) as f32;
         let hue = t * t;
@@ -73,6 +77,10 @@ fn main() {
         // Update
         //----------------------------------------------------------------------------------
         // Grow flameRoot
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for x in 2..flame_width as usize {
             let mut flame = flame_root_buffer[x] as i32;
             flame += rl.get_random_value::<i32>(0..=2);
@@ -80,12 +88,20 @@ fn main() {
         }
 
         // Transfer flameRoot to indexBuffer
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for x in 0..flame_width as usize {
             let i = x + ((image_height - 1) * image_width) as usize;
             index_buffer[i] = flame_root_buffer[x];
         }
 
         // Clear top row, because it can't move any higher
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for x in 0..image_width as usize {
             if index_buffer[x] != 0 {
                 index_buffer[x] = 0;

--- a/showcase/examples/textures/textures_sprite_animation.rs
+++ b/showcase/examples/textures/textures_sprite_animation.rs
@@ -80,6 +80,10 @@ fn main() {
             frames_speed -= 1;
         }
 
+        #[expect(
+            clippy::manual_clamp,
+            reason = "C-parity: C clamps with explicit if branches"
+        )]
         if frames_speed > MAX_FRAME_SPEED {
             frames_speed = MAX_FRAME_SPEED;
         } else if frames_speed < MIN_FRAME_SPEED {

--- a/showcase/examples/textures/textures_tiled_drawing.rs
+++ b/showcase/examples/textures/textures_tiled_drawing.rs
@@ -23,6 +23,10 @@ const MARGIN_SIZE: i32 = 8; // Size for the margins
 const COLOR_SIZE: i32 = 16; // Size of the color select buttons
 
 // Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest
+#[expect(
+    clippy::too_many_arguments,
+    reason = "C-parity: mirrors the C function signature"
+)]
 fn draw_texture_tiled<D: RaylibDraw>(
     d: &mut D,
     texture: &Texture2D,

--- a/showcase/examples/textures/textures_tiled_drawing.rs
+++ b/showcase/examples/textures/textures_tiled_drawing.rs
@@ -285,6 +285,10 @@ fn main() {
     {
         let mut x = 0;
         let mut y = 0;
+        #[expect(
+            clippy::needless_range_loop,
+            reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+        )]
         for i in 0..MAX_COLORS {
             color_rec[i].x = 2.0 + MARGIN_SIZE as f32 + x as f32;
             color_rec[i].y = 22.0 + 256.0 + MARGIN_SIZE as f32 + y as f32;
@@ -320,6 +324,10 @@ fn main() {
             let mouse = rl.get_mouse_position();
 
             // Check which pattern was clicked and set it as the active pattern
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..rec_pattern.len() {
                 if Rectangle::new(
                     2.0 + MARGIN_SIZE as f32 + rec_pattern[i].x,
@@ -335,6 +343,10 @@ fn main() {
             }
 
             // Check to see which color was clicked and set it as the active color
+            #[expect(
+                clippy::needless_range_loop,
+                reason = "C-parity: mirrors the C for (i = 0; i < n; i++) indexed loop"
+            )]
             for i in 0..MAX_COLORS {
                 if color_rec[i].check_collision_point_rec(mouse) {
                     active_col = i;


### PR DESCRIPTION
## What

Makes `cargo clippy -p raylib-showcase --examples` **zero-warning** across all three feature legs, and adds a `-D warnings` gate so it stays that way — **without restructuring any port** (the F1 source-viewer C↔Rust side-by-side is intact).

Verified on a clean build:

| Leg | Examples built | Errors | Warnings |
|-----|---------------:|-------:|---------:|
| `raygui,SUPPORT_CUSTOM_FRAME_CONTROL` (all examples) | 229 | 0 | 0 |
| default features | 197 | 0 | 0 |
| `software_renderer` | 197 | 0 | 0 |

119 example files touched (+881/−130); **208 `#[expect(...)]`** added, each with a `reason`.

## How — triage by lint type

- **Rust-only port artifacts → FIXED** (no C line, removal is parity-safe): `useless_conversion` ×52, `needless_borrows_for_generic_args` ×26, `unused_imports` ×2, `mem_replace_option_with_none` ×1, `unnecessary_cast` ×4, `explicit_auto_deref` ×2.
- **C-parity structural mirrors → `#[expect(reason = "C-parity: …")]`** at tightest scope: `needless_range_loop` ×108, `unused_assignments` ×32, `assign_op_pattern` ×17, `collapsible_if`, `manual_clamp`, `too_many_arguments`, `identity_op`, `excessive_precision`, and the long tail.
- **Ambiguous → inspected, defaulted to expect** (bias-to-allow): `approx_constant` (deny-level Web-Audio `ln(10)` literal), `type_complexity`, `search_is_some` ×4 (mirrors C `TextFindIndex(...) > -1`), `dead_code` ×2.

No blind `clippy --fix` — that would collapse C's nested ifs / `x = x + y` / etc. and break parity.

### A couple of real fixes beyond removals
- Three `#[expect(unused_assignments)]` would have landed on bare **assignment-expressions** (E0658, "attributes on expressions are experimental"), which aborts the build. Hoisted to `fn`-level `#[expect]` (nested-expect-safe). One expect was also mis-scoped (`unfulfilled_lint_expectations`) and moved to the right binding.

## ⚠️ Gate decision — please weigh in

Adds two clippy `-D warnings` steps to the existing `build` job in `showcase.yml` (base leg + the `raygui,SUPPORT_CUSTOM_FRAME_CONTROL` superset, which builds every example incl. the previously-never-CI-built `core_custom_frame_control`). Added as **steps on the existing job**, so no new required-check context and no `unstable` ruleset edit needed.

**Signal change:** every future port must land warning-free or with a documented `#[expect]`, and the showcase build job gets ~1 clippy-compile slower (notable while sccache is disabled for the GHA cache outage). Happy to drop the gate if you'd rather keep showcase CI build-only.

## Notes
- Spec/plan/done-note: `docs/superpowers/{specs,plans,notes}/2026-06-03-showcase-clippy-cleanup*` / `post-release-showcase-clippy-cleanup-complete.md`. The done-note records the census + two clippy-censusing gotchas (deny-level lints and warm-cache truncate `--examples`; use `cargo clean -p raylib-showcase` + `--keep-going`).
- Pre-existing `#[allow(unused_assignments)]` in `shapes_rectangle_scaling.rs` left as-is (predates this sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
