### PR TITLE
refactor(error): finish the thiserror migration (SetCallbackError + complete RaylibError)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Upgrade from raylib 5.x to **raylib 6.0**. MSRV bumped to **1.85** (edition 2024
 - **`samples/` directory removed.** Migration: see [`showcase/`](./showcase) for runnable Rust ports of raylib's C examples. Anyone running `cd samples && cargo run --bin <name>` against the pre-release 6.0-rc branch should switch to `showcase/` instead. The WS9 finale of the 6.0 effort completes the port of all upstream examples and publishes the gallery as a GitHub Pages site.
 - `RaylibGuiIcons::gui_get_icons_raw` removed; use `gui_get_icons` / `gui_get_icons_mut`.
 - `RaylibGuiIcons::gui_load_icons_raw` removed; use `gui_load_icons` / `gui_load_icons_with_names`.
+- `SetLogError` (core/callbacks) is replaced by `SetCallbackError` in `core::error` — a `thiserror` struct without the artificial lifetime parameter. The ~10 `set_*_callback` functions/methods now return `Result<(), SetCallbackError>`.
+- `RaylibError` is now `#[non_exhaustive]` and gained `#[from]` variants for `UpdateAudioStreamError`, `InvalidMeshError`, `GenMeshError`, `Base64Error`, `LoadIconsError`, `LoadStyleFromMemoryError`, `PixelColorError`, and `SetCallbackError` — every leaf error now composes via `?`. Exhaustive matches on `RaylibError` need a wildcard arm.
 
 ### Added
 

--- a/docs/superpowers/plans/2026-06-03-thiserror-migration-completion.md
+++ b/docs/superpowers/plans/2026-06-03-thiserror-migration-completion.md
@@ -1,0 +1,460 @@
+# thiserror Migration Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the last hand-rolled error type (`SetLogError`) with a thiserror struct and complete the `RaylibError` aggregate (8 missing `#[from]` variants + `#[non_exhaustive]`).
+
+**Architecture:** Two breaking-but-pre-final API changes in the safe crate: (1) `core/callbacks.rs`'s `SetLogError<'a>` newtype + manual `Display`/`Error` impls become a `SetCallbackError(&'static str)` thiserror struct living in `core/error.rs` with the other error types; (2) `RaylibError` gains `#[from]` variants for the 6 error.rs leaf enums it's missing plus `PixelColorError` (from `core/pixel.rs`) and the new `SetCallbackError`, and becomes `#[non_exhaustive]`. Tests are Tier-1 (window-independent) unit tests inside `error.rs`'s existing `#[cfg(test)]` pattern.
+
+**Tech Stack:** Rust 1.85 / edition 2024, `thiserror` 2.x (already a dependency), cargo-nextest.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-thiserror-migration-completion-design.md`
+**Branch:** `chore/thiserror-migration` (already created off `origin/unstable` @ `1462ea1`)
+
+---
+
+## File structure
+
+- Modify: `raylib/src/core/error.rs` — add `SetCallbackError` (+ tests), add 8 `RaylibError` variants + `#[non_exhaustive]`, update `RaylibError` doc example.
+- Modify: `raylib/src/core/callbacks.rs` — delete `SetLogError` + impls; update macro, 5 free fns, 5 deprecated `RaylibHandle` methods, and the doc example.
+- Modify: `CHANGELOG.md` — two entries under the existing `### Breaking` section of the `6.0.0-rc.2` block (that block becomes `6.0.0` final per its header note).
+
+House style note for every new doc comment: each new variant/type gets a summary line, a **Cause:** paragraph, and a **Recovery:** paragraph, matching the existing entries in `error.rs` (see e.g. `AudioInitError::DoubleInit` at the top of the file). `deny(missing_docs)` is crate-wide — undocumented public items fail the build.
+
+---
+
+## Task 1: `SetCallbackError` replaces `SetLogError`
+
+**Files:**
+- Modify: `raylib/src/core/error.rs` (new type after `LoadStyleFromMemoryError`, ~line 1165; new test mod at the bottom)
+- Modify: `raylib/src/core/callbacks.rs:141-194` (type + macro + free fns) and `:500-545` (RaylibHandle methods)
+
+- [ ] **Step 1: Write the failing Display test**
+
+At the bottom of `raylib/src/core/error.rs` (after the existing `load_icons_error_tests` mod):
+
+```rust
+#[cfg(test)]
+mod set_callback_error_tests {
+    use super::*;
+
+    #[test]
+    fn display_names_the_occupied_slot() {
+        let e = SetCallbackError("save file data");
+        assert_eq!(
+            e.to_string(),
+            "there is a save file data callback already set"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (from repo root): `cargo nextest run -p raylib -E 'test(set_callback_error)'`
+Expected: compile error — `cannot find ... SetCallbackError` (the type doesn't exist yet).
+
+- [ ] **Step 3: Add `SetCallbackError` to `error.rs`**
+
+Insert after `LoadStyleFromMemoryError`'s closing brace (~line 1165), before the `#[cfg(test)]` mods:
+
+```rust
+/// Error returned when installing a process-global callback whose slot is already occupied.
+///
+/// Each callback slot in [`crate::core::callbacks`] ([`set_save_file_data_callback`],
+/// [`set_load_file_data_callback`], [`set_save_file_text_callback`],
+/// [`set_load_file_text_callback`]) holds at most one function at a time. Calling a setter
+/// while its slot is occupied returns this error rather than silently overwriting. The inner
+/// `&'static str` names which callback kind was already set (e.g. `"save file data"`).
+///
+/// **Cause:** A previous call to the same setter installed a callback that has not been
+/// removed.
+///
+/// **Recovery:** Keep a single registration site per callback kind, or remove the existing
+/// callback (where an unset function exists) before installing a new one.
+///
+/// # Examples
+///
+/// ```no_run
+/// use raylib::prelude::*;
+/// use raylib::core::callbacks::set_save_file_data_callback;
+///
+/// fn writer(_path: &str, _bytes: &[u8]) -> bool { true }
+/// set_save_file_data_callback(writer).expect("first install");
+/// match set_save_file_data_callback(writer) {
+///     Err(e) => eprintln!("{e}"), // "there is a save file data callback already set"
+///     Ok(()) => unreachable!(),
+/// }
+/// ```
+///
+/// [`set_save_file_data_callback`]: crate::core::callbacks::set_save_file_data_callback
+/// [`set_load_file_data_callback`]: crate::core::callbacks::set_load_file_data_callback
+/// [`set_save_file_text_callback`]: crate::core::callbacks::set_save_file_text_callback
+/// [`set_load_file_text_callback`]: crate::core::callbacks::set_load_file_text_callback
+#[derive(Error, Debug)]
+#[error("there is a {0} callback already set")]
+pub struct SetCallbackError(pub(crate) &'static str);
+```
+
+Note: the message is lowercase without a trailing period (Rust error-message convention);
+the old hand-rolled message was `"There is a {} callback already set."` — the doc comment in
+callbacks.rs quoting it is updated in Step 4.
+
+- [ ] **Step 4: Migrate `callbacks.rs`**
+
+(a) Delete lines ~141–172: the `SetLogError` doc comment, `pub struct SetLogError<'a>(&'a str);`, the `impl std::fmt::Display`, and the `impl std::error::Error`. (Its doc example moves to `SetCallbackError` in Step 3, already done.)
+
+(b) Add the import near the top of the file alongside the existing `use` items:
+
+```rust
+use crate::core::error::SetCallbackError;
+```
+
+(c) In `safe_callback_set_func!` change the error construction:
+
+```rust
+            Err(SetCallbackError($ty))
+```
+
+(d) Update the 5 free-fn signatures (drop the lifetime params — they exist only for the old error type):
+
+```rust
+pub fn set_trace_log_callback(cb: fn(TraceLogLevel, &str)) -> Result<(), SetCallbackError> {
+```
+```rust
+pub fn set_save_file_data_callback(cb: fn(&str, &[u8]) -> bool) -> Result<(), SetCallbackError> {
+```
+```rust
+pub fn set_load_file_data_callback(cb: fn(&str) -> Vec<u8>) -> Result<(), SetCallbackError> {
+```
+```rust
+pub fn set_save_file_text_callback(cb: fn(&str, &str) -> bool) -> Result<(), SetCallbackError> {
+```
+```rust
+pub fn set_load_file_text_callback(cb: fn(&str) -> String) -> Result<(), SetCallbackError> {
+```
+
+(`set_trace_log_callback` keeps its `Result` return for API uniformity even though its body
+always returns `Ok` — spec decision; do not change its body.)
+
+(e) Update the 5 deprecated `RaylibHandle` methods (~lines 500–545): each
+`Result<(), SetLogError<'_>>` becomes `Result<(), SetCallbackError>`. The `&'_ mut self`
+receivers stay as they are. Example for the first; apply identically to all five:
+
+```rust
+    pub fn set_trace_log_callback(
+        &'_ mut self,
+        cb: fn(TraceLogLevel, &str),
+    ) -> Result<(), SetCallbackError> {
+        set_trace_log_callback(cb)
+    }
+```
+
+(f) Search the file for any remaining references: `grep -n "SetLogError" raylib/src/core/callbacks.rs` must return nothing.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo nextest run -p raylib -E 'test(set_callback_error)'`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Verify the crate still compiles + no stragglers**
+
+Run: `cargo check -p raylib` → clean.
+Run: `grep -rn "SetLogError" raylib/src` → no matches.
+Run: `grep -rnE "impl std::error::Error for|impl std::fmt::Display for" raylib/src` → no matches (definition-of-done check #1).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add raylib/src/core/error.rs raylib/src/core/callbacks.rs
+git commit -m "refactor(error): replace hand-rolled SetLogError with thiserror SetCallbackError
+
+The last manual Display/Error impl in the safe crate. The artificial
+lifetime parameter on the callback setters goes away with it.
+BREAKING (pre-6.0.0-final): public type renamed, no alias.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Complete the `RaylibError` aggregate
+
+**Files:**
+- Modify: `raylib/src/core/error.rs:919-1055` (doc example + enum) and the test mods at the bottom.
+
+- [ ] **Step 1: Write the failing conversion tests**
+
+Add at the bottom of `error.rs`:
+
+```rust
+#[cfg(test)]
+mod raylib_error_from_tests {
+    use super::*;
+    use crate::consts::PixelFormat;
+    use crate::core::pixel::PixelColorError;
+
+    #[test]
+    fn all_new_leaf_errors_convert_via_from() {
+        assert!(matches!(
+            RaylibError::from(UpdateAudioStreamError::CallbackSlotBusy),
+            RaylibError::UpdateAudioStream(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(InvalidMeshError::TrianglePointMiscount),
+            RaylibError::InvalidMesh(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(GenMeshError::InvalidMesh(
+                InvalidMeshError::TrianglePointMiscount
+            )),
+            RaylibError::GenMesh(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(Base64Error::DecodeFailed),
+            RaylibError::Base64(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(LoadIconsError::HeaderTruncated(3)),
+            RaylibError::LoadIcons(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(LoadStyleFromMemoryError::LengthOverflow(5)),
+            RaylibError::LoadStyleFromMemory(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(PixelColorError::CompressedFormat(
+                PixelFormat::PIXELFORMAT_COMPRESSED_DXT1_RGB
+            )),
+            RaylibError::PixelColor(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(SetCallbackError("trace log")),
+            RaylibError::SetCallback(_)
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p raylib -E 'test(raylib_error_from)'`
+Expected: compile error — `no variant named UpdateAudioStream` (etc.).
+
+- [ ] **Step 3: Add the 8 variants + `#[non_exhaustive]`**
+
+(a) Add `#[non_exhaustive]` between `#[derive(Error, Debug)]` and `pub enum RaylibError {` (~line 944):
+
+```rust
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum RaylibError {
+```
+
+(b) Append the 8 variants before the enum's closing brace (~line 1055), keeping the existing house style:
+
+```rust
+    /// Wraps an [`UpdateAudioStreamError`] surfaced through `?` from an audio-stream update
+    /// or callback-install site.
+    ///
+    /// **Cause:** An `AudioStream::update` or `set_audio_stream_callback` call propagated up
+    /// an [`UpdateAudioStreamError`].
+    ///
+    /// **Recovery:** Inspect the inner [`UpdateAudioStreamError`] variant and apply its
+    /// recovery.
+    #[error("audio stream update error")]
+    UpdateAudioStream(#[from] UpdateAudioStreamError),
+    /// Wraps an [`InvalidMeshError`] surfaced through `?` from a mesh-validation site.
+    ///
+    /// **Cause:** A mesh accessor or builder validated a [`crate::ffi::Mesh`] and found its
+    /// buffers inconsistent.
+    ///
+    /// **Recovery:** Inspect the inner [`InvalidMeshError`] variant and apply its recovery.
+    #[error("invalid mesh error")]
+    InvalidMesh(#[from] InvalidMeshError),
+    /// Wraps a [`GenMeshError`] surfaced through `?` from a mesh-generation site.
+    ///
+    /// **Cause:** A `MeshBuilder::build` (or other mesh-generation) call propagated up a
+    /// [`GenMeshError`].
+    ///
+    /// **Recovery:** Inspect the inner [`GenMeshError`] variant and apply its recovery.
+    #[error("mesh generation error")]
+    GenMesh(#[from] GenMeshError),
+    /// Wraps a [`Base64Error`] surfaced through `?` from a base64 encode/decode site.
+    ///
+    /// **Cause:** An `encode_data_base64` or `decode_data_base64` call propagated up a
+    /// [`Base64Error`].
+    ///
+    /// **Recovery:** Inspect the inner [`Base64Error`] variant and apply its recovery.
+    #[error("base64 error")]
+    Base64(#[from] Base64Error),
+    /// Wraps a [`LoadIconsError`] surfaced through `?` from a raygui icons-load site.
+    ///
+    /// **Cause:** A `gui_load_icons`/`gui_load_icons_from_memory` call propagated up a
+    /// [`LoadIconsError`].
+    ///
+    /// **Recovery:** Inspect the inner [`LoadIconsError`] variant and apply its recovery.
+    #[error("icons loading error")]
+    LoadIcons(#[from] LoadIconsError),
+    /// Wraps a [`LoadStyleFromMemoryError`] surfaced through `?` from a raygui style-load site.
+    ///
+    /// **Cause:** A `gui_load_style_from_memory` call propagated up a
+    /// [`LoadStyleFromMemoryError`].
+    ///
+    /// **Recovery:** Inspect the inner [`LoadStyleFromMemoryError`] variant and apply its
+    /// recovery.
+    #[error("style loading error")]
+    LoadStyleFromMemory(#[from] LoadStyleFromMemoryError),
+    /// Wraps a [`crate::core::pixel::PixelColorError`] surfaced through `?` from a
+    /// pixel-level color read/write site.
+    ///
+    /// **Cause:** A `get_pixel_color`/`set_pixel_color` call propagated up a
+    /// [`crate::core::pixel::PixelColorError`].
+    ///
+    /// **Recovery:** Inspect the inner error variant and apply its recovery.
+    #[error("pixel color error")]
+    PixelColor(#[from] crate::core::pixel::PixelColorError),
+    /// Wraps a [`SetCallbackError`] surfaced through `?` from a callback-install site.
+    ///
+    /// **Cause:** A `set_*_callback` call found its global slot already occupied.
+    ///
+    /// **Recovery:** Keep a single registration site per callback kind.
+    #[error("callback registration error")]
+    SetCallback(#[from] SetCallbackError),
+```
+
+(c) Update the `RaylibError` rustdoc example (~lines 919–943): doctests compile as an
+external crate, so `#[non_exhaustive]` makes a `_` arm mandatory. Replace the example with:
+
+```rust
+/// Top-level error type that aggregates all raylib-rs domain errors.
+///
+/// Marked `#[non_exhaustive]`: new domain errors may gain variants here in minor releases,
+/// so matches must include a wildcard arm.
+///
+/// # Examples
+///
+/// ```no_run
+/// use raylib::core::error::RaylibError;
+///
+/// fn handle(e: RaylibError) {
+///     match e {
+///         RaylibError::AudioInit(_) => eprintln!("audio device failed to initialize"),
+///         RaylibError::LoadSound(_) => eprintln!("sound load failed"),
+///         RaylibError::LoadModel(_) => eprintln!("model load failed"),
+///         RaylibError::LoadFont(_) => eprintln!("font load failed"),
+///         RaylibError::LoadTexture(_) => eprintln!("texture load failed"),
+///         RaylibError::SetCallback(_) => eprintln!("callback slot already occupied"),
+///         other => eprintln!("raylib error: {other}"),
+///     }
+/// }
+/// ```
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo nextest run -p raylib -E 'test(raylib_error_from)'`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Definition-of-done coverage check**
+
+Every `pub enum *Error`/`pub struct *Error` leaf in the safe crate must now have a `#[from]`
+in `RaylibError`. Verify the counts line up:
+
+```bash
+grep -E "^pub (enum|struct) \w*Error" raylib/src/core/error.rs raylib/src/core/pixel.rs
+grep -c "#\[from\]" <(awk '/^pub enum RaylibError/,/^\}/' raylib/src/core/error.rs)
+```
+Expected: **22 declarations** grepped (error.rs: 19 pre-existing leaf enums + `RaylibError`
+itself + the new `SetCallbackError` struct = 21; pixel.rs: `PixelColorError` = 1). Minus
+`RaylibError` itself → **21 leaves**, matching **21 `#[from]` lines** in the awk-extracted
+`RaylibError` block (13 existing + 8 new). Note `GenMeshError`'s own two `#[from]` lines live
+inside *that* enum — the awk extraction is scoped to `RaylibError` only, so they don't
+inflate the count. (If the numbers disagree, list which leaf lacks a variant and add it.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add raylib/src/core/error.rs
+git commit -m "feat(error): complete RaylibError aggregate + mark non_exhaustive
+
+Adds #[from] variants for UpdateAudioStream/InvalidMesh/GenMesh/Base64/
+LoadIcons/LoadStyleFromMemory/PixelColor/SetCallback so every leaf error
+composes via ?. BREAKING (pre-6.0.0-final): exhaustive matches on
+RaylibError stop compiling (new variants + non_exhaustive).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: CHANGELOG entries
+
+**Files:**
+- Modify: `CHANGELOG.md` (the `### Breaking` section of the `## 6.0.0-rc.2` block — per that block's header note, it describes what ships in `6.0.0` final)
+
+- [ ] **Step 1: Add the two entries**
+
+Append to the existing `### Breaking` bullet list:
+
+```markdown
+- `SetLogError` (core/callbacks) is replaced by `SetCallbackError` in `core::error` — a `thiserror` struct without the artificial lifetime parameter. The ~10 `set_*_callback` functions/methods now return `Result<(), SetCallbackError>`.
+- `RaylibError` is now `#[non_exhaustive]` and gained `#[from]` variants for `UpdateAudioStreamError`, `InvalidMeshError`, `GenMeshError`, `Base64Error`, `LoadIconsError`, `LoadStyleFromMemoryError`, `PixelColorError`, and `SetCallbackError` — every leaf error now composes via `?`. Exhaustive matches on `RaylibError` need a wildcard arm.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): record SetCallbackError rename + RaylibError completion
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full verification + PR
+
+- [ ] **Step 1: Full test suite**
+
+Run from repo root:
+```bash
+cargo nextest run -p raylib
+cargo test --doc -p raylib
+```
+Expected: all green. The doctests cover the updated `SetCallbackError` and `RaylibError`
+examples. (Note: per CLAUDE.md, a couple of pre-existing software-renderer doctest failures
+exist only under the SR feature set — the default-feature doc run here is expected clean.)
+
+- [ ] **Step 2: Quality gates**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p raylib --all-targets -- -D warnings
+```
+Expected: both clean. (`deny(missing_docs)` is enforced at compile time, so Step 1 already
+proved docs coverage.)
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin chore/thiserror-migration
+gh pr create --base unstable --repo raylib-rs/raylib-rs \
+  --title "refactor(error): finish the thiserror migration (SetCallbackError + complete RaylibError)" \
+  --body "<summary of: scope finding (migration was ~95% done), the SetLogError->SetCallbackError rename, the 8 new RaylibError variants + non_exhaustive, the two CHANGELOG breaking entries, and the deliberate keep-as-is decision for window.rs std-error returns. Link the spec. End with the Claude Code attribution line.>"
+```
+
+- [ ] **Step 4: Mark flexible-queue item 12 complete**
+
+After the PR merges, no separate done-note is needed (spec + plan suffice per the spec's
+Deliverables); the merge itself closes flexible-queue item 12.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** SetCallbackError shape + location (Task 1), lifetime removal + 10 signatures (Task 1 Step 4 d/e), uniform `Result` on `set_trace_log_callback` kept (Task 1 Step 4d note), 8 `#[from]` variants + non_exhaustive + doc example (Task 2), std-error returns untouched (no task — deliberate), Display + conversion tests (Tasks 1–2), CHANGELOG (Task 3), gates + PR (Task 4). Definition-of-done greps embedded in Task 1 Step 6 and Task 2 Step 5. ✓
+- **Type consistency:** `SetCallbackError(pub(crate) &'static str)` constructed as `SetCallbackError($ty)` in the macro and `SetCallbackError("trace log")`/`("save file data")` in tests — consistent. Variant names in Task 2 Step 1 tests match Step 3 definitions. ✓
+- **Doctest gotcha:** the `SetCallbackError` doc example can't construct the type directly (field is `pub(crate)`) — it goes through `set_save_file_data_callback`, which exists by the time the doctest compiles (same commit). ✓

--- a/docs/superpowers/specs/2026-06-03-thiserror-migration-completion-design.md
+++ b/docs/superpowers/specs/2026-06-03-thiserror-migration-completion-design.md
@@ -1,0 +1,118 @@
+# thiserror migration completion — design
+
+**Date:** 2026-06-03
+**Branch:** `chore/thiserror-migration` (off canonical `unstable` @ `1462ea1`)
+**Status:** approved, pre-implementation
+**Origin:** flexible-queue item 12 (`ws8e-checkpoint-review-feedback.md` §7 — owner: "TODO: Use this_error for all error types.")
+
+## Scope finding (why this is small)
+
+The review comment that spawned this workstream is largely stale: `raylib/src/core/error.rs`
+already holds ~19 leaf error enums, all `#[derive(thiserror::Error)]` with house-style
+Cause/Recovery variant docs, plus a `RaylibError` aggregate with `#[from]` composition.
+`audio_stream_callback.rs` (the commented file) already returns
+`Result<(), UpdateAudioStreamError>`. A crate-wide sweep found exactly one hand-rolled
+error type and one incomplete aggregate. This spec completes the migration rather than
+restarting it.
+
+## Goals
+
+1. **Zero hand-rolled error impls in the safe crate.** The single remaining manual
+   `impl Display` + `impl std::error::Error` (`SetLogError` in `core/callbacks.rs`) is
+   replaced by a thiserror type.
+2. **Complete `?` composition.** Every public leaf error type converts into `RaylibError`
+   via `#[from]`.
+3. **Future-proof the aggregate.** `RaylibError` becomes `#[non_exhaustive]` so adding
+   leaf errors later is not a semver-major event.
+
+## Non-goals
+
+- No renaming or restructuring of the existing 19 leaf error enums.
+- No wrapping of the two std-error returns in `core/window.rs`
+  (`get_monitor_name`/`get_monitor_info` → `std::ffi::IntoStringError`,
+  `get_clipboard_text` → `std::str::Utf8Error`). These are precise std types for genuinely
+  std failures; wrapping adds a layer for no gain. **Deliberate decision, recorded here.**
+- No `source()` re-plumbing or error-message rewording of existing types.
+- Leaf enums stay exhaustive (matching leaf variants is the documented pattern);
+  `#[non_exhaustive]` applies to the `RaylibError` aggregate only.
+
+## Design
+
+### 1. `SetCallbackError` replaces `SetLogError`
+
+New type in `raylib/src/core/error.rs`, alongside the other error types:
+
+```rust
+/// Error returned when installing a callback whose global slot is already occupied.
+/// (house-style docs: Cause / Recovery / # Examples)
+#[derive(Error, Debug)]
+#[error("there is a {0} callback already set")]
+pub struct SetCallbackError(pub(crate) &'static str);
+```
+
+Rationale for a struct over an enum: the error has exactly one cause ("slot already
+occupied"); the only payload is *which* slot, and the call site already determines that.
+Per-kind enum variants would add ~7 documented variants for no matchability gain.
+
+Changes in `raylib/src/core/callbacks.rs`:
+- Delete `SetLogError<'a>` and its manual `Display`/`Error` impls (lines ~163–172).
+- The artificial lifetime disappears: all ~10 setter signatures change from
+  `Result<(), SetLogError<'a>>` to `Result<(), SetCallbackError>` (the `'a`/`'b` lifetime
+  params on those functions go away entirely).
+- `safe_callback_set_func!` macro body: `Err(SetLogError($ty))` → `Err(SetCallbackError($ty))`.
+  The `&'static str` kind arguments ("save file data", …) are unchanged.
+- `set_trace_log_callback` keeps its `Result` signature for API uniformity even though it
+  currently always returns `Ok` (it overwrites rather than guards its slot).
+- Doc examples referencing `SetLogError` (e.g. the doctest above the type) updated.
+
+**Breaking change** (allowed pre-6.0.0-final): public type `SetLogError` is renamed; no
+deprecated alias (the lifetime parameter makes an alias awkward and we are pre-final).
+CHANGELOG entry required.
+
+### 2. `RaylibError` aggregate completion
+
+Add the eight missing `#[from]` variants, each with house-style Cause/Recovery docs:
+
+| New variant | Wraps | Defined in |
+|---|---|---|
+| `UpdateAudioStream` | `UpdateAudioStreamError` | error.rs |
+| `InvalidMesh` | `InvalidMeshError` | error.rs |
+| `GenMesh` | `GenMeshError` | error.rs |
+| `Base64` | `Base64Error` | error.rs |
+| `LoadIcons` | `LoadIconsError` | error.rs |
+| `LoadStyleFromMemory` | `LoadStyleFromMemoryError` | error.rs |
+| `PixelColor` | `PixelColorError` | core/pixel.rs |
+| `SetCallback` | `SetCallbackError` | error.rs (new) |
+
+Plus:
+- `#[non_exhaustive]` on `RaylibError`.
+- Its rustdoc match example gains a `_` arm (required by `non_exhaustive` anyway) and a
+  sentence noting the enum is non-exhaustive.
+
+**Breaking change**: exhaustive matches on `RaylibError` stop compiling (both from the new
+variants and from `non_exhaustive`). CHANGELOG entry required.
+
+### 3. Tests (Tier-1, window-independent)
+
+- `SetCallbackError` Display output matches `"there is a save file data callback already set"`.
+- A conversion test exercising `RaylibError::from(...)`/`?` for each of the 8 new variants
+  (compile-time guarantee that `#[from]` is wired; runtime asserts on variant identity).
+- Existing gates do the rest: `deny(missing_docs)` forces docs on every new variant,
+  clippy `-D warnings`, doctests (the updated examples in callbacks.rs + error.rs must pass).
+
+### 4. Deliverables
+
+- One PR to canonical `unstable` from `chore/thiserror-migration`.
+- `CHANGELOG.md` entries under the unreleased/6.0.0 section: the `SetLogError` →
+  `SetCallbackError` rename and the `RaylibError` `non_exhaustive` + new variants.
+- No done-note needed beyond this spec + the plan (small workstream); the flexible-queue
+  tracking note can mark item 12 complete when the PR merges.
+
+## Definition of done
+
+- `grep` finds no manual `impl std::error::Error`/`impl Display for *Error` in `raylib/src`.
+- Every `pub enum *Error`/`pub struct *Error` leaf in the safe crate has a `#[from]` variant
+  in `RaylibError` (std error types in window.rs deliberately excluded).
+- `RaylibError` is `#[non_exhaustive]`.
+- `cargo nextest run` + `cargo test --doc` green from `raylib/`; fmt + clippy `-Dwarnings` clean.
+- CHANGELOG updated.

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use crate::core::error::SetCallbackError;
 use crate::{RaylibHandle, ffi};
 pub use raylib_sys::TraceLogLevel;
 use std::{
@@ -138,39 +139,6 @@ extern "C" fn custom_load_file_text_callback(a: *const c_char) -> *mut c_char {
     oh.as_ptr() as *mut c_char
 }
 
-/// Error returned when a callback registration fails because a callback of that type is already set.
-///
-/// Each callback slot in this module ([`set_trace_log_callback`],
-/// [`set_save_file_data_callback`], [`set_load_file_data_callback`],
-/// [`set_save_file_text_callback`], [`set_load_file_text_callback`]) holds at most one
-/// closure at a time. Calling the setter twice without intervening reset returns this error
-/// rather than overwriting silently. The inner `&str` names which callback type was already
-/// set (e.g. `"save file data"`); the `Display` impl includes it in the message.
-///
-/// # Examples
-///
-/// ```no_run
-/// use raylib::prelude::*;
-/// use raylib::core::callbacks::{set_save_file_data_callback, SetLogError};
-///
-/// fn writer(_path: &str, _bytes: &[u8]) -> bool { true }
-/// set_save_file_data_callback(writer).expect("first install");
-/// match set_save_file_data_callback(writer) {
-///     Err(e) => eprintln!("{e}"),       // "There is a save file data callback already set."
-///     Ok(()) => unreachable!(),
-/// }
-/// ```
-#[derive(Debug)]
-pub struct SetLogError<'a>(&'a str);
-
-impl std::fmt::Display for SetLogError<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("There is a {} callback already set.", self.0))
-    }
-}
-
-impl std::error::Error for SetLogError<'_> {}
-
 macro_rules! safe_callback_set_func {
     ($cb:expr, $target_cb:expr, $rawsetter:expr, $ogfunc:expr, $ty:literal) => {
         if $target_cb.load(Ordering::Acquire) == 0 {
@@ -178,13 +146,13 @@ macro_rules! safe_callback_set_func {
             unsafe { $rawsetter(Some($ogfunc)) };
             Ok(())
         } else {
-            Err(SetLogError($ty))
+            Err(SetCallbackError($ty))
         }
     };
 }
 
 /// Set custom trace log
-pub fn set_trace_log_callback<'a>(cb: fn(TraceLogLevel, &str)) -> Result<(), SetLogError<'a>> {
+pub fn set_trace_log_callback(cb: fn(TraceLogLevel, &str)) -> Result<(), SetCallbackError> {
     TRACE_LOG_CALLBACK.store(cb as usize, Ordering::Relaxed);
     #[cfg(not(feature = "nobuild"))]
     unsafe {
@@ -193,7 +161,7 @@ pub fn set_trace_log_callback<'a>(cb: fn(TraceLogLevel, &str)) -> Result<(), Set
     Ok(())
 }
 /// Set custom file binary data saver
-pub fn set_save_file_data_callback<'a>(cb: fn(&str, &[u8]) -> bool) -> Result<(), SetLogError<'a>> {
+pub fn set_save_file_data_callback(cb: fn(&str, &[u8]) -> bool) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         SAVE_FILE_DATA_CALLBACK,
@@ -205,7 +173,7 @@ pub fn set_save_file_data_callback<'a>(cb: fn(&str, &[u8]) -> bool) -> Result<()
 /// Set custom file binary data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-pub fn set_load_file_data_callback<'b>(cb: fn(&str) -> Vec<u8>) -> Result<(), SetLogError<'b>> {
+pub fn set_load_file_data_callback(cb: fn(&str) -> Vec<u8>) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         LOAD_FILE_DATA_CALLBACK,
@@ -215,7 +183,7 @@ pub fn set_load_file_data_callback<'b>(cb: fn(&str) -> Vec<u8>) -> Result<(), Se
     )
 }
 /// Set custom file text data saver
-pub fn set_save_file_text_callback<'a>(cb: fn(&str, &str) -> bool) -> Result<(), SetLogError<'a>> {
+pub fn set_save_file_text_callback(cb: fn(&str, &str) -> bool) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         SAVE_FILE_TEXT_CALLBACK,
@@ -227,7 +195,7 @@ pub fn set_save_file_text_callback<'a>(cb: fn(&str, &str) -> bool) -> Result<(),
 /// Set custom file text data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-pub fn set_load_file_text_callback<'a>(cb: fn(&str) -> String) -> Result<(), SetLogError<'a>> {
+pub fn set_load_file_text_callback(cb: fn(&str) -> String) -> Result<(), SetCallbackError> {
     safe_callback_set_func!(
         cb,
         LOAD_FILE_TEXT_CALLBACK,
@@ -504,7 +472,7 @@ impl RaylibHandle {
     pub fn set_trace_log_callback(
         &'_ mut self,
         cb: fn(TraceLogLevel, &str),
-    ) -> Result<(), SetLogError<'_>> {
+    ) -> Result<(), SetCallbackError> {
         set_trace_log_callback(cb)
     }
     /// Set custom file binary data saver
@@ -512,7 +480,7 @@ impl RaylibHandle {
     pub fn set_save_file_data_callback(
         &'_ mut self,
         cb: fn(&str, &[u8]) -> bool,
-    ) -> Result<(), SetLogError<'_>> {
+    ) -> Result<(), SetCallbackError> {
         set_save_file_data_callback(cb)
     }
     /// Set custom file binary data loader
@@ -522,7 +490,7 @@ impl RaylibHandle {
     pub fn set_load_file_data_callback(
         &'_ mut self,
         cb: fn(&str) -> Vec<u8>,
-    ) -> Result<(), SetLogError<'_>> {
+    ) -> Result<(), SetCallbackError> {
         set_load_file_data_callback(cb)
     }
     /// Set custom file text data saver
@@ -530,7 +498,7 @@ impl RaylibHandle {
     pub fn set_save_file_text_callback(
         &'_ mut self,
         cb: fn(&str, &str) -> bool,
-    ) -> Result<(), SetLogError<'_>> {
+    ) -> Result<(), SetCallbackError> {
         set_save_file_text_callback(cb)
     }
     /// Set custom file text data loader
@@ -540,7 +508,7 @@ impl RaylibHandle {
     pub fn set_load_file_text_callback(
         &'_ mut self,
         cb: fn(&str) -> String,
-    ) -> Result<(), SetLogError<'_>> {
+    ) -> Result<(), SetCallbackError> {
         set_load_file_text_callback(cb)
     }
 }

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -918,6 +918,9 @@ pub enum LoadTextureError {
 
 /// Top-level error type that aggregates all raylib-rs domain errors.
 ///
+/// Marked `#[non_exhaustive]`: new domain errors may gain variants here in minor releases,
+/// so matches must include a wildcard arm.
+///
 /// # Examples
 ///
 /// ```no_run
@@ -926,22 +929,17 @@ pub enum LoadTextureError {
 /// fn handle(e: RaylibError) {
 ///     match e {
 ///         RaylibError::AudioInit(_) => eprintln!("audio device failed to initialize"),
-///         RaylibError::ExportWave(_) => eprintln!("wave export failed"),
 ///         RaylibError::LoadSound(_) => eprintln!("sound load failed"),
-///         RaylibError::Allocation(_) => eprintln!("raylib allocator failed"),
-///         RaylibError::Compression(_) => eprintln!("data compression failed"),
 ///         RaylibError::LoadModel(_) => eprintln!("model load failed"),
-///         RaylibError::LoadModelAnim(_) => eprintln!("model animation load failed"),
-///         RaylibError::SetMaterial(_) => eprintln!("material assignment out of bounds"),
-///         RaylibError::LoadMaterial(_) => eprintln!("material load failed"),
 ///         RaylibError::LoadFont(_) => eprintln!("font load failed"),
-///         RaylibError::InvalidImage(_) => eprintln!("image was invalid"),
-///         RaylibError::UpdateTexture(_) => eprintln!("texture update failed"),
 ///         RaylibError::LoadTexture(_) => eprintln!("texture load failed"),
+///         RaylibError::SetCallback(_) => eprintln!("callback slot already occupied"),
+///         other => eprintln!("raylib error: {other}"),
 ///     }
 /// }
 /// ```
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum RaylibError {
     /// Wraps an [`AudioInitError`] surfaced through `?` from an audio init call site.
     ///
@@ -1052,6 +1050,73 @@ pub enum RaylibError {
     /// **Recovery:** Inspect the inner [`LoadTextureError`] variant and apply its recovery.
     #[error("texture loading error")]
     LoadTexture(#[from] LoadTextureError),
+    /// Wraps an [`UpdateAudioStreamError`] surfaced through `?` from an audio-stream update
+    /// or callback-install site.
+    ///
+    /// **Cause:** An `AudioStream::update` or `set_audio_stream_callback` call propagated up
+    /// an [`UpdateAudioStreamError`].
+    ///
+    /// **Recovery:** Inspect the inner [`UpdateAudioStreamError`] variant and apply its
+    /// recovery.
+    #[error("audio stream update error")]
+    UpdateAudioStream(#[from] UpdateAudioStreamError),
+    /// Wraps an [`InvalidMeshError`] surfaced through `?` from a mesh-validation site.
+    ///
+    /// **Cause:** A mesh accessor or builder validated a [`crate::ffi::Mesh`] and found its
+    /// buffers inconsistent.
+    ///
+    /// **Recovery:** Inspect the inner [`InvalidMeshError`] variant and apply its recovery.
+    #[error("invalid mesh error")]
+    InvalidMesh(#[from] InvalidMeshError),
+    /// Wraps a [`GenMeshError`] surfaced through `?` from a mesh-generation site.
+    ///
+    /// **Cause:** A `MeshBuilder::build` (or other mesh-generation) call propagated up a
+    /// [`GenMeshError`].
+    ///
+    /// **Recovery:** Inspect the inner [`GenMeshError`] variant and apply its recovery.
+    #[error("mesh generation error")]
+    GenMesh(#[from] GenMeshError),
+    /// Wraps a [`Base64Error`] surfaced through `?` from a base64 encode/decode site.
+    ///
+    /// **Cause:** An `encode_data_base64` or `decode_data_base64` call propagated up a
+    /// [`Base64Error`].
+    ///
+    /// **Recovery:** Inspect the inner [`Base64Error`] variant and apply its recovery.
+    #[error("base64 error")]
+    Base64(#[from] Base64Error),
+    /// Wraps a [`LoadIconsError`] surfaced through `?` from a raygui icons-load site.
+    ///
+    /// **Cause:** A `gui_load_icons`/`gui_load_icons_from_memory` call propagated up a
+    /// [`LoadIconsError`].
+    ///
+    /// **Recovery:** Inspect the inner [`LoadIconsError`] variant and apply its recovery.
+    #[error("icons loading error")]
+    LoadIcons(#[from] LoadIconsError),
+    /// Wraps a [`LoadStyleFromMemoryError`] surfaced through `?` from a raygui style-load site.
+    ///
+    /// **Cause:** A `gui_load_style_from_memory` call propagated up a
+    /// [`LoadStyleFromMemoryError`].
+    ///
+    /// **Recovery:** Inspect the inner [`LoadStyleFromMemoryError`] variant and apply its
+    /// recovery.
+    #[error("style loading error")]
+    LoadStyleFromMemory(#[from] LoadStyleFromMemoryError),
+    /// Wraps a [`crate::core::pixel::PixelColorError`] surfaced through `?` from a
+    /// pixel-level color read/write site.
+    ///
+    /// **Cause:** A `get_pixel_color`/`set_pixel_color` call propagated up a
+    /// [`crate::core::pixel::PixelColorError`].
+    ///
+    /// **Recovery:** Inspect the inner error variant and apply its recovery.
+    #[error("pixel color error")]
+    PixelColor(#[from] crate::core::pixel::PixelColorError),
+    /// Wraps a [`SetCallbackError`] surfaced through `?` from a callback-install site.
+    ///
+    /// **Cause:** A `set_*_callback` call found its global slot already occupied.
+    ///
+    /// **Recovery:** Keep a single registration site per callback kind.
+    #[error("callback registration error")]
+    SetCallback(#[from] SetCallbackError),
 }
 
 /// Errors that can occur while loading a raygui `.rgi` icons file.
@@ -1259,5 +1324,52 @@ mod set_callback_error_tests {
             e.to_string(),
             "there is a save file data callback already set"
         );
+    }
+}
+
+#[cfg(test)]
+mod raylib_error_from_tests {
+    use super::*;
+    use crate::consts::PixelFormat;
+    use crate::core::pixel::PixelColorError;
+
+    #[test]
+    fn all_new_leaf_errors_convert_via_from() {
+        assert!(matches!(
+            RaylibError::from(UpdateAudioStreamError::CallbackSlotBusy),
+            RaylibError::UpdateAudioStream(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(InvalidMeshError::TrianglePointMiscount),
+            RaylibError::InvalidMesh(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(GenMeshError::InvalidMesh(
+                InvalidMeshError::TrianglePointMiscount
+            )),
+            RaylibError::GenMesh(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(Base64Error::DecodeFailed),
+            RaylibError::Base64(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(LoadIconsError::HeaderTruncated(3)),
+            RaylibError::LoadIcons(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(LoadStyleFromMemoryError::LengthOverflow(5)),
+            RaylibError::LoadStyleFromMemory(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(PixelColorError::CompressedFormat(
+                PixelFormat::PIXELFORMAT_COMPRESSED_DXT1_RGB
+            )),
+            RaylibError::PixelColor(_)
+        ));
+        assert!(matches!(
+            RaylibError::from(SetCallbackError("trace log")),
+            RaylibError::SetCallback(_)
+        ));
     }
 }

--- a/raylib/src/core/error.rs
+++ b/raylib/src/core/error.rs
@@ -1164,6 +1164,42 @@ pub enum LoadStyleFromMemoryError {
     LengthOverflow(usize),
 }
 
+/// Error returned when installing a process-global callback whose slot is already occupied.
+///
+/// Each callback slot in [`crate::core::callbacks`] ([`set_save_file_data_callback`],
+/// [`set_load_file_data_callback`], [`set_save_file_text_callback`],
+/// [`set_load_file_text_callback`]) holds at most one function at a time. Calling a setter
+/// while its slot is occupied returns this error rather than silently overwriting. The inner
+/// `&'static str` names which callback kind was already set (e.g. `"save file data"`).
+///
+/// **Cause:** A previous call to the same setter installed a callback that has not been
+/// removed.
+///
+/// **Recovery:** Keep a single registration site per callback kind, or remove the existing
+/// callback (where an unset function exists) before installing a new one.
+///
+/// # Examples
+///
+/// ```no_run
+/// use raylib::prelude::*;
+/// use raylib::core::callbacks::set_save_file_data_callback;
+///
+/// fn writer(_path: &str, _bytes: &[u8]) -> bool { true }
+/// set_save_file_data_callback(writer).expect("first install");
+/// match set_save_file_data_callback(writer) {
+///     Err(e) => eprintln!("{e}"), // "there is a save file data callback already set"
+///     Ok(()) => unreachable!(),
+/// }
+/// ```
+///
+/// [`set_save_file_data_callback`]: crate::core::callbacks::set_save_file_data_callback
+/// [`set_load_file_data_callback`]: crate::core::callbacks::set_load_file_data_callback
+/// [`set_save_file_text_callback`]: crate::core::callbacks::set_save_file_text_callback
+/// [`set_load_file_text_callback`]: crate::core::callbacks::set_load_file_text_callback
+#[derive(Error, Debug)]
+#[error("there is a {0} callback already set")]
+pub struct SetCallbackError(pub(crate) &'static str);
+
 #[cfg(test)]
 mod load_icons_error_tests {
     use super::*;
@@ -1209,5 +1245,19 @@ mod load_icons_error_tests {
         let err: LoadIconsError = io_err.into();
         assert!(err.to_string().contains("denied"));
         assert!(matches!(err, LoadIconsError::Io(_)));
+    }
+}
+
+#[cfg(test)]
+mod set_callback_error_tests {
+    use super::*;
+
+    #[test]
+    fn display_names_the_occupied_slot() {
+        let e = SetCallbackError("save file data");
+        assert_eq!(
+            e.to_string(),
+            "there is a save file data callback already set"
+        );
     }
 }


### PR DESCRIPTION
## What

Finishes flexible-queue item 12 ("thiserror migration"). A crate-wide sweep found the migration was **~95% already done** — `core/error.rs` already holds ~19 documented thiserror enums and the review comment that spawned the item (on `audio_stream_callback.rs`) was stale. This PR completes the remainder:

- **`SetCallbackError` replaces `SetLogError`** — the last hand-rolled `impl Display`/`impl std::error::Error` in the safe crate becomes a thiserror struct in `core::error`, and the artificial lifetime parameter on the ~10 `set_*_callback` functions/methods disappears with it.
- **`RaylibError` aggregate completed** — 8 new `#[from]` variants (`UpdateAudioStream`, `InvalidMesh`, `GenMesh`, `Base64`, `LoadIcons`, `LoadStyleFromMemory`, `PixelColor`, `SetCallback`) so **every** leaf error now composes via `?`, plus `#[non_exhaustive]` so future leaf errors aren't semver-major.

## Breaking (pre-6.0.0-final, recorded in CHANGELOG)

- Public type `SetLogError<'a>` → `SetCallbackError` (no alias — the lifetime param made one awkward; we're pre-final).
- Exhaustive matches on `RaylibError` need a wildcard arm (new variants + `non_exhaustive`).

## Deliberate non-changes

- The two std-error returns in `core/window.rs` (`IntoStringError`, `Utf8Error`) stay as-is — precise std types for genuinely std failures; recorded in the spec.
- No renaming/restructuring of the existing 19 leaf enums.

## Verification

- `cargo nextest run -p raylib`: 77/77 (includes the new Display test + an 8-way `From` conversion test)
- `cargo test --doc -p raylib`: 144 passed (covers the new `SetCallbackError` doctest + the updated `RaylibError` example with its now-mandatory `_` arm)
- fmt + clippy `--all-targets -D warnings`: clean; `deny(missing_docs)` enforced docs on every new variant
- `grep` confirms zero manual `impl Display`/`impl Error` remain in `raylib/src`

Spec: `docs/superpowers/specs/2026-06-03-thiserror-migration-completion-design.md` · Plan: `docs/superpowers/plans/2026-06-03-thiserror-migration-completion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
