### PR TITLE
fix(ci): link wasm examples with -sFORCE_FILESYSTEM=1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  EMCC_CFLAGS: "-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1"
+  EMCC_CFLAGS: "-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1 -sFORCE_FILESYSTEM=1"
   # sccache + rust-cache interaction: disable incremental in CI to avoid
   # false misses caused by the rustc-wrapper showing up in incremental metadata.
   # TODO(re-enable): GHA artifact-cache outage 2026-06-02 — sccache disabled until cache recovers

--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
   # raylib-sys's emscripten target panics in build.rs without this. Matches
   # web.yml's pinned flag set.
-  EMCC_CFLAGS: "-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1"
+  EMCC_CFLAGS: "-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1 -sFORCE_FILESYSTEM=1"
   # Wave 4 closed every raylib core example as a Rust port. Escalate missing
   # pairs from warn-only to fatal so new C examples added upstream get
   # surfaced as a build break, not buried in the diagnostic noise.

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,7 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Required by raylib-sys/build.rs for the emscripten target (it panics without it).
-  EMCC_CFLAGS: "-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1"
+  EMCC_CFLAGS: "-O3 -sUSE_GLFW=3 -sASSERTIONS=1 -sWASM=1 -sASYNCIFY -sGL_ENABLE_GET_PROC_ADDRESS=1 -sFORCE_FILESYSTEM=1"
   # sccache + rust-cache interaction: disable incremental in CI to avoid
   # false misses caused by the rustc-wrapper showing up in incremental metadata.
   # TODO(re-enable): GHA artifact-cache outage 2026-06-02 — sccache disabled until cache recovers


### PR DESCRIPTION
## Summary

Hotfix for the deployed Pages site: every example page in a category with resources currently aborts at startup with

```
Aborted('FS_createPath' was not exported. add it to EXPORTED_RUNTIME_METHODS …
Alternatively, forcing filesystem support (-sFORCE_FILESYSTEM) can export this for you)
```

Root cause: #311's per-category resource bundles run emscripten's `file_packager` **separately from the link**, so emcc doesn't know the build stages files from JS and strips the `Module`-level `FS_*` runtime exports from the main loader. The injected `<cat>_res.js` then trips the ASSERTIONS getter-trap at `preRun`. (When emcc runs `--preload-file` itself it adds these exports implicitly — packaging post-hoc requires `-sFORCE_FILESYSTEM=1`, exactly as the abort message prescribes.)

One-line change to the shared `EMCC_CFLAGS` pin, applied to all three workflows that the comments require to stay matched (`pages.yml`, `showcase.yml`, `web.yml`).

A Playwright smoke gate (load sample example pages, fail the pages workflow on console aborts before deploy) follows in a separate PR — kept out of this one so an unproven gate can't block the deploy that unbreaks the site.

## Test Plan

- [x] Flag matches the remedy named by the abort + emscripten's documented requirement for standalone file_packager use
- [ ] CI: showcase wasm shards + web build green with the new flag
- [ ] Post-merge pages deploy: `core_2d_camera_platformer` (reported), `shaders_eratosthenes_sieve`, `shaders_ascii_rendering`, and a textures example boot without console aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)