### PR TITLE
feat(showcase): add C/Rust source links to per-example pages

### DIFF
--- a/showcase/index/example_shell.html
+++ b/showcase/index/example_shell.html
@@ -9,6 +9,7 @@
   <nav><a href="../../index.html">&larr; back to showcase</a></nav>
   <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
   <p class="hint">F1 inside the canvas: view source side-by-side.</p>
+  <p class="hint">Source on GitHub: <a href="{{{ C_URL }}}">C</a> &middot; <a href="{{{ RUST_URL }}}">Rust</a></p>
   <script>
     var Module = {
       canvas: (function() { return document.getElementById('canvas'); })(),

--- a/showcase/src/bin/xtask_build_pages.rs
+++ b/showcase/src/bin/xtask_build_pages.rs
@@ -221,6 +221,8 @@ fn main() {
             };
             let html = shell_template
                 .replace("{{{ EXAMPLE_NAME }}}", &m.name)
+                .replace("{{{ C_URL }}}", &m.c_url)
+                .replace("{{{ RUST_URL }}}", &m.rust_url)
                 .replace("{{{ SCRIPT }}}", &script_tag);
             fs::write(out_dir.join(format!("{}.html", m.name)), html).unwrap();
         } else {


### PR DESCRIPTION
## Problem

Follow-up to #316. The synthesized per-example pages (`examples/<cat>/<name>.html`) had no visible source access outside the in-canvas F1 overlay — only the gallery index tiles carried the C/Rust GitHub deep-links. If the overlay is unavailable (touch devices, wasm load failure), the page offered no path to the source at all. The desktop-only and unbuilt-wasm placeholder pages already had equivalent links.

## Change

- `showcase/index/example_shell.html`: add a muted `Source on GitHub: C · Rust` line (reusing the existing `.hint` styling) under the F1 hint, with `{{{ C_URL }}}` / `{{{ RUST_URL }}}` placeholders.
- `showcase/src/bin/xtask_build_pages.rs`: substitute both placeholders when synthesizing each page — the `c_url`/`rust_url` values are already deserialized from `examples_meta.json` (baked by `build.rs` from the submodule remotes + pinned SHAs).

The shell template is also passed to emcc as `--shell-file` during wasm builds, but emcc never enters HTML-emit mode there (documented in `xtask_build_pages.rs`), so `xtask_build_pages` remains the only consumer that renders it.

## Verification

- Faked one wasm artifact (`core_basic_window.js`) and ran `cargo run -p raylib-showcase --bin xtask-build-pages`: the synthesized page carries the correct pinned-SHA C and Rust URLs, and `Select-String '\{\{\{'` finds **zero** unsubstituted placeholders across all 229 generated pages.
- `cargo clippy -p raylib-showcase --lib --tests --bins -- -D warnings` clean; `cargo fmt --all` applied.
- Goes live with the next `pages.yml` deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
