### PR TITLE
refactor(sys)!: remove identity From<&Color> impl (queue item 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Upgrade from raylib 5.x to **raylib 6.0**. MSRV bumped to **1.85** (edition 2024
 - `RaylibGuiIcons::gui_load_icons_raw` removed; use `gui_load_icons` / `gui_load_icons_with_names`.
 - `SetLogError` (core/callbacks) is replaced by `SetCallbackError` in `core::error` — a `thiserror` struct without the artificial lifetime parameter. The ~10 `set_*_callback` functions/methods now return `Result<(), SetCallbackError>`.
 - `RaylibError` is now `#[non_exhaustive]` and gained `#[from]` variants for `UpdateAudioStreamError`, `InvalidMeshError`, `GenMeshError`, `Base64Error`, `LoadIconsError`, `LoadStyleFromMemoryError`, `PixelColorError`, and `SetCallbackError` — every leaf error now composes via `?`. Exhaustive matches on `RaylibError` need a wildcard arm.
+- The identity `impl From<&Color> for Color` is removed — `&Color` no longer satisfies `Into<Color>` bounds (e.g. on draw functions). Dereference instead: `d.draw_x(.., *c)`. `Color` is `Copy`; no other type had such an impl.
 
 ### Added
 

--- a/docs/superpowers/plans/2026-06-03-color-ref-from-removal.md
+++ b/docs/superpowers/plans/2026-06-03-color-ref-from-removal.md
@@ -1,0 +1,136 @@
+# Color `From<&Color>` Removal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the identity `impl From<&Color> for Color` and replace its 13 internal ceremony callsites with `*` derefs.
+
+**Architecture:** Pure removal in `raylib-sys/src/color.rs`: the impl goes away, and every `<&Color>.into()` in the same file becomes `*<ref>` (`Color` is `Copy`). The compile gate IS the test: `cargo check --workspace --all-targets` enumerated every consumer during the audit, so green proves completeness. One CHANGELOG breaking entry.
+
+**Tech Stack:** Rust 1.85, cargo-nextest.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md`
+**Branch:** `chore/remove-color-ref-from` (already created off `origin/unstable`)
+
+---
+
+## Task 1: Remove the impl + deref the callsites
+
+**Files:**
+- Modify: `raylib-sys/src/color.rs:56-65` (delete impl) and lines 97, 103, 109, 133, 138, 143, 148, 154, 160, 165, 171 (deref replacements)
+
+- [ ] **Step 1: Delete the impl (lines 56–65)**
+
+Remove exactly:
+
+```rust
+impl From<&Color> for Color {
+    fn from(v: &Color) -> Self {
+        Color {
+            r: v.r,
+            g: v.g,
+            b: v.b,
+            a: v.a,
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Replace the 13 ceremony conversions**
+
+| Line | Before | After |
+|---|---|---|
+| 97 | `super::ColorToInt(self.into())` | `super::ColorToInt(*self)` |
+| 103 | `super::ColorNormalize(self.into())` | `super::ColorNormalize(*self)` |
+| 109 | `super::ColorToHSV(self.into())` | `super::ColorToHSV(*self)` |
+| 133 | `super::ColorTint(self.into(), color)` | `super::ColorTint(*self, color)` |
+| 138 | `super::ColorBrightness(self.into(), factor)` | `super::ColorBrightness(*self, factor)` |
+| 143 | `super::ColorContrast(self.into(), factor)` | `super::ColorContrast(*self, factor)` |
+| 148 | `super::ColorAlpha(self.into(), alpha)` | `super::ColorAlpha(*self, alpha)` |
+| 154 | `super::Fade(self.into(), alpha)` | `super::Fade(*self, alpha)` |
+| 160 | `super::ColorAlphaBlend(dst.into(), src.into(), tint.into())` | `super::ColorAlphaBlend(*dst, *src, *tint)` |
+| 165 | `super::ColorIsEqual(self.into(), rhs.into())` | `super::ColorIsEqual(*self, rhs.into())` |
+| 171 | `super::ColorLerp(self.into(), rhs, factor)` | `super::ColorLerp(*self, rhs, factor)` |
+
+**Caution (line 165):** `rhs: impl Into<super::Color>` — `rhs.into()` is a genuine generic
+conversion and MUST stay. Only `self.into()` changes.
+
+- [ ] **Step 3: Verify with the audit's gate command**
+
+```bash
+cargo check --workspace --all-targets
+grep -rn "From<&" raylib-sys/src raylib/src
+```
+Expected: check green (this exact command enumerated every consumer during the audit);
+grep empty.
+
+- [ ] **Step 4: Run the conversion/unit tests**
+
+```bash
+cargo nextest run -p raylib-sys
+cargo nextest run -p raylib
+```
+Expected: all green (no test exercised the removed impl).
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt --all
+git add raylib-sys/src/color.rs
+git commit -m "refactor(sys)!: remove identity From<&Color> impl
+
+Color is Copy; the impl's only consumers were 13 self.into() ceremony
+calls in its own file, now spelled *self. BREAKING (pre-6.0.0-final):
+&Color no longer satisfies Into<Color> bounds - deref instead.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (`### Breaking` list in the `## 6.0.0-rc.2` block)
+
+- [ ] **Step 1: Append the entry**
+
+```markdown
+- The identity `impl From<&Color> for Color` is removed — `&Color` no longer satisfies `Into<Color>` bounds (e.g. on draw functions). Dereference instead: `d.draw_x(.., *c)`. `Color` is `Copy`; no other type had such an impl.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): record From<&Color> removal
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Gates + PR
+
+- [ ] **Step 1: Quality gates**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p raylib-sys -p raylib --all-targets -- -D warnings
+```
+Expected: clean.
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin chore/remove-color-ref-from
+gh pr create --base unstable --repo raylib-rs/raylib-rs \
+  --title "refactor(sys)!: remove identity From<&Color> impl (queue item 14)" \
+  --body "<audit findings (14 consumers, all internal ceremony; zero external/showcase/book usage), the removal + *deref migration, the CHANGELOG breaking entry, spec link. Claude Code attribution.>"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: impl deletion (T1S1), 13 derefs incl. the line-165 caution (T1S2), audit-gate verification + grep (T1S3), tests (T1S4), CHANGELOG (T2), gates+PR (T3). Non-goals respected (other From impls untouched). ✓
+- The audit counted "14 errors" across `--all-targets` (lib + test unit double-reporting one span); the textual change list is 13 `.into()` removals on 11 lines — the compile gate, not the count, is the source of truth. ✓

--- a/docs/superpowers/plans/2026-06-03-color-ref-from-removal.md
+++ b/docs/superpowers/plans/2026-06-03-color-ref-from-removal.md
@@ -133,4 +133,4 @@ gh pr create --base unstable --repo raylib-rs/raylib-rs \
 ## Self-review notes
 
 - Spec coverage: impl deletion (T1S1), 13 derefs incl. the line-165 caution (T1S2), audit-gate verification + grep (T1S3), tests (T1S4), CHANGELOG (T2), gates+PR (T3). Non-goals respected (other From impls untouched). ✓
-- The audit counted "14 errors" across `--all-targets` (lib + test unit double-reporting one span); the textual change list is 13 `.into()` removals on 11 lines — the compile gate, not the count, is the source of truth. ✓
+- The audit counted 14 errors; the textual `.into()` list covers 13. The 14th consumer (found during execution) is `impl PartialEq for Color` — `self.is_equal(other)` passes `other: &Self` through the `impl Into<Color>` bound with no textual `.into()`. Fixed as `self.is_equal(*other)`. The compile gate, not the textual count, is the source of truth — and it caught exactly this. ✓

--- a/docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md
+++ b/docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md
@@ -10,8 +10,15 @@
 The ws8e note asked for an audit of `Into<Color>` callsites and "analogous `From<&T>` impls
 on Vector2/3/4, Rectangle, etc." Findings:
 
-1. **No analogous impls exist.** `impl From<&Color> for Color` (`raylib-sys/src/color.rs:56-65`)
-   is the only `From<&T>` identity impl in the workspace. The audit target is this one impl.
+1. **No analogous identity impls exist.** `impl From<&Color> for Color`
+   (`raylib-sys/src/color.rs:56-65`) is the only `From<&T> for T` *identity* impl in the
+   workspace. The audit target is this one impl.
+   (The safe crate does carry ten **cross-type** borrowing converters —
+   `From<&Camera2D> for ffi::Camera2D`, `From<&Ray> for ffi::Ray`, etc. in
+   `core/{camera,math,texture,vr}.rs` — each one of a `From<ffi::T>`/`From<T>`/`From<&T>`
+   trio serving `impl Into<ffi::T>` bounds at FFI callsites. These are genuine conversions
+   between distinct types, not identity ceremony; they are out of scope here and recorded
+   as an observation for any future conversion-surface audit.)
 2. **Compile experiment** (impl disabled via `#[cfg(any())]`, then
    `cargo check --workspace --all-targets`): exactly **14 errors, all in
    `raylib-sys/src/color.rs` itself** — `self.into()` / `dst.into()`-style calls inside
@@ -53,5 +60,7 @@ remove it. There is no soundness/perf issue — this is API hygiene before the s
 - `cargo nextest run -p raylib-sys` and `cargo nextest run -p raylib` green (existing
   conversion/unit tests).
 - fmt + clippy `-D warnings` clean.
-- `grep -rn "From<&" raylib-sys/src raylib/src` returns nothing.
+- `grep -rn "From<&" raylib-sys/src` returns nothing (no identity `From<&T> for T` impls
+  remain; the safe crate's cross-type `From<&T> for ffi::T` trio-impls are out of scope —
+  see Audit findings #1).
 - CHANGELOG entry present. One PR to canonical `unstable`.

--- a/docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md
+++ b/docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md
@@ -1,0 +1,57 @@
+# Color `From<&Color>` removal — design
+
+**Date:** 2026-06-03
+**Branch:** `chore/remove-color-ref-from` (off canonical `unstable`)
+**Status:** approved, pre-implementation
+**Origin:** flexible-queue item 14 (`ws8e-checkpoint-review-feedback.md` §5 — owner: "This probably isn't necessary if we implement clone on Color")
+
+## Audit findings (the evidence)
+
+The ws8e note asked for an audit of `Into<Color>` callsites and "analogous `From<&T>` impls
+on Vector2/3/4, Rectangle, etc." Findings:
+
+1. **No analogous impls exist.** `impl From<&Color> for Color` (`raylib-sys/src/color.rs:56-65`)
+   is the only `From<&T>` identity impl in the workspace. The audit target is this one impl.
+2. **Compile experiment** (impl disabled via `#[cfg(any())]`, then
+   `cargo check --workspace --all-targets`): exactly **14 errors, all in
+   `raylib-sys/src/color.rs` itself** — `self.into()` / `dst.into()`-style calls inside
+   `&self`/`&Color`-parameter methods (`color_to_int`, `color_normalize`, `color_to_hsv`,
+   `tint`, `brightness`, `contrast`, `alpha`, `color_alpha_blend`, …). Each is an identity
+   copy dressed as a conversion; the idiomatic spelling is `*self` / `*dst` (`Color` is `Copy`).
+3. **Zero usage anywhere else**: safe crate (133 `impl Into<Color>` bounds across 5 files —
+   none called with `&Color`), tests, all 229 showcase examples, the mdBook. No test
+   exercises the impl.
+
+## Decision
+
+**Remove the impl** (owner-confirmed). Rationale: it is an accidental, inconsistent semver
+commitment (no other type promises `&T: Into<T>`), its only consumers are 14 self-inflicted
+ceremony calls in its own file, and the pre-6.0.0-final window is the only cheap time to
+remove it. There is no soundness/perf issue — this is API hygiene before the surface freezes.
+
+## Changes
+
+1. `raylib-sys/src/color.rs`:
+   - Delete `impl From<&Color> for Color` (lines 56–65).
+   - Replace the 14 `<ref>.into()` calls with `*<ref>` (e.g. `super::ColorToInt(*self)`,
+     `super::ColorAlphaBlend(*dst, *src, *tint)`). No other behavior change.
+2. `CHANGELOG.md` — `### Breaking` section of the `6.0.0-rc.2` block (which ships as 6.0.0
+   final): `&Color` no longer satisfies `Into<Color>` bounds (the identity
+   `impl From<&Color> for Color` is removed); callers passing `&Color` to draw functions
+   dereference instead (`*c`).
+
+## Non-goals
+
+- No changes to the other `Color` conversions (`From<Color> for Vector4`,
+  `From<(u8,u8,u8,u8)>`) — they are genuine conversions, not identity ceremony.
+- No new `From<&T>` policy doc; the absence of such impls is now consistent.
+
+## Verification (definition of done)
+
+- `cargo check --workspace --all-targets` green — this exact command enumerated all 14
+  consumers during the audit, so green proves the migration is complete.
+- `cargo nextest run -p raylib-sys` and `cargo nextest run -p raylib` green (existing
+  conversion/unit tests).
+- fmt + clippy `-D warnings` clean.
+- `grep -rn "From<&" raylib-sys/src raylib/src` returns nothing.
+- CHANGELOG entry present. One PR to canonical `unstable`.

--- a/raylib-sys/src/color.rs
+++ b/raylib-sys/src/color.rs
@@ -53,17 +53,6 @@ impl From<Color> for Vector4 {
     }
 }
 
-impl From<&Color> for Color {
-    fn from(v: &Color) -> Self {
-        Color {
-            r: v.r,
-            g: v.g,
-            b: v.b,
-            a: v.a,
-        }
-    }
-}
-
 impl From<(u8, u8, u8, u8)> for Color {
     fn from(col: (u8, u8, u8, u8)) -> Color {
         Color::new(col.0, col.1, col.2, col.3)
@@ -94,19 +83,19 @@ impl Color {
     /// Get hexadecimal value for a Color (0xRRGGBBAA)
     #[inline]
     pub fn color_to_int(&self) -> i32 {
-        unsafe { super::ColorToInt(self.into()) }
+        unsafe { super::ColorToInt(*self) }
     }
 
     /// Get Color normalized as float [0..1]
     #[inline]
     pub fn color_normalize(&self) -> Vector4 {
-        unsafe { super::ColorNormalize(self.into()) }
+        unsafe { super::ColorNormalize(*self) }
     }
 
     /// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
     #[inline]
     pub fn color_to_hsv(&self) -> Vector3 {
-        unsafe { super::ColorToHSV(self.into()) }
+        unsafe { super::ColorToHSV(*self) }
     }
 
     /// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
@@ -130,45 +119,45 @@ impl Color {
     /// Get color multiplied with another color
     #[inline]
     pub fn tint(&self, color: Self) -> Self {
-        unsafe { super::ColorTint(self.into(), color) }
+        unsafe { super::ColorTint(*self, color) }
     }
     /// Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
     #[inline]
     pub fn brightness(&self, factor: f32) -> Self {
-        unsafe { super::ColorBrightness(self.into(), factor) }
+        unsafe { super::ColorBrightness(*self, factor) }
     }
     /// Get color with contrast correction, contrast values between -1.0f and 1.0f
     #[inline]
     pub fn contrast(&self, factor: f32) -> Self {
-        unsafe { super::ColorContrast(self.into(), factor) }
+        unsafe { super::ColorContrast(*self, factor) }
     }
     /// Get color with alpha applied, alpha goes from 0.0f to 1.0f
     #[inline]
     pub fn alpha(&self, alpha: f32) -> Self {
-        unsafe { super::ColorAlpha(self.into(), alpha) }
+        unsafe { super::ColorAlpha(*self, alpha) }
     }
 
     /// Get color with alpha applied, alpha goes from 0.0f to 1.0f
     #[deprecated = "Use Color::alpha instead"]
     pub fn fade(&self, alpha: f32) -> Self {
-        unsafe { super::Fade(self.into(), alpha) }
+        unsafe { super::Fade(*self, alpha) }
     }
 
     /// Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
     #[inline]
     pub fn color_alpha_blend(dst: &Color, src: &Color, tint: &Color) -> Color {
-        unsafe { super::ColorAlphaBlend(dst.into(), src.into(), tint.into()) }
+        unsafe { super::ColorAlphaBlend(*dst, *src, *tint) }
     }
     /// Check if two colors are equal
     #[inline]
     pub fn is_equal(&self, rhs: impl Into<super::Color>) -> bool {
-        unsafe { super::ColorIsEqual(self.into(), rhs.into()) }
+        unsafe { super::ColorIsEqual(*self, rhs.into()) }
     }
 
     /// Get color lerp interpolation between two colors, factor [0.0f..1.0f]
     #[inline]
     pub fn lerp(&self, rhs: Color, factor: f32) -> Color {
-        unsafe { super::ColorLerp(self.into(), rhs, factor) }
+        unsafe { super::ColorLerp(*self, rhs, factor) }
     }
 }
 
@@ -176,7 +165,7 @@ impl Color {
 /// change or do anything different, but in the ultra rare case that it does, we want to mimic Raylib's behavior.
 impl PartialEq for Color {
     fn eq(&self, other: &Self) -> bool {
-        self.is_equal(other)
+        self.is_equal(*other)
     }
 }
 impl Eq for Color {}


### PR DESCRIPTION
## What

Closes flexible-queue item 14 (Color/Vector conversion ergonomics audit, ws8e review comment 5: "This probably isn't necessary if we implement clone on Color").

Removes the identity `impl From<&Color> for Color` from `raylib-sys` and replaces its internal consumers with plain `*` derefs (`Color` is `Copy`).

## Audit findings (what made the call easy)

- It was the **only** `From<&T> for T` identity impl in the workspace. (The safe crate's `From<&Camera2D> for ffi::Camera2D`-style impls are *cross-type* borrowing converters — a different, genuine pattern; documented as out of scope in the spec.)
- Compile experiment (impl disabled + `cargo check --workspace --all-targets`): **all 14 consumers were in `color.rs` itself** — 13 `self.into()`/`dst.into()` ceremony calls plus `PartialEq::eq` passing `&Self` through the `is_equal` `Into<Color>` bound.
- Zero usage in the safe crate's 133 `Into<Color>` bounds' callsites, the 229 showcase examples, tests, or the book.

## Breaking (pre-6.0.0-final, in CHANGELOG)

`&Color` no longer satisfies `Into<Color>` bounds (e.g. draw functions). Downstream fix is a deref: `d.draw_x(.., *c)`.

## Verification

- `cargo check --workspace --all-targets` green — this exact command enumerated every consumer during the audit, so green proves the migration is complete.
- nextest: raylib-sys 77/77, raylib 75/75; fmt + clippy `--all-targets -D warnings` clean.
- `grep "From<&" raylib-sys/src` → empty.

Spec: `docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md` · Plan: `docs/superpowers/plans/2026-06-03-color-ref-from-removal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
