### PR TITLE
fix(showcase): resource bundles, book link, and gallery tile repair for the Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -64,7 +64,16 @@ jobs:
         run: cargo run -p raylib-showcase --release --bin xtask-wasm-build
       - name: Generate thumbnails (software_renderer)
         run: cargo run -p raylib-showcase --release --features software_renderer --bin gen-thumbnails
+      - name: Set up mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.5.3'   # match book.yml's pin
+      - name: Build the book (deployed at /book/)
+        run: mdbook build book
       - name: Assemble Pages site
+        # xtask-build-pages also packages per-category resource bundles via
+        # $EMSDK's file_packager (so file-loading examples work on the web)
+        # and copies book/book/ into _site/book/.
         run: cargo run -p raylib-showcase --release --bin xtask-build-pages
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/showcase/examples/text/text_3d_drawing.rs
+++ b/showcase/examples/text/text_3d_drawing.rs
@@ -34,7 +34,11 @@ use raylib::prelude::*;
 use raylib::rlgl::RaylibRlgl;
 use raylib_showcase::SourceViewer;
 
-// Always glsl330 in this Rust port (desktop only; raylib-rs pins glsl330)
+// Mirror the C #if PLATFORM_DESKTOP / #else fork: glsl330 on desktop,
+// glsl100 on web (WebGL/GLES2) — same cfg pattern as the shaders ports.
+#[cfg(target_family = "wasm")]
+const GLSL_VERSION: i32 = 100;
+#[cfg(not(target_family = "wasm"))]
 const GLSL_VERSION: i32 = 330;
 
 //--------------------------------------------------------------------------------------

--- a/showcase/examples/text/text_font_sdf.rs
+++ b/showcase/examples/text/text_font_sdf.rs
@@ -18,8 +18,11 @@ use raylib::core::drawing::RaylibShaderModeExt;
 use raylib::prelude::*;
 use raylib_showcase::SourceViewer;
 
-// Mirror the C #if PLATFORM_DESKTOP / #else: we always run on desktop (wasm uses glsl100, but
-// the GLSL version is selected at C build time — Rust port pins to glsl330 like other ports).
+// Mirror the C #if PLATFORM_DESKTOP / #else fork: glsl330 on desktop,
+// glsl100 on web (WebGL/GLES2) — same cfg pattern as the shaders ports.
+#[cfg(target_family = "wasm")]
+const GLSL_VERSION: i32 = 100;
+#[cfg(not(target_family = "wasm"))]
 const GLSL_VERSION: i32 = 330;
 
 //------------------------------------------------------------------------------------

--- a/showcase/index/style.css
+++ b/showcase/index/style.css
@@ -52,10 +52,19 @@ main { padding: 1rem; }
   border: 1px solid var(--tile-border);
   border-radius: 6px;
   padding: 0.5rem;
-  text-decoration: none;
-  color: inherit;
   background: var(--tile-bg);
   transition: transform 0.08s ease, box-shadow 0.08s ease;
+}
+
+/* Inner anchor wrapping thumb + caption (the C/Rust links are siblings —
+   anchors must not nest). Grows so the links row sits at a consistent
+   bottom edge across tiles whose captions wrap differently. */
+.tile .tile-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  text-decoration: none;
+  color: inherit;
 }
 
 .tile:hover {
@@ -64,17 +73,21 @@ main { padding: 1rem; }
 }
 
 .tile .thumb {
+  /* `position: relative` + absolutely-positioned children below make the
+     box size depend ONLY on width + aspect-ratio: neither a missing/odd-size
+     <img> nor placeholder text can stretch it, so every tile's thumb block
+     is identical regardless of content. */
+  position: relative;
   width: 100%;
   aspect-ratio: 16 / 10;
   background: var(--placeholder-bg);
   border-radius: 4px;
   overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .tile .thumb img {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -85,7 +98,14 @@ main { padding: 1rem; }
   /* No <img>; show the example name inside the placeholder so the tile
      is still identifiable when gen-thumbnails couldn't capture it. */
 }
-.tile .placeholder span {
+.tile .placeholder .ph-name {
+  /* Scoped to the name span only — the desktop-only badge overlay is also a
+     span inside .placeholder and must keep its own corner positioning. */
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.4rem 0.6rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.75rem;
@@ -124,6 +144,16 @@ main { padding: 1rem; }
   background: var(--badge-bg);
   color: var(--badge-fg);
   vertical-align: middle;
+}
+
+/* Badge overlaid on the tile's thumb box (desktop-only marker). Needs an
+   opaque-ish background to stay readable over thumbnail imagery. */
+.thumb .badge-overlay {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  margin: 0;
+  background: rgba(255, 244, 230, 0.92);
 }
 
 .hidden { display: none !important; }

--- a/showcase/index/template.html
+++ b/showcase/index/template.html
@@ -10,9 +10,10 @@
   <header>
     <h1>raylib-rs showcase</h1>
     <p class="banner">
-      Preview build of raylib-rs 6.0-rc &mdash;
-      final docs at <a href="https://raylib-rs.github.io/">raylib-rs.github.io</a>
-      after release.
+      Rust ports of raylib's official examples, running in your browser.
+      New to raylib-rs? Start with the
+      <a class="book-link" href="book/">&#128214; raylib-rs book</a> &mdash;
+      install, quickstart, and a chapter per module.
     </p>
     <input id="filter" type="search" placeholder="filter by name&hellip;" autocomplete="off" />
     <p id="status"></p>

--- a/showcase/src/bin/xtask_build_pages.rs
+++ b/showcase/src/bin/xtask_build_pages.rs
@@ -8,8 +8,10 @@
 //! click target.
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde::Deserialize;
 
@@ -95,31 +97,40 @@ fn main() {
         ));
         for m in entries {
             total_tiles += 1;
+            // Desktop-only entries are marked with a badge overlaid on the
+            // thumb box itself (not in the caption), so the marking is
+            // visible at tile-scan level and the thumb box stays the same
+            // fixed size as every other tile.
+            let overlay = if m.wasm_excluded {
+                "<span class=\"badge badge-overlay\">desktop only</span>"
+            } else {
+                ""
+            };
             let thumb_html = match thumbs.get(&m.name).and_then(|t| t.clone()) {
                 Some(file) => format!(
-                    "<div class=\"thumb\"><img src=\"thumbnails/{}\" alt=\"{}\" loading=\"lazy\" /></div>",
-                    file, m.name,
+                    "<div class=\"thumb\"><img src=\"thumbnails/{}\" alt=\"{}\" loading=\"lazy\" />{}</div>",
+                    file, m.name, overlay,
                 ),
                 // No thumbnail captured (gen-thumbnails failed for this
                 // example). Show the name inside the placeholder so the
                 // tile is still identifiable at a glance instead of being
                 // a blank gray box.
                 None => format!(
-                    "<div class=\"thumb placeholder\"><span>{}</span></div>",
-                    m.name,
+                    "<div class=\"thumb placeholder\"><span class=\"ph-name\">{}</span>{}</div>",
+                    m.name, overlay,
                 ),
             };
-            let badge = if m.wasm_excluded {
-                " <span class=\"badge\">desktop only</span>"
-            } else {
-                ""
-            };
+            // The tile root is a <div> with an inner <a> around the thumb +
+            // caption, and the C/Rust links as a *sibling* <p>. Nesting the
+            // C/Rust anchors inside one big tile anchor is invalid HTML —
+            // the parser's misnested-anchor recovery splits every tile into
+            // a real tile plus a collapsed clone (doubling the tile count
+            // and producing mismatched tile sizes in the gallery).
             categories_body.push_str(&format!(
-                "        <a class=\"tile\" href=\"examples/{cat}/{name}.html\" data-name=\"{name}\">\n          {thumb}\n          <p>{name}{badge}</p>\n          <p class=\"links\"><a href=\"{c_url}\">C</a> &middot; <a href=\"{rust_url}\">Rust</a></p>\n        </a>\n",
+                "        <div class=\"tile\" data-name=\"{name}\">\n          <a class=\"tile-main\" href=\"examples/{cat}/{name}.html\">\n            {thumb}\n            <p>{name}</p>\n          </a>\n          <p class=\"links\"><a href=\"{c_url}\">C</a> &middot; <a href=\"{rust_url}\">Rust</a></p>\n        </div>\n",
                 cat = cat,
                 name = m.name,
                 thumb = thumb_html,
-                badge = badge,
                 c_url = m.c_url,
                 rust_url = m.rust_url,
             ));
@@ -151,6 +162,17 @@ fn main() {
         .join("examples");
     let shell_template = fs::read_to_string(manifest_dir.join("index/example_shell.html"))
         .expect("index/example_shell.html not found; required to synthesize per-example pages");
+
+    // Package per-category resources into emscripten preload bundles
+    // (`<cat>_res.data` + `<cat>_res.js`) so examples can fopen their
+    // `resources/<cat>/...` files at runtime. Without this every
+    // file-loading example aborts on the web — the wasm link never sees
+    // an emcc `--preload-file` flag (and can't: the bucketed build shares
+    // one EMCC_CFLAGS across many examples), so we run emscripten's
+    // file_packager post-hoc instead. One bundle per category keeps the
+    // download per page bounded (and browser-cached across that
+    // category's examples) instead of duplicating 49 MB per example.
+    let packaged_categories = package_category_resources(&manifest_dir, &site, &by_category);
     for m in &metas {
         let out_dir = site.join("examples").join(&m.category);
         fs::create_dir_all(&out_dir).unwrap();
@@ -179,11 +201,24 @@ fn main() {
         if js_copied {
             // Substitute placeholders in the shell. `{{{ SCRIPT }}}` is the
             // emscripten loader script tag (defaulted to async to match
-            // emscripten's own default HTML output).
-            let script_tag = format!(
+            // emscripten's own default HTML output). When the category has a
+            // resource bundle, a synchronous file_packager loader script is
+            // injected *before* the async main loader: the sync script blocks
+            // the parser, so its preRun/run-dependency registration is
+            // guaranteed to happen before the runtime starts and main() can
+            // touch the FS.
+            let main_tag = format!(
                 "<script async type=\"text/javascript\" src=\"{}.js\"></script>",
                 m.name
             );
+            let script_tag = if packaged_categories.contains(m.category.as_str()) {
+                format!(
+                    "<script type=\"text/javascript\" src=\"{}_res.js\"></script>\n  {}",
+                    m.category, main_tag,
+                )
+            } else {
+                main_tag
+            };
             let html = shell_template
                 .replace("{{{ EXAMPLE_NAME }}}", &m.name)
                 .replace("{{{ SCRIPT }}}", &script_tag);
@@ -211,12 +246,147 @@ fn main() {
         }
     }
 
+    // Copy a prebuilt mdBook (book/book/, produced by `mdbook build book`)
+    // into _site/book/ so the gallery header's book link resolves on the
+    // deployed Pages site. Optional: local gallery builds without mdbook
+    // still work, with a warning so the gap is visible in CI logs.
+    let book_src = workspace_root.join("book").join("book");
+    if book_src.join("index.html").exists() {
+        copy_dir_recursive(&book_src, &site.join("book"));
+        eprintln!("xtask_build_pages: copied mdBook into _site/book/");
+    } else {
+        eprintln!(
+            "xtask_build_pages: WARNING: {:?} not found (run `mdbook build book` first); \
+             the gallery's book link will 404 on this build",
+            book_src,
+        );
+    }
+
     eprintln!(
-        "xtask_build_pages: wrote {} tiles across {} categories to {:?}",
+        "xtask_build_pages: wrote {} tiles across {} categories to {:?} ({} resource bundles)",
         total_tiles,
         by_category.len(),
         site,
+        packaged_categories.len(),
     );
+}
+
+/// Runs emscripten's `file_packager` once per category that has vendored
+/// resources, emitting `_site/examples/<cat>/<cat>_res.data` (the bundle) and
+/// `<cat>_res.js` (the synchronous preRun loader injected into each of that
+/// category's example pages). Returns the set of categories that were
+/// successfully packaged.
+///
+/// Skips (with a warning) when the `EMSDK` env var, the file_packager script,
+/// or a `python3`/`python` interpreter is unavailable — local site builds
+/// without emsdk still produce a browsable gallery, just without runtime
+/// resources.
+fn package_category_resources(
+    manifest_dir: &Path,
+    site: &Path,
+    by_category: &BTreeMap<String, Vec<&ExampleMeta>>,
+) -> BTreeSet<String> {
+    let mut packaged = BTreeSet::new();
+
+    let Ok(emsdk) = std::env::var("EMSDK") else {
+        eprintln!(
+            "xtask_build_pages: WARNING: EMSDK not set; skipping resource bundles — \
+             file-loading examples will not run on the generated site",
+        );
+        return packaged;
+    };
+    let file_packager = PathBuf::from(&emsdk)
+        .join("upstream")
+        .join("emscripten")
+        .join("tools")
+        .join("file_packager.py");
+    if !file_packager.exists() {
+        eprintln!(
+            "xtask_build_pages: WARNING: {:?} not found; skipping resource bundles",
+            file_packager,
+        );
+        return packaged;
+    }
+    // emsdk environments ship python3 on Linux/macOS and python on Windows.
+    let python = ["python3", "python"]
+        .iter()
+        .find(|p| {
+            Command::new(p)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .copied();
+    let Some(python) = python else {
+        eprintln!(
+            "xtask_build_pages: WARNING: no python3/python on PATH; skipping resource bundles",
+        );
+        return packaged;
+    };
+
+    for cat in by_category.keys() {
+        let res_dir = manifest_dir.join("resources").join(cat);
+        // Skip categories with no vendored resources (e.g. `shapes`) — their
+        // examples don't fopen anything, so no bundle is needed.
+        let has_files = fs::read_dir(&res_dir)
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false);
+        if !has_files {
+            continue;
+        }
+        let out_dir = site.join("examples").join(cat);
+        fs::create_dir_all(&out_dir).unwrap();
+        let data_path = out_dir.join(format!("{}_res.data", cat));
+        let js_path = out_dir.join(format!("{}_res.js", cat));
+        // Map the on-disk `showcase/resources/<cat>` to the virtual FS path
+        // `/resources/<cat>` — examples fopen `resources/<cat>/...` relative
+        // to the emscripten CWD `/`, so the paths line up.
+        let preload_spec = format!("{}@/resources/{}", res_dir.display(), cat);
+        let status = Command::new(python)
+            .arg(&file_packager)
+            .arg(&data_path)
+            .arg("--preload")
+            .arg(&preload_spec)
+            .arg(format!("--js-output={}", js_path.display()))
+            .status();
+        match status {
+            Ok(s) if s.success() => {
+                packaged.insert(cat.clone());
+                eprintln!(
+                    "xtask_build_pages: packaged resources/{} ({} bytes)",
+                    cat,
+                    fs::metadata(&data_path).map(|m| m.len()).unwrap_or(0),
+                );
+            }
+            Ok(s) => eprintln!(
+                "xtask_build_pages: WARNING: file_packager for {} exited {:?}; \
+                 that category's examples will lack runtime resources",
+                cat,
+                s.code(),
+            ),
+            Err(e) => eprintln!(
+                "xtask_build_pages: WARNING: failed to spawn file_packager for {}: {}",
+                cat, e,
+            ),
+        }
+    }
+    packaged
+}
+
+/// Recursively copies `src` into `dst` (creating `dst`). Panics on I/O errors
+/// — site assembly is all-or-nothing.
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap().flatten() {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_recursive(&from, &to);
+        } else {
+            fs::copy(&from, &to).unwrap();
+        }
+    }
 }
 
 fn render_desktop_only_placeholder(m: &ExampleMeta) -> String {


### PR DESCRIPTION
## Summary

Three independent fixes for the deployed gallery at <https://raylib-rs.github.io/raylib-rs/>:

### 1. File-loading examples were all broken on the web (resource bundles)
The wasm builds never passed `--preload-file`, so `showcase/resources/` (49 MB) never reached the browser — **every** example that `fopen`s a file aborted at runtime (all of `shaders/` incl. the reported `shaders_eratosthenes_sieve` / `shaders_ascii_rendering`, plus most of `textures/`, `models/`, `text/`). The bucketed wasm build (one cargo invocation for many examples, #306) can't carry per-example EMCC flags, so `xtask-build-pages` now packages **post-hoc, per category** via emscripten's `file_packager`: shared `examples/<cat>/<cat>_res.{data,js}` bundles (browser-cached across a category's examples instead of duplicating 49 MB × 229), with the sync loader script injected ahead of the async emscripten loader (parser ordering guarantees the FS mounts before `main()`). Skips with a warning when EMSDK/python are unavailable locally.

Census fallout: `text_font_sdf` and `text_3d_drawing` pinned `glsl330` with no wasm fork — both now use the standard `target_family` cfg mirror (upstream glsl100 shaders were already vendored). Every other glsl330 user either forks already or is wasm-excluded.

### 2. No link to the book
The mdBook was never deployed anywhere (the banner linked to `raylib-rs.github.io`, which doesn't exist). `pages.yml` now builds the book (mdbook 0.5.3, matching `book.yml`'s pin), `xtask-build-pages` copies it into `_site/book/`, and the gallery banner links to it.

### 3. Gallery tiles were split + mismatched sizes
The C/Rust links were anchors **nested inside the tile anchor** — invalid HTML whose parser recovery split every tile into a real tile plus a collapsed clone (the status line counted "458 examples" for 229 tiles; the clones are the odd-sized "placeholder blocks"). Tiles are now a `<div>` with an inner `tile-main` anchor and sibling links; thumb-box content is absolutely positioned inside the fixed-aspect box so **every tile is pixel-identical**; "desktop only" renders as an overlay badge pinned top-right on the thumb box.

| before (live site bug, reproduced locally) | after |
|---|---|
| alternating collapsed tiles, 458 counted | 229 equal tiles, badges top-right |

## Test Plan

- [x] Local site assembly: graceful-skip warnings fire without EMSDK/mdbook; 229 tiles / 9 categories
- [x] Headless-Edge screenshots: equal-size tiles for all 4 variants (img / img+badge / placeholder / placeholder+badge), badge pinned top-right without overlapping the name, book link in banner, count shows 229
- [x] `cargo clippy -p raylib-showcase` (`-D warnings`) + `rustfmt --check` on changed files
- [x] `text_font_sdf` + `text_3d_drawing` build on desktop (cfg-mirror unchanged there)
- [ ] CI: showcase wasm shards build the two text examples for emscripten
- [ ] Post-merge: pages.yml deploy — verify `shaders_eratosthenes_sieve` / `shaders_ascii_rendering` / a textures example run, book link resolves, `<cat>_res.data` bundles served

🤖 Generated with [Claude Code](https://claude.com/claude-code)