### PR TITLE
fix(showcase): normalize rlsw readback before thumbnail export

### DIFF
--- a/raylib/src/test_harness.rs
+++ b/raylib/src/test_harness.rs
@@ -103,9 +103,16 @@ pub fn render_frame<F: FnOnce(&mut RaylibDrawHandle<'_>)>(
     img
 }
 
-/// Correct the rlsw readback in place: flip vertically and correct the
+/// Correct an rlsw screen readback in place: flip vertically and fix the
 /// BGRA-as-RGBA byte order, yielding a true top-left RGBA image.
-fn normalize_readback(img: &mut Image) {
+///
+/// The raw readback from [`load_image_from_screen`](RaylibHandle::load_image_from_screen)
+/// under the `software_renderer` backend is BGRA + Y-inverted (deterministic on
+/// every OS; see `notes/ws4b-complete.md`). [`render_frame`] applies this to its
+/// result automatically; call it directly when you read the framebuffer yourself
+/// (e.g. capturing a frame to export as a PNG). Only sound for a 32-bit
+/// `PIXELFORMAT_UNCOMPRESSED_R8G8B8A8` image (debug-asserted).
+pub fn normalize_readback(img: &mut Image) {
     // Fix Y-inversion using the existing safe image op. NOTE: `flip_vertical`
     // (ImageFlipVertical) replaces the underlying data buffer, so the raw pointer
     // must be taken *after* this call — which it is, below.

--- a/showcase/src/viewer.rs
+++ b/showcase/src/viewer.rs
@@ -352,7 +352,15 @@ fn thumbnail_from_env() -> Option<ThumbnailCapture> {
 fn capture_and_exit(rl: &mut RaylibHandle, thread: &RaylibThread, out_path: &std::path::Path) {
     use std::process;
 
-    let img = rl.load_image_from_screen(thread);
+    // Thumbnails are generated under the `software_renderer` (rlsw) backend,
+    // whose screen readback is BGRA + Y-inverted (see raylib::test_harness).
+    // Normalize to true top-left RGBA before export so thumbnails aren't
+    // flipped vertically or colour-swapped. A real GPU readback is already
+    // correct, so the correction is software_renderer-only.
+    #[allow(unused_mut)]
+    let mut img = rl.load_image_from_screen(thread);
+    #[cfg(feature = "software_renderer")]
+    raylib::test_harness::normalize_readback(&mut img);
 
     // Fix C: surface directory-creation failures instead of silently swallowing them.
     if let Some(parent) = out_path.parent() {


### PR DESCRIPTION
## Summary

Gallery thumbnails came out vertically flipped with red/blue swapped. `gen_thumbnails` captures frames via `load_image_from_screen`, whose raw readback under the `software_renderer` (rlsw) backend is **BGRA + Y-inverted** — the same deterministic quirk the Tier-2 test harness already corrects in `render_frame` (rlsw's `SW_FRAMEBUFFER_OUTPUT_BGRA` default + `rlReadScreenPixels`'s unconditional vertical flip). The showcase capture path (`SourceViewer::capture_and_exit`) exported the raw image, so every thumbnail inherited both defects.

- **`raylib/src/test_harness.rs`** — make `normalize_readback` `pub` (+ rustdoc) so the flip + R↔B swap has a single source of truth instead of duplicating the unsafe byte-swap.
- **`showcase/src/viewer.rs`** — normalize in `capture_and_exit` before `export_image`, `cfg`-gated to `software_renderer`: a real GPU readback is already correctly oriented, so the correction must not run on normal desktop builds.

## Test Plan

- [x] Regenerated the `shapes_basic_shapes` thumbnail via the same env-var path `gen_thumbnails` uses — output is upright (title at top) with correct colors (RED rectangle is red, not blue)
- [x] `cargo build -p raylib-showcase --example …` with and without `software_renderer` (cfg-off path is warning-free)
- [x] `cargo clippy -p raylib --tests` (software_renderer CI leg feature set) — clean
- [x] `cargo clippy -p raylib-showcase` with and without `software_renderer` (`-D warnings`) — clean
- [x] `rustfmt --check` on both changed files
- [ ] CI green; regenerate + push the full thumbnail set after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)