### PR TITLE
chore: opaque type __mingw_ldbl_type_t

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -324,6 +324,7 @@ fn gen_bindings() {
         .blocklist_type("Quaternion")
         .blocklist_type("Rectangle")
         .blocklist_type("Color")
+        .opaque_type("__mingw_ldbl_type_t")
         .parse_callbacks(Box::new(TypeOverrideCallback))
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.


### PR DESCRIPTION
Fixes my `mingw-w64` CI when building with `v6.0.0-rc.2` as mentioned in #321 by applying [`opaque_type`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.opaque_type) to `__mingw_ldbl_type_t`.

In current `unstable`, the generated bindings for `mingw-w64` end up having this:

```rust
#[repr(C)]
#[repr(align(8))]
#[derive(Copy, Clone)]
pub union __mingw_ldbl_type_t {
    pub x: u128,
    pub lh: __mingw_ldbl_type_t__bindgen_ty_1,
}
```

But
```rust
std::mem::align_of::<u128>() = 16
```

The underlying C definition in `mingw-w64` headers is:
```c
  typedef union __mingw_ldbl_type_t
  {
    long double x;
    __C89_NAMELESS struct {
      unsigned int low, high;
      int sign_exponent : 16;
      int res1 : 16;
      int res0 : 32;
    } lh;
  } __mingw_ldbl_type_t;
```

Here's a `bindgen` issue naming this exact problem:
- https://github.com/rust-lang/rust-bindgen/issues/2159

This one could be related:
- https://github.com/rust-lang/rust-bindgen/issues/1549

I would love to mention some `mingw-w64` reference about a breaking change somewhere but this specific bit of code seems to have a git blame of 14 years ago on [here](https://github.com/mingw-w64/mingw-w64/blame/b536c4fdb038a9c59a7e5fb36e7d1293c4dc61d6/mingw-w64-headers/crt/math.h#L130).

From this issue, it seems `GCC` was to blame for using to have a wrong ABI for `long double`, *BUT* it's for `aarch64`, while I'm testing `x86_64`:
- https://github.com/mingw-w64/mingw-w64/issues/120#issuecomment-3289795189

Since that issue comment (dated September '25) mentions that `GCC` was moving towards changing its `long double` ABI, I tried looking in [here](https://inbox.sourceware.org/gcc-patches/?q=LONG_DOUBLE_TYPE_SIZE) and [here](https://inbox.sourceware.org/gcc-patches/?q=TARGET_LONG_DOUBLE_64) since I would love to reference the `GCC` commit that led to this, but I haven't pinpointed it yet.

I am really not sure about this, but I think [`opaque_type`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.opaque_type) could be preferred to [`blocklist_type`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.blocklist_type).

The preference for `opaque_type` comes from the fact the generated bindings with this PR contain:

```rust
#[repr(C)]
#[repr(align(8))]
#[derive(Copy, Clone)]
pub union __mingw_ldbl_type_t {
    pub _bindgen_opaque_blob: [u64; 2usize],
}
```

While if we use `blocklist_type`, the generated bindings do NOT contain a definition for `__mingw_ldbl_type_t` at all, which could lead to stuff I don't really know enough about.

A small portion of what GPT spewed when asked about blocklist usage:

```clanker
Blocking __mingw_ldbl_type_t in bindgen is a pragmatic workaround, but it comes with some subtle (and some not-so-subtle) tradeoffs.

That type exists in MinGW headers to describe how long double is physically represented on a given ABI (typically an 80-bit extended precision format packed into 96 or 128 bits depending on alignment).
It’s used by libc / math headers to reason about floating-point layout, not just abstract arithmetic.

When you blocklist it, you’re essentially telling bindgen: “pretend this type doesn’t exist anywhere in the C API I’m binding.”
[...]
3. Hidden dependency breakage

Even if your crate compiles now, future updates to headers might introduce:
- inline functions that access lh.low/high
- macros that depend on the union layout
- structs embedding __mingw_ldbl_type_t

Once that happens, bindgen will either:
- fail again elsewhere
- or silently degrade bindings

4. Loss of type fidelity in generated bindings

Bindgen uses such types to decide:
- size/alignment of long double
- whether to expose it as a distinct ABI type or alias

By removing it, you may lose:
- correct repr(C) compatibility guarantees
- accurate #[repr(C)] struct layout involving floating fields
```

It sounds happier with `opaque_type`. I detailed the pragmatic reason before:
> While if we use `blocklist_type`, the generated bindings do NOT contain a definition for `__mingw_ldbl_type_t` at all, which could lead to stuff I don't really know enough about.

Also see (or not, it's just the same info in there):

- #323 