### PR TITLE
docs(safety): rewrite export_image_to_memory SAFETY comment + codify FFI-proof methodology

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -15,6 +15,10 @@ Please remember to use `unsafe` sparingly--only when absolutely necessary and ab
   
 A good way to do this is by looking at the `/// # Safety` docs of each `unsafe` function/operation being performed within your `unsafe` block, then listing off *how* your function is ensuring those requirements.
 
+> **Anti-pattern to avoid.** A `// SAFETY:` comment must explain *how you are upholding* the called function's contract — **not** restate what the function does. `// SAFETY: foo() returns None on null` describes `foo`; it does not prove that *your* call to `foo` is sound. The reviewer should be able to read your comment, walk through each precondition the unsafe API lists, and find each one accounted for.
+
+> **In safe functions, assume the worst case.** You cannot rely on callers to be well-behaved when your function is not marked `unsafe`. Write soundness arguments that hold even when someone is *trying* to cause UB without writing `unsafe`. The only time you may assume the caller is well-behaved is when (1) the function itself is `unsafe` and (2) you have documented the requirements in `/// # Safety`.
+
 ### Examples
 
 - If it is safe "so long as the function is used as intended", then write something like "Caller must uphold safety contract", **mark the function itself as `unsafe`, and write a `/// # Safety` doc describing the exact requirements for "intended" use.**
@@ -75,6 +79,36 @@ A good way to do this is by looking at the `/// # Safety` docs of each `unsafe` 
   }
   ```
   In `unsound_incr`, `AddOne` has no *preconditions*, but does not give the same protections as Rust would. If `n` is 255, `sound_incr` would panic, but `unsound_incr` would return **an invalid `NonZeroU8` containing 0**.
+
+- If the unsafe API you're calling has a **multi-clause safety contract** (especially something like `slice::from_raw_parts` or a `DataBuf::slice_from_raw`-style wrapper around a raylib-allocated buffer), don't summarize. Enumerate each precondition the API lists, then for each one, point at the line of FFI/C code that guarantees it. Methodology:
+
+  1. **Copy the full `# Safety` list** of every unsafe function being called inside the block.
+  2. **Read the C source** (`raylib-sys/raylib/src/...`) to learn what the FFI function actually does — what it allocates, what it initializes, what it returns on each branch.
+  3. **For each precondition, write one line** explaining which C-side guarantee satisfies it (e.g. *"allocated with `RL_MALLOC` via `STBIW_MALLOC` alias in `rtextures.c`"*, *"`*dataSize` is unconditionally zeroed at function entry"*, *"the null return branch is handled by the wrapper returning `None`"*).
+  4. **Collapse the proof into the `// SAFETY:` comment.** The detailed walkthrough lives in the PR review; the comment summarizes the load-bearing facts so the next reader can re-verify.
+
+  Worked example — the pattern used by `Image::export_image_to_memory` in `raylib/src/core/texture.rs`:
+
+  ```rs
+  // SAFETY: `slice_from_raw`'s contract is upheld:
+  //   * `data_size` is initialized whenever `data` is non-null:
+  //     `ExportImageToMemory` writes `*dataSize = 0` unconditionally at function
+  //     entry (rtextures.c) before any branch, and on the success path
+  //     `stbi_write_png_to_mem` overwrites it with the buffer length.
+  //   * `data` is a unique, owned, non-dangling pointer allocated by `RL_MALLOC`:
+  //     `stbi_write_png_to_mem` allocates via `STBIW_MALLOC`, which `rtextures.c`
+  //     aliases to `RL_MALLOC`. The buffer escapes only via the return value.
+  //   * `data` points to `*data_size` initialized bytes: `stbi_write_png_to_mem`
+  //     fully populates the PNG stream before returning and asserts the cursor
+  //     matches `*out_len`.
+  //   * `data` is properly aligned for `u8` (trivial: alignment = 1).
+  //   * The null-return branch (unsupported format / allocation failure) is
+  //     handled by `slice_from_raw` returning `None`, so we never construct a
+  //     slice over invalid memory.
+  let buf = unsafe { DataBuf::slice_from_raw(data, data_size) };
+  ```
+
+  The comment doesn't paraphrase `slice_from_raw`; it walks each clause of `slice_from_raw`'s contract and points at the specific C-side fact that satisfies it. A reviewer can re-verify by opening `rtextures.c` and `stb_image_write.h` and reading exactly the lines named.
 
 ## Working on the book
 

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -955,11 +955,25 @@ impl Image {
         let c_filetype = CString::new(file_type).unwrap();
         let mut data_size = MaybeUninit::uninit();
         let data = unsafe {
-            // ExportImageToMemory returns null if the code for converting to a file type never goes off.
+            // ExportImageToMemory returns null if the file_type's encoder branch is not compiled in.
             ffi::ExportImageToMemory(self.0, c_filetype.as_ptr(), data_size.as_mut_ptr())
         };
 
-        // SAFETY: DataBuf::slice_from_raw returns None if the data ptr is null.
+        // SAFETY: `slice_from_raw`'s contract is upheld:
+        //   * `data_size` is initialized whenever `data` is non-null:
+        //     `ExportImageToMemory` writes `*dataSize = 0` unconditionally at function
+        //     entry (rtextures.c) before any branch, and on the success path
+        //     `stbi_write_png_to_mem` overwrites it with the buffer length.
+        //   * `data` is a unique, owned, non-dangling pointer allocated by `RL_MALLOC`:
+        //     `stbi_write_png_to_mem` allocates via `STBIW_MALLOC`, which `rtextures.c`
+        //     aliases to `RL_MALLOC`. The buffer escapes only via the return value.
+        //   * `data` points to `*data_size` initialized bytes: `stbi_write_png_to_mem`
+        //     fully populates the PNG stream before returning and asserts the cursor
+        //     matches `*out_len`.
+        //   * `data` is properly aligned for `u8` (trivial: alignment = 1).
+        //   * The null-return branch (unsupported format / allocation failure) is
+        //     handled by `slice_from_raw` returning `None`, so we never construct a
+        //     slice over invalid memory.
         let buf = unsafe { DataBuf::slice_from_raw(data, data_size) };
         buf.ok_or(InvalidImageError::UnsupportedFormat)
     }


### PR DESCRIPTION
## Summary

The `// SAFETY:` comment on `Image::export_image_to_memory` paraphrased what `DataBuf::slice_from_raw` *does* (\"returns None if the data ptr is null\") rather than proving each clause of its contract is *upheld*. AmityWilder pointed this out in their review of #250 and walked through the correct methodology in painstaking detail. This PR applies that methodology and codifies it in `CONTRIBUTE.md` so future contributors don't repeat the same mistake.

The underlying memory leak fix (#247) is already in `unstable` — it rode the 6.0.0 squash via cherry-pick `8e8bb4b` on `6.0-rc`. Only the soundness comment was outstanding.

**Supersedes #250.**

## Changes

- **`raylib/src/core/texture.rs`** — rewrite the SAFETY comment to enumerate each precondition of `DataBuf::slice_from_raw` (initialization, ownership, allocator provenance, alignment, null-branch handling) and cite the specific guarantee in `rtextures.c` / `stb_image_write.h` that satisfies each one.
- **`CONTRIBUTE.md`** — adds two callouts and a worked example, distilled from AmityWilder's review:
  - *Anti-pattern:* a `// SAFETY:` comment must explain how *you* uphold the called API's contract, not restate what the API does.
  - *In safe functions, assume the worst case* — write soundness arguments that hold even when callers try to cause UB without writing `unsafe`.
  - A 4-step methodology for proving a multi-clause unsafe contract (especially around FFI), with the rewritten `export_image_to_memory` comment as the reference example.

## Why one PR

The texture.rs fix is the canonical demonstration of the methodology the doc teaches. Bundling them means the worked example in `CONTRIBUTE.md` and the real-world example in the code stay byte-for-byte consistent — and any future drift will surface in review of either file.

## Closes

- Closes #250 (superseded — the fix is already in `unstable`; this PR contributes the missing soundness comment + general guidance).
- The original leak (#247) was already closed by the 6.0.0 release.

## Test plan

- [ ] CI `check`: rustfmt + clippy `-Dwarnings` + `cargo-deny` + MSRV 1.85
- [ ] CI `test`: nextest unit + integration + doctests
- [ ] CI `web`: wasm32 build
- [ ] Doc-only change to `texture.rs`; the diff is a comment, cannot affect runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)