### PR TITLE
chore: bump bindgen to 0.72.1

### DIFF
--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 [build-dependencies]
 cmake = "0.1.51"
 cc = { version = "1.0", features = ["parallel"] }
-bindgen = "0.71"
+bindgen = "0.72.1"
 
 [features]
 # default features follow the cmake version: https://github.com/raysan5/raylib/wiki/CMake-Build-Options


### PR DESCRIPTION
Version `6.0.0-rc.2` bumped `bindgen` to `0.71`, but it seems that tag has a bug that trips when using newish Clang compilers while generating the bindings.

The bug was fixed in `0.72.1`.

References:

- https://github.com/rust-lang/rust-bindgen/issues/3264
- https://github.com/rust-lang/rust-bindgen/releases/tag/v0.72.1
- https://github.com/platformed-com/rust-xmlsec/commit/07a8e87dd1cee68f60deb40664b84da9a7f60cf3

Hoping to fix my broken CI for `mingw-w64` when building with `v6.0.0-rc.2`:

- https://github.com/JGGR/F-value/pull/24