### PR TITLE
feat(sys): make raylib-sys unconditionally #![no_std]

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -122,3 +122,44 @@ jobs:
           shared-key: check-msrv
       - name: Build on MSRV
         run: cargo +1.85.0 build -p raylib -p raylib-sys --features full
+
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check-no-std
+      # rust-toolchain.toml installs the thumb target automatically; this is a
+      # cheap idempotent belt-and-suspenders for runners with a preinstalled
+      # toolchain.
+      - name: Add no-std target
+        run: rustup target add thumbv7em-none-eabihf
+      # Step 1 of the proof: bindgen runs on the host (build scripts always
+      # have std); `nobuild` skips the C compile entirely. The build-script
+      # JSON message pinpoints the exact out_dir — newest-file heuristics can
+      # pick up bindings from other feature sets.
+      - name: Generate binding on host and locate it (bindgen only, no C build)
+        run: |
+          out_dir=$(cargo check -p raylib-sys --features nobuild --message-format=json \
+            | jq -r 'select(.reason == "build-script-executed" and (.package_id | tostring | contains("raylib-sys"))) | .out_dir' \
+            | tail -n1)
+          test -f "$out_dir/bindings.rs"
+          # nobuild bindings are generated without bindgen layout asserts
+          # (host pointer widths would break the cross-target compile check).
+          if grep -q 'Size of' "$out_dir/bindings.rs"; then
+            echo "::error::selected binding still contains layout asserts - wrong artifact"
+            exit 1
+          fi
+          echo "RAYLIB_BINDGEN_LOCATION=$out_dir/bindings.rs" >> "$GITHUB_ENV"
+      # Step 2: a real no-std target proves the crate graph builds without
+      # std. The binding is host-flavored — fine for a compile-only proof; it
+      # never runs.
+      - name: Check raylib-sys on a no-std target
+        run: cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+      # mint is documented as no-std-compatible — keep that claim honest.
+      - name: Check raylib-sys + mint on a no-std target
+        run: cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen,mint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@
   `"raylib"`), making `RUST_LOG`-style filtering the single source of
   truth. Levels map `TRACE/DEBUG/INFO/WARNING→trace/debug/info/warn`,
   `ERROR`+`FATAL→error`. See the *Callbacks and logging* book chapter.
+- `raylib-sys` is now unconditionally `#![no_std]` (adopts community PR
+  [#251](https://github.com/raylib-rs/raylib-rs/pull/251) by @nbe1233,
+  adapted for 6.0). Zero feature changes — std consumers and
+  `default-features = false` users are unaffected. The crate now builds for
+  no-std targets (CI-checked against `thumbv7em-none-eabihf` via the
+  `nobuild`/`nobindgen` escape hatches; the `mint` adapter feature is included
+  in that check). `glam`/`serde` currently require a std-capable target.
+  `nobuild` bindings are generated without bindgen layout assertions so they
+  can be compile-checked cross-target; hosted default builds keep them.
+
+### Fixed
+
+- `nobindgen` now actually skips running bindgen in `build.rs` (previously it
+  only ignored the output), and `nobuild` bindgen finds the vendored raylib
+  headers again (`-I../raylib/src` resolved outside the package — broken on
+  any host without a system-wide raylib, likely including docs.rs).
 
 ## 6.0.0-rc.2 — 2026-06-02
 

--- a/docs/superpowers/notes/raylib-sys-no-std-complete.md
+++ b/docs/superpowers/notes/raylib-sys-no-std-complete.md
@@ -1,0 +1,79 @@
+# raylib-sys no_std — done-note (queue item 18)
+
+**Date:** 2026-06-06 · **Spec:** `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md`
+**Adopts:** PR #251 (nbe1233), with attribution on the adopting commit.
+
+## std-usage census
+
+| Location | Before | After |
+|---|---|---|
+| generated `bindings.rs` (nobuild) | 1359 `::std::` lines | 0 (`.use_core()`; 1341 `::core::` lines — fewer lines, same tokens: shorter paths wrap less) |
+| `src/vector_math.rs` | 27 (`std::ops`) | 0 |
+| `src/matrix_quat_math.rs` | 16 (`std::ops`) | 0 |
+| `src/color.rs` | 1 (`ParseIntError`) | 0 |
+| `build.rs` / `tests/` | host-side, unchanged | host-side, unchanged |
+
+Regen diff verified: after normalizing `::core::ffi::` → `::std::os::raw::`
+and `::core::` → `::std::`, the use_core binding differs from the before
+binding only in line wrapping and trailing commas (token-identical after
+whitespace + trailing-comma normalization) — `.use_core()` under bindgen
+0.72.1 changes nothing but path prefixes.
+
+## Feature topology decision
+
+Unconditional `#![no_std]`, zero feature changes (spec Decision 1). No `std`
+feature (it would gate nothing), no `default` split. The compiler itself now
+polices `std::` paths in every build — stronger than any lint.
+
+## Proof leg (verbatim)
+
+CI (`check.yml` job `no-std`): host-generate via
+`cargo check -p raylib-sys --features nobuild` with the out_dir taken from
+cargo's `build-script-executed` JSON message (newest-file heuristics proved
+unreliable — other feature sets leave newer bindings.rs files with layout
+asserts), then with `RAYLIB_BINDGEN_LOCATION` exported:
+
+    cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+
+plus a `…,mint` variant (proves the mint adapter no-std-clean). Verified
+able-to-fail (std canary → E0433). `thumbv7em-none-eabihf` added to
+`rust-toolchain.toml` targets.
+
+## Contingency hit: bindgen layout asserts
+
+The first thumb check failed not on std paths but on bindgen's layout
+assertions (host 64-bit sizes vs 32-bit ARM: `size_of::<Image>() - 24`
+underflows). The spec's `--target`-passthrough fallback would need newlib
+headers on every generating host, so `nobuild` bindings are generated with
+`.layout_tests(false)` instead — the proof leg is a compile-only no-std
+check, not an ARM ABI claim. Hosted default builds keep layout tests, and
+`tests/layout_compat.rs` still covers layout on real targets.
+
+## Optional-dep disposition
+
+- `mint`: no-std-clean, proven in CI.
+- `glam`/`serde`: current dep shapes pull std — fine on hosted targets,
+  won't build on no-std targets. Documented in crate docs + CHANGELOG.
+
+## Fixed in passing
+
+- `nobindgen` now actually skips bindgen in build.rs (it previously ran
+  bindgen and discarded the output).
+- `nobuild` bindgen could not find `raylib.h`: `-I../raylib/src` resolved
+  (relative to the build-script CWD = package root) to the safe crate's Rust
+  source dir. Fixed to `-Iraylib/src` (the vendored submodule). The default
+  `binding.h` path never noticed because its quoted `../raylib/src/` includes
+  resolve file-relative. Likely also fixes docs.rs builds
+  (`features = ["nobuild"]`).
+- Stale `cargo:rerun-if-changed=/usr/include/raylib.h` under `nobuild`
+  (missing file = build-script rerun every build) now points at
+  `binding/nobuild.h`.
+
+## Future work seeded
+
+- Relax `glam`/`serde` to `default-features = false` shapes for no-std use.
+- Reference/committed binding for the nobuild-CI-matrix (queue item 13) — any
+  pregenerated binding must come from the use_core output.
+- MSRV pressure datapoint for the queued MSRV-bump workstream: a fresh
+  worktree lock resolved `wasip2 v1.0.3` (requires Rust 1.87) as a
+  target-gated transitive dep on 2026-06-06.

--- a/docs/superpowers/plans/2026-06-06-raylib-sys-no-std.md
+++ b/docs/superpowers/plans/2026-06-06-raylib-sys-no-std.md
@@ -1,0 +1,620 @@
+# raylib-sys no_std Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `raylib-sys` unconditionally `#![no_std]`, proven by a CI check against `thumbv7em-none-eabihf` (adopts community PR #251 by nbe1233, adapted for 6.0).
+
+**Architecture:** Plain `#![no_std]` on the crate — zero feature/Cargo.toml changes (approved Decision 1). All 44 source `std::` refs are mechanical `core::` swaps; the ~1,495 `::std::` paths in the generated binding are erased by bindgen `.use_core()`. Proof leg (approved Decision 2): generate the binding on the host with `nobuild` (no C compile), then `cargo check` for thumb with `nobuild,nobindgen` + `RAYLIB_BINDGEN_LOCATION`. One discovered gap gets fixed first: build.rs currently runs bindgen even under `nobindgen`.
+
+**Tech Stack:** Rust 1.85 (pinned via `rust-toolchain.toml`), bindgen 0.72.1, GitHub Actions (`check.yml`).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md`
+
+**Branch:** `feat/raylib-sys-no-std` (off `origin/unstable`; spec already committed there). Target PR base: `unstable`.
+
+**Environment notes for the implementer:**
+- Windows host, PowerShell. Env vars do NOT persist between tool calls — set `$env:RAYLIB_BINDGEN_LOCATION` in the *same* command as the `cargo check` that needs it.
+- `cargo fmt -p raylib-sys` before commits (NOT `--all` — breaks on Windows long paths in worktrees).
+- Stage modified files explicitly; never `git add -A`.
+- CI commands appear verbatim from `.github/workflows/check.yml` — do not paraphrase them (memory: `plan-clippy-vs-ci-command-divergence`).
+- If a subagent executes a task, verify its commit landed on `feat/raylib-sys-no-std` (`git log -1`) before trusting its report (memory: `subagent-worktree-cwd-trap`).
+
+---
+
+### Task 1: Make `nobindgen` honest in build.rs + amend spec
+
+build.rs currently runs `gen_bindings()` even when `nobindgen` is enabled (the feature only gates the `include!` in lib.rs). The proof leg would therefore run bindgen against the thumb target — fragile and pointless. Gate it off, and record the discovery in the spec.
+
+**Files:**
+- Modify: `raylib-sys/build.rs` (fn `gen_bindings` at ~line 284, call site at ~line 521)
+- Modify: `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md`
+
+- [ ] **Step 1: Gate the `gen_bindings` definition**
+
+In `raylib-sys/build.rs`, change:
+
+```rust
+fn gen_bindings() {
+```
+
+to:
+
+```rust
+#[cfg(not(feature = "nobindgen"))]
+fn gen_bindings() {
+```
+
+- [ ] **Step 2: Gate the call site**
+
+In `fn main()` (~line 521), change:
+
+```rust
+    gen_bindings();
+```
+
+to:
+
+```rust
+    // `nobindgen` consumers supply a pregenerated binding via RAYLIB_BINDGEN_LOCATION
+    // (see src/lib.rs); skip bindgen entirely — it may not be runnable for the
+    // build target (e.g. the no-std CI leg cross-checking thumbv7em-none-eabihf).
+    #[cfg(not(feature = "nobindgen"))]
+    gen_bindings();
+```
+
+- [ ] **Step 3: Hosted regression check**
+
+Run: `cargo check -p raylib-sys`
+Expected: PASS (default path untouched; warm cache makes this quick).
+
+- [ ] **Step 4: Amend the spec**
+
+In `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md`, replace the bullet:
+
+```markdown
+- `raylib-sys/build.rs`: add `.use_core()` to the bindgen builder. No other
+  build.rs changes — build scripts run on the host with std.
+```
+
+with:
+
+```markdown
+- `raylib-sys/build.rs`: add `.use_core()` to the bindgen builder, and gate
+  `gen_bindings()` behind `#[cfg(not(feature = "nobindgen"))]` so `nobindgen`
+  does what its docs claim (planning discovery: build.rs ran bindgen even
+  under `nobindgen`, which would have made the proof leg run bindgen against
+  the thumb target). Build scripts otherwise unchanged — they run on the
+  host with std.
+```
+
+And at the end of the "Decision 2" section, append:
+
+```markdown
+**Plan refinements:** the CI job also checks `--features
+nobuild,nobindgen,mint` to prove the `mint` adapter is no-std-clean, and
+`thumbv7em-none-eabihf` is added to `rust-toolchain.toml` targets so local
+runs need no manual `rustup target add`.
+```
+
+- [ ] **Step 5: Format and commit**
+
+```powershell
+cargo fmt -p raylib-sys
+git add raylib-sys/build.rs docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
+git commit -m @'
+fix(sys): skip bindgen entirely under the nobindgen feature
+
+nobindgen only gated the include! in lib.rs; build.rs still ran bindgen
+and threw the output away. Gate gen_bindings() so pregenerated-binding
+consumers (and the upcoming no-std CI leg) never invoke bindgen.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 2: RED — prove the proof leg fails today
+
+**Files:**
+- Modify: `rust-toolchain.toml`
+
+- [ ] **Step 1: Add the thumb target to the pinned toolchain**
+
+In `rust-toolchain.toml`, change:
+
+```toml
+targets = ["wasm32-unknown-emscripten"]
+```
+
+to:
+
+```toml
+# thumbv7em-none-eabihf: no-std proof target for raylib-sys (check.yml `no-std` job)
+targets = ["wasm32-unknown-emscripten", "thumbv7em-none-eabihf"]
+```
+
+Then run: `rustup target add thumbv7em-none-eabihf`
+Expected: target installs (or "is up to date") for the pinned 1.85.0 toolchain.
+
+- [ ] **Step 2: Generate the host binding (pre-use_core) and save a "before" copy**
+
+```powershell
+cargo check -p raylib-sys --features nobuild
+$b = Get-ChildItem target\debug\build\raylib-sys-*\out\bindings.rs | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+Copy-Item $b.FullName "$env:TEMP\bindings-before-use-core.rs"
+$b.FullName
+```
+
+Expected: PASS (bindgen runs, no C compile); note the printed path. The "before" copy feeds the Task 4 diff.
+
+- [ ] **Step 3: Run the thumb check, expect failure**
+
+```powershell
+$b = Get-ChildItem target\debug\build\raylib-sys-*\out\bindings.rs | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$env:RAYLIB_BINDGEN_LOCATION = $b.FullName
+cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+```
+
+Expected: **FAIL** with `error[E0463]: can't find crate for `std`` (the crate isn't `no_std` yet, and the binding is full of `::std::` paths). This is the red state. If it *passes*, STOP — the leg is silently skipping something (pitfall 4); investigate before continuing.
+
+- [ ] **Step 4: Commit the toolchain change**
+
+```powershell
+git add rust-toolchain.toml
+git commit -m @'
+chore: add thumbv7em-none-eabihf to pinned toolchain targets
+
+Local + CI runs of the upcoming raylib-sys no-std proof leg need the
+target installed; the toolchain file makes that automatic.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 3: GREEN — the no_std change
+
+**Files:**
+- Modify: `raylib-sys/src/lib.rs` (top of file)
+- Modify: `raylib-sys/src/vector_math.rs` (27 × `std::ops::`)
+- Modify: `raylib-sys/src/matrix_quat_math.rs` (16 × `std::ops::`)
+- Modify: `raylib-sys/src/color.rs` (line 64, `std::num::ParseIntError`)
+- Modify: `raylib-sys/build.rs` (bindgen builder, ~line 319)
+
+- [ ] **Step 1: lib.rs — crate docs + `#![no_std]`**
+
+Replace the current top of `raylib-sys/src/lib.rs`:
+
+```rust
+#![allow(non_upper_case_globals)]
+```
+
+with:
+
+```rust
+//! Raw FFI bindings for [raylib](https://www.raylib.com/).
+//!
+//! The crate is unconditionally `#![no_std]` — it depends only on `core`, so
+//! it builds for embedded/no-std targets (linking raylib's C library for such
+//! a target is the consumer's responsibility; see the `nobuild` and
+//! `nobindgen` features). std consumers are unaffected. The `mint` adapter
+//! feature is no-std-compatible; `glam` and `serde` currently require a
+//! std-capable target.
+#![no_std]
+#![allow(non_upper_case_globals)]
+```
+
+(The remaining `#![allow(...)]` lines and everything below stay as-is.)
+
+- [ ] **Step 2: vector_math.rs sweep**
+
+Edit `raylib-sys/src/vector_math.rs`: replace **all** occurrences of `impl std::ops::` with `impl core::ops::` (27 occurrences — Add/AddAssign/Sub/SubAssign/Mul/MulAssign/Div/Neg for Vector2/3/4).
+
+- [ ] **Step 3: matrix_quat_math.rs sweep**
+
+Edit `raylib-sys/src/matrix_quat_math.rs`: replace **all** occurrences of `impl std::ops::` with `impl core::ops::` (16 occurrences — Matrix and Quaternion impls).
+
+- [ ] **Step 4: color.rs**
+
+In `raylib-sys/src/color.rs` line 64, change:
+
+```rust
+    pub fn from_hex(color_hex_str: &str) -> Result<Color, std::num::ParseIntError> {
+```
+
+to:
+
+```rust
+    pub fn from_hex(color_hex_str: &str) -> Result<Color, core::num::ParseIntError> {
+```
+
+- [ ] **Step 5: build.rs — `.use_core()`**
+
+In `raylib-sys/build.rs` (~line 319, inside `gen_bindings`), change:
+
+```rust
+    let mut builder = bindgen::Builder::default()
+        .header(header)
+        .rustified_enum(".+")
+```
+
+to:
+
+```rust
+    let mut builder = bindgen::Builder::default()
+        .header(header)
+        .use_core()
+        .rustified_enum(".+")
+```
+
+- [ ] **Step 6: No stray `std::` left in src/**
+
+Run (Grep tool or ripgrep): pattern `std::` in `raylib-sys/src/`
+Expected: **zero** matches. (`tests/` and `build.rs` keep theirs — host-side.)
+
+- [ ] **Step 7: Regenerate the host binding with use_core**
+
+```powershell
+cargo check -p raylib-sys --features nobuild
+```
+
+Expected: PASS (build.rs changed → bindgen reruns, now emitting `::core::` paths; the `#![no_std]` lib compiles against the fresh binding on the host).
+
+- [ ] **Step 8: Run the thumb check, expect success**
+
+```powershell
+$b = Get-ChildItem target\debug\build\raylib-sys-*\out\bindings.rs | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$env:RAYLIB_BINDGEN_LOCATION = $b.FullName
+cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+```
+
+Expected: **PASS**. This is the green state. (Warnings are acceptable; errors are not. If thumb chokes on host-specific output — e.g. u128 long-double externs — see the spec's contingency: pass `--target` through to bindgen's clang args. Do NOT improvise a different fix.)
+
+Do not commit yet — Task 4 verifies the regen diff first.
+
+---
+
+### Task 4: Bindgen regen diff + hosted regression + the adopting commit
+
+**Files:** none new (verification + commit of Task 3's edits)
+
+- [ ] **Step 1: Diff the regenerated binding against the "before" copy**
+
+The only acceptable change class is `::std::` → `::core::`. Normalize and compare (the before-binding had **zero** `::core::` refs — verified during brainstorming — so the substitution is sound):
+
+```powershell
+$b = Get-ChildItem target\debug\build\raylib-sys-*\out\bindings.rs | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+Copy-Item $b.FullName "$env:TEMP\bindings-after-use-core.rs"
+(Get-Content "$env:TEMP\bindings-after-use-core.rs") -replace '::core::', '::std::' | Set-Content -Encoding ascii "$env:TEMP\bindings-after-normalized.rs"
+git diff --no-index "$env:TEMP\bindings-before-use-core.rs" "$env:TEMP\bindings-after-normalized.rs"
+```
+
+Expected: **empty diff** (exit code 0). If non-empty: STOP — anything beyond the path prefix is a bindgen-0.72.1/use_core regression; investigate before committing. Record the std/core ref counts for the done-note:
+
+```powershell
+(Select-String -Path "$env:TEMP\bindings-before-use-core.rs" -Pattern '::std::').Count
+(Select-String -Path "$env:TEMP\bindings-after-use-core.rs" -Pattern '::core::').Count
+```
+
+- [ ] **Step 2: Hosted regression — default build unchanged**
+
+```powershell
+cargo check -p raylib-sys
+cargo check -p raylib
+```
+
+Expected: both PASS (full default path: C build cached, safe crate consumes the no_std sys crate with zero changes).
+
+- [ ] **Step 3: Format, stage explicitly, adopting commit with attribution**
+
+```powershell
+cargo fmt -p raylib-sys
+git add raylib-sys/src/lib.rs raylib-sys/src/vector_math.rs raylib-sys/src/matrix_quat_math.rs raylib-sys/src/color.rs raylib-sys/build.rs
+git commit -m @'
+feat(sys): make raylib-sys unconditionally #![no_std]
+
+Adopts PR #251 (nbe1233), adapted for 6.0: simpler unconditional-no_std
+topology (zero feature changes — nothing in the lib needs std), bindgen
+0.72.1 .use_core() (~1.5k ::std:: paths -> ::core:: in the generated
+binding), and the post-WS2a raymath files swept std::ops -> core::ops.
+std consumers are unaffected; mint is no-std-clean, glam/serde currently
+need a std-capable target (documented, relaxation is future work).
+
+Co-Authored-By: nbe1233 <27390193+nbe1233@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 5: Anti-silent-skip — prove the proof leg can fail
+
+A gated check that silently compiles out proves nothing (pitfall 4, three instances found in queue item 11). Inject a std canary, watch the leg go red, revert.
+
+**Files:** `raylib-sys/src/vector_math.rs` (temporary edit, reverted in this task)
+
+- [ ] **Step 1: Inject the canary**
+
+At the top of `raylib-sys/src/vector_math.rs` (below any existing `use` lines), add:
+
+```rust
+use std::ops::Add as _; // CANARY — must never be committed
+```
+
+- [ ] **Step 2: Run the verbatim thumb check, expect failure**
+
+```powershell
+$b = Get-ChildItem target\debug\build\raylib-sys-*\out\bindings.rs | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$env:RAYLIB_BINDGEN_LOCATION = $b.FullName
+cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+```
+
+Expected: **FAIL** with `error[E0433]: failed to resolve: use of unresolved module or unlinked crate `std``. If it passes, STOP — the leg is not actually compiling the crate.
+
+- [ ] **Step 3: Revert the canary and confirm green**
+
+```powershell
+git checkout -- raylib-sys/src/vector_math.rs
+$b = Get-ChildItem target\debug\build\raylib-sys-*\out\bindings.rs | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$env:RAYLIB_BINDGEN_LOCATION = $b.FullName
+cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+```
+
+Expected: PASS. Also confirm `git status --porcelain` shows a clean tree (no stray canary).
+
+---
+
+### Task 6: Quality gates (verbatim CI commands)
+
+**Files:** none (verification only; fix-forward if anything fails)
+
+- [ ] **Step 1: Clippy raylib-sys — verbatim from check.yml:46**
+
+Run: `cargo clippy -p raylib-sys --features full -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 2: Clippy safe crate — verbatim from check.yml:44**
+
+Run: `cargo clippy -p raylib --lib --bins --features full -- -D warnings`
+Expected: PASS (proves the safe crate is unaffected; if it fails because of the sys change, that is a bug in the sys change — fix there, do not patch the safe crate).
+
+- [ ] **Step 3: raylib-sys test suites (std test crates against the no_std lib)**
+
+Run: `cargo nextest run -p raylib-sys`
+Expected: PASS (layout_compat + raymath_wrappers binaries; they link std regardless of the lib being no_std).
+
+Run: `cargo test -p raylib-sys --doc`
+Expected: PASS (doctest binaries get std by default even for no_std crates).
+
+If any gate fails: fix, re-run the failed gate AND the thumb check from Task 5 Step 3, then amend nothing — make a follow-up commit:
+
+```powershell
+cargo fmt -p raylib-sys
+git add <only the files you fixed>
+git commit -m @'
+fix(sys): <one-line description of the gate fix>
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 7: CI proof leg in check.yml (own `ci:` commit)
+
+**Files:**
+- Modify: `.github/workflows/check.yml` (append new job after `msrv`, line 124)
+
+- [ ] **Step 1: Append the `no-std` job**
+
+Add at the end of `.github/workflows/check.yml` (same indentation as the other jobs):
+
+```yaml
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check-no-std
+      # rust-toolchain.toml installs the thumb target automatically; this is a
+      # cheap idempotent belt-and-suspenders for runners with a preinstalled toolchain.
+      - name: Add no-std target
+        run: rustup target add thumbv7em-none-eabihf
+      # Step 1 of the proof: bindgen runs on the host (build scripts always have
+      # std); `nobuild` skips the C compile entirely.
+      - name: Generate binding on host (bindgen only, no C build)
+        run: cargo check -p raylib-sys --features nobuild
+      - name: Locate generated binding
+        run: echo "RAYLIB_BINDGEN_LOCATION=$(ls -t target/debug/build/raylib-sys-*/out/bindings.rs | head -n1)" >> "$GITHUB_ENV"
+      # Step 2: a real no-std target proves the crate graph builds without std.
+      # The binding is host-flavored — fine for a compile-only proof; it never runs.
+      - name: Check raylib-sys on a no-std target
+        run: cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+      # mint is documented as no-std-compatible — keep that claim honest.
+      - name: Check raylib-sys + mint on a no-std target
+        run: cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen,mint
+```
+
+- [ ] **Step 2: Sanity-check the YAML**
+
+Run: `gh act -W .github/workflows/check.yml -j no-std -n` (dry-run; requires Docker).
+If `act`/Docker is unavailable, skip — the real check happens on the PR (Task 8); at minimum confirm the file parses: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/check.yml'))"` (or any YAML parser available).
+
+- [ ] **Step 3: Commit (workflow changes in their own `ci:` commit)**
+
+```powershell
+git add .github/workflows/check.yml
+git commit -m @'
+ci: add raylib-sys no-std proof leg to check.yml
+
+Host-generates the binding with nobuild (bindgen only, no C compile),
+then cargo-checks raylib-sys for thumbv7em-none-eabihf with
+nobuild,nobindgen + RAYLIB_BINDGEN_LOCATION; a second check adds mint
+to keep its no-std claim honest. Leg verified able-to-fail locally
+(std canary -> E0433).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+**Note:** this is an *added* job — no rename/delete, so the branch-protection required-checks list (ruleset 17203815) is unaffected. Adding `no-std` as a *required* check is a maintainer action in the GitHub UI after merge (flagged in Task 9's handoff); do not attempt it via API.
+
+---
+
+### Task 8: CHANGELOG + done-note
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased → Added section, after the `log` feature bullet at line 11)
+- Create: `docs/superpowers/notes/raylib-sys-no-std-complete.md`
+
+- [ ] **Step 1: CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## Unreleased` → `### Added`, append after the existing `log`-feature bullet:
+
+```markdown
+- `raylib-sys` is now unconditionally `#![no_std]` (adopts community PR
+  [#251](https://github.com/raylib-rs/raylib-rs/pull/251) by @nbe1233,
+  adapted for 6.0). Zero feature changes — std consumers and
+  `default-features = false` users are unaffected. The crate now builds for
+  no-std targets (CI-checked against `thumbv7em-none-eabihf` via the
+  `nobuild`/`nobindgen` escape hatches). The `mint` adapter feature is
+  no-std-compatible; `glam`/`serde` currently require a std-capable target.
+  `nobindgen` now also skips running bindgen in build.rs (previously it only
+  ignored the output).
+```
+
+- [ ] **Step 2: Done-note**
+
+Create `docs/superpowers/notes/raylib-sys-no-std-complete.md`. Use the run results from Tasks 2–6 to fill the two `<measured>` counts (everything else is settled):
+
+```markdown
+# raylib-sys no_std — done-note (queue item 18)
+
+**Date:** 2026-06-06 · **Spec:** `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md`
+**Adopts:** PR #251 (nbe1233), with attribution on the adopting commit.
+
+## std-usage census
+
+| Location | Before | After |
+|---|---|---|
+| generated `bindings.rs` | <measured> `::std::` refs | 0 (`.use_core()`; <measured> `::core::` refs) |
+| `src/vector_math.rs` | 27 (`std::ops`) | 0 |
+| `src/matrix_quat_math.rs` | 16 (`std::ops`) | 0 |
+| `src/color.rs` | 1 (`ParseIntError`) | 0 |
+| `build.rs` / `tests/` | host-side, unchanged | host-side, unchanged |
+
+Regen diff verified: normalizing `::core::`→`::std::` in the after-binding
+reproduced the before-binding byte-identically — `.use_core()` under bindgen
+0.72.1 changes nothing but the path prefix.
+
+## Feature topology decision
+
+Unconditional `#![no_std]`, zero feature changes (spec Decision 1). No `std`
+feature (it would gate nothing), no `default` split. The compiler itself now
+polices `std::` paths in every build — stronger than any lint.
+
+## Proof leg (verbatim)
+
+CI (`check.yml` job `no-std`), after host-generating the binding with
+`cargo check -p raylib-sys --features nobuild` and exporting
+`RAYLIB_BINDGEN_LOCATION`:
+
+    cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen
+
+plus a `…,mint` variant. Verified able-to-fail (std canary → E0433).
+`thumbv7em-none-eabihf` added to `rust-toolchain.toml` targets.
+
+## Optional-dep disposition
+
+- `mint`: no-std-clean, proven in CI.
+- `glam`/`serde`: current dep shapes pull std — fine on hosted targets,
+  won't build on no-std targets. Documented in crate docs + CHANGELOG.
+
+## Future work seeded
+
+- Relax `glam`/`serde` to `default-features = false` shapes for no-std use.
+- Reference/committed binding for nobuild-CI-matrix (queue item 13) — the
+  use_core output is what any pregenerated binding must be generated from.
+
+## Fixed in passing
+
+- `nobindgen` now actually skips bindgen in build.rs (it previously ran
+  bindgen and discarded the output).
+```
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add CHANGELOG.md docs/superpowers/notes/raylib-sys-no-std-complete.md
+git commit -m @'
+docs: CHANGELOG entry + done-note for raylib-sys no_std (queue item 18)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 9: Push, PR, handoff notes
+
+**Files:** none (a temp PR-body file outside the repo)
+
+- [ ] **Step 1: Push the branch**
+
+```powershell
+git push -u origin feat/raylib-sys-no-std
+```
+
+- [ ] **Step 2: Create the PR (body via temp file — embedded quotes break PS 5.1 arg marshalling)**
+
+Write `$env:TEMP\no-std-pr-body.md`:
+
+```markdown
+Closes #251, adapted for 6.0 — with thanks to @nbe1233 for the original patch (co-authored on the adopting commit).
+
+Makes `raylib-sys` unconditionally `#![no_std]`. Spec: `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md` (queue item 18, queued via #307).
+
+**What changed vs #251** (it predates 6.0): unconditional `#![no_std]` instead of a `std` feature + `default` split (nothing in the lib needs std, so the feature would gate nothing); bindgen 0.72.1 `.use_core()` with a verified before/after regen diff (only `::std::` → `::core::` moves); the post-WS2a raymath wrapper files swept `std::ops` → `core::ops`; `nobindgen` fixed to actually skip bindgen in build.rs.
+
+**Compatibility:** zero feature/Cargo.toml changes. std consumers and `default-features = false` users see no semantic change. `mint` is no-std-clean (CI-proven); `glam`/`serde` currently require a std-capable target (documented; relaxation is future work).
+
+**Proof leg:** new `no-std` job in check.yml — host-generates the binding (`nobuild`, no C compile), then `cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen` (+ `,mint`). Verified able-to-fail locally (std canary → E0433).
+
+**Maintainer follow-ups:** merge #307 (docs-only queue entry) or tell me to fold it in; optionally add `no-std` to the required checks in ruleset 17203815 (it's fast).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Then:
+
+```powershell
+gh pr create --base unstable --title "feat(sys): make raylib-sys unconditionally #![no_std]" --body-file "$env:TEMP\no-std-pr-body.md"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks --watch` (or poll `gh pr checks`).
+Expected: all check.yml jobs green **including the new `no-std` job**; test/web/sanitizers legs green. Confirm in the `no-std` job log that both thumb `cargo check` steps actually ran and compiled `raylib-sys` (look for `Checking raylib-sys`) — a leg that skipped is a silent-skip failure even if green.
+
+- [ ] **Step 4: Verify branch integrity**
+
+```powershell
+git log --oneline origin/unstable..HEAD
+```
+
+Expected: exactly these commits (top to bottom): docs (CHANGELOG+done-note), ci (check.yml), feat (adopting commit, with both co-author trailers), chore (toolchain targets), fix (nobindgen), docs (plan, if committed separately), docs (spec). Confirm the adopting commit shows `Co-Authored-By: nbe1233` via `git log --format=full`.
+
+---
+
+## Done criteria (from the spec)
+
+- [ ] Proof leg green in CI on the PR, verified able-to-fail locally
+- [ ] Default/hosted builds unchanged (`cargo check -p raylib-sys`, `-p raylib`, clippy gates green)
+- [ ] PR closes #251 with attribution; #307 merged or folded (maintainer call)
+- [ ] CHANGELOG entry, done-note written, queue item 18 closeable

--- a/docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
+++ b/docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
@@ -99,6 +99,11 @@ bindgen's clang args. Rejected-for-now alternative (b2): committing a reference
 `bindings.rs` — large generated file that drifts with every raylib/bindgen
 bump; revisit with the nobuild-CI-matrix queue item (13) if it wants one.
 
+**Plan refinements:** the CI job also checks `--features
+nobuild,nobindgen,mint` to prove the `mint` adapter is no-std-clean, and
+`thumbv7em-none-eabihf` is added to `rust-toolchain.toml` targets so local
+runs need no manual `rustup target add`.
+
 ## Code changes
 
 - `raylib-sys/src/lib.rs`: `#![no_std]` at top; existing `allow` attrs stay.
@@ -106,8 +111,12 @@ bump; revisit with the nobuild-CI-matrix queue item (13) if it wants one.
   `core::ops::`.
 - `raylib-sys/src/color.rs`: `std::num::ParseIntError` →
   `core::num::ParseIntError`.
-- `raylib-sys/build.rs`: add `.use_core()` to the bindgen builder. No other
-  build.rs changes — build scripts run on the host with std.
+- `raylib-sys/build.rs`: add `.use_core()` to the bindgen builder, and gate
+  `gen_bindings()` behind `#[cfg(not(feature = "nobindgen"))]` so `nobindgen`
+  does what its docs claim (planning discovery: build.rs ran bindgen even
+  under `nobindgen`, which would have made the proof leg run bindgen against
+  the thumb target). Build scripts otherwise unchanged — they run on the
+  host with std.
 - `raylib-sys/tests/`: unchanged.
 - `raylib-sys/Cargo.toml`: unchanged (no feature edits).
 

--- a/docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
+++ b/docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
@@ -93,11 +93,17 @@ revert. A gated check that silently compiles out proves nothing.
 branch-protection required-checks list is unaffected. Add it as required — it
 is fast.
 
-**Contingency (not built up-front):** if thumb chokes on host-specific output
-(e.g. u128 long-double externs), fall back to passing `--target` through to
-bindgen's clang args. Rejected-for-now alternative (b2): committing a reference
-`bindings.rs` — large generated file that drifts with every raylib/bindgen
-bump; revisit with the nobuild-CI-matrix queue item (13) if it wants one.
+**Contingency (resolved during implementation):** the host-generated binding
+failed the thumb check on bindgen *layout assertions* (host 64-bit sizes vs
+32-bit ARM), not on missing-std paths. The spec's original fallback (pass
+`--target` to bindgen's clang args) would require target libc headers
+(newlib) on every generating host, so instead `nobuild` bindings are
+generated with `.layout_tests(false)` — the proof leg is a compile-only
+no-std check, not an ARM ABI claim; hosted default builds keep layout tests
+(plus `tests/layout_compat.rs`). Rejected-for-now alternative (b2):
+committing a reference `bindings.rs` — large generated file that drifts with
+every raylib/bindgen bump; revisit with the nobuild-CI-matrix queue item
+(13) if it wants one.
 
 **Plan refinements:** the CI job also checks `--features
 nobuild,nobindgen,mint` to prove the `mint` adapter is no-std-clean, and

--- a/docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
+++ b/docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md
@@ -1,0 +1,160 @@
+# raylib-sys no_std — design
+
+**Date:** 2026-06-06
+**Status:** approved (maintainer sign-off on topology + proof leg, this session)
+**Queue:** post-release flexible-queue item 18 (`ws8e-checkpoint-review-feedback.md`, queued via PR #307)
+**Adopts:** community PR #251 (nbe1233), adapted for 6.0 — see "Attribution" below.
+
+## Goal
+
+Make `raylib-sys` compile under `#![no_std]`, proven by a CI check against a
+real no-std target. Scope is **raylib-sys only** — the safe `raylib` crate uses
+`String`/`Vec`/`Box` throughout and is not a no_std candidate. If the safe
+crate breaks because of this change, that is a bug in this change.
+
+## Sequencing decision
+
+crates.io is still at `6.0.0-rc.2` (final 6.0.0 publish outstanding). The queue
+memory suggested landing no_std after 6.0.0 ships. **Maintainer decision
+(2026-06-06): proceed now** — the change is additive and rides into 6.0.0 (or a
+6.0.x) whenever the publish happens.
+
+## std-usage census (verified 2026-06-06 on `unstable`)
+
+| Location | `std::` refs | Class |
+|---|---|---|
+| generated `bindings.rs` | 1,495 | bindgen default paths → fixed wholesale by `.use_core()` |
+| `src/vector_math.rs` | 27 | all `std::ops::*` trait impls |
+| `src/matrix_quat_math.rs` | 16 | all `std::ops::*` trait impls |
+| `src/color.rs` | 1 | `std::num::ParseIntError` (identical type exists in `core::num`) |
+| `build.rs` | 12 | host-side; build scripts always run with std — not a no_std concern |
+| `tests/*.rs` | 19 | separate test crates; they link std regardless — unchanged |
+
+No float-math methods (`.sqrt()` etc.) anywhere in `src/` — all math goes
+through the raymath C shim (WS2a), so the source sweep is purely mechanical
+`std::` → `core::` path swaps. Nothing in the library code needs std.
+
+## Decision 1: feature topology — unconditional `#![no_std]`
+
+**Chosen: Approach A — plain `#![no_std]`, zero feature changes.**
+
+- `lib.rs` gets `#![no_std]`. No `std` feature, no `default` split, no new
+  public feature names.
+- A no_std *library* crate is fully consumable by std code. Consumers observe
+  nothing: same types, same impls (`core::num::ParseIntError` *is*
+  `std::num::ParseIntError`).
+- The safe crate's `raylib-sys = { default-features = false }` +
+  `default = ["raylib-sys/default"]` forwarding is untouched. Existing
+  `default-features = false` users see no semantic change.
+- No `clippy::std_instead_of_core` lint needed: under unconditional
+  `#![no_std]` the compiler rejects any `std::` path in the lib crate, which is
+  strictly stronger.
+- If a future addition genuinely needs std, adding a default-on `std` feature
+  then is additive and non-breaking for hosted users. `core::error::Error`
+  (stable since 1.81, MSRV is 1.85) removes the classic reason to need one.
+
+**Rejected — B: PR #251's `default = ["std", "default_cmake_build_options"]`
+split.** The `std` feature would gate nothing today (a no-op feature, its own
+confusion) and the split adds two public feature names that exist only to
+serve it.
+
+**Rejected — C: explicit `no_std` opt-in feature.** Non-additive feature
+semantics; broken by cargo feature unification.
+
+## Decision 2: proof leg — thumb check with host-generated binding
+
+**Chosen: (b1)** — new CI job (in `.github/workflows/check.yml`, landed as its
+own `ci:` commit), two steps in one job:
+
+1. **Generate binding on host:** `cargo build -p raylib-sys --features nobuild`
+   (bindgen runs; no C compile), then locate
+   `target/debug/build/raylib-sys-*/out/bindings.rs`.
+2. **Check on a real no-std target:**
+   `rustup target add thumbv7em-none-eabihf`, then
+
+   ```
+   RAYLIB_BINDGEN_LOCATION=<abs path to bindings.rs> \
+     cargo check -p raylib-sys --target thumbv7em-none-eabihf \
+       --no-default-features --features nobuild,nobindgen
+   ```
+
+Self-refreshing (no committed binding artifact, no drift). The binding is
+host-flavored (x86_64 layouts) compiled for ARM — fine for a compile-only
+proof; it never runs. Hosted `--no-default-features` builds were rejected as
+the proof: under unconditional `#![no_std]` every existing build already
+polices `std::` paths; only a std-less target proves the crate graph builds
+without std.
+
+**Anti-silent-skip verification (required, pre-CI-wiring):** temporarily add a
+`std::` reference locally and confirm the verbatim command above goes red, then
+revert. A gated check that silently compiles out proves nothing.
+
+**Ruleset note:** this is an *added* job (no rename/delete), so the
+branch-protection required-checks list is unaffected. Add it as required — it
+is fast.
+
+**Contingency (not built up-front):** if thumb chokes on host-specific output
+(e.g. u128 long-double externs), fall back to passing `--target` through to
+bindgen's clang args. Rejected-for-now alternative (b2): committing a reference
+`bindings.rs` — large generated file that drifts with every raylib/bindgen
+bump; revisit with the nobuild-CI-matrix queue item (13) if it wants one.
+
+## Code changes
+
+- `raylib-sys/src/lib.rs`: `#![no_std]` at top; existing `allow` attrs stay.
+- `raylib-sys/src/vector_math.rs`, `matrix_quat_math.rs`: `std::ops::` →
+  `core::ops::`.
+- `raylib-sys/src/color.rs`: `std::num::ParseIntError` →
+  `core::num::ParseIntError`.
+- `raylib-sys/build.rs`: add `.use_core()` to the bindgen builder. No other
+  build.rs changes — build scripts run on the host with std.
+- `raylib-sys/tests/`: unchanged.
+- `raylib-sys/Cargo.toml`: unchanged (no feature edits).
+
+## Bindgen regen verification
+
+`.use_core()` flips ~1,495 `::std::` paths to `::core::` in the generated
+binding. Required step: generate before/after, diff, confirm the **only**
+change class is the path prefix — nothing else may shift under bindgen 0.72.1.
+Since `nobindgen` users consume pregenerated bindings, use_core output is what
+any future reference binding must be generated from.
+
+## Optional deps (v1 disposition)
+
+- `mint` — core-only; works on no-std targets as-is.
+- `glam`, `serde` — current declarations pull std. Hosted targets: nothing
+  changes. No-std targets: enabling those features won't build. **Documented,
+  not gated** (there is no `std` feature to gate on). Relaxing via
+  `default-features = false` dep shapes is recorded as future work in the
+  done-note.
+
+## Attribution & PR mechanics
+
+- Adopting commit: `Co-authored-by: nbe1233 <27390193+nbe1233@users.noreply.github.com>`
+  + the standard Claude trailer. PR body: "Closes #251, adapted for 6.0"
+  (adaptations: post-WS1 feature list, bindgen 0.72.1, post-WS2a raymath files,
+  simpler unconditional-no_std topology).
+- PR #307 (docs-only, queues this item): merge as-is first; fallback, fold into
+  this workstream's PR.
+- CHANGELOG entry under unreleased.
+- Done-note: `docs/superpowers/notes/raylib-sys-no-std-complete.md` capturing
+  the before/after census, the topology decision, the verbatim proof-leg
+  command, and the optional-dep disposition.
+
+## Testing
+
+- Existing Tier-1/Tier-2 suites unchanged (they exercise raylib-sys through std
+  test crates).
+- The proof leg is the new test; local reproduction copies the CI command
+  verbatim (memory: `plan-clippy-vs-ci-command-divergence`).
+- Full quality gates apply: `cargo fmt -p raylib-sys`, clippy `-Dwarnings`,
+  doctests, MSRV 1.85.
+
+## Done criteria
+
+- `raylib-sys` compiles for `thumbv7em-none-eabihf` (proof leg green in CI,
+  verified able-to-fail).
+- Default/hosted builds completely unchanged; existing
+  `default-features = false` users unaffected.
+- PR #251 closed with attribution; PR #307 merged or folded.
+- CHANGELOG entry; done-note written; queue item 18 closed.

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -319,6 +319,7 @@ fn gen_bindings() {
     }
     let mut builder = bindgen::Builder::default()
         .header(header)
+        .use_core()
         .rustified_enum(".+")
         .derive_partialeq(true)
         .derive_default(true)
@@ -350,6 +351,16 @@ fn gen_bindings() {
     if platform == Platform::Desktop && os == PlatformOS::Windows {
         // odd workaround for booleans being broken
         builder = builder.clang_arg("-D__STDC__");
+    }
+
+    // nobuild bindings may be consumed cross-target via nobindgen +
+    // RAYLIB_BINDGEN_LOCATION (e.g. the no-std CI leg compile-checks a
+    // host-generated binding for thumbv7em). bindgen's layout asserts
+    // hardcode the generating host's pointer width and break such
+    // compile-only cross-checks; hosted default builds keep them.
+    #[cfg(feature = "nobuild")]
+    {
+        builder = builder.layout_tests(false);
     }
 
     if platform == Platform::Web {

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -13,7 +13,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 
   3. This notice may not be removed or altered from any source distribution.
 */
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 extern crate bindgen;
 

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -281,6 +281,7 @@ fn build_with_cmake(src_path: &str) {
     }
 }
 
+#[cfg(not(feature = "nobindgen"))]
 fn gen_bindings() {
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
     let (platform, os) = platform_from_target(&target);
@@ -518,6 +519,10 @@ fn main() {
     let raylib_src = "./raylib";
     build_with_cmake(raylib_src);
 
+    // `nobindgen` consumers supply a pregenerated binding via RAYLIB_BINDGEN_LOCATION
+    // (see src/lib.rs); skip bindgen entirely — it may not be runnable for the
+    // build target (e.g. the no-std CI leg cross-checking thumbv7em-none-eabihf).
+    #[cfg(not(feature = "nobindgen"))]
     gen_bindings();
 
     link(platform, platform_os);

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -330,7 +330,11 @@ fn gen_bindings() {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .clang_arg("-I../raylib/src")
+        // Vendored raylib headers, relative to the build-script CWD (the package
+        // root). nobuild.h resolves raylib.h/raymath.h/rlgl.h through this -I;
+        // binding.h's quoted ../raylib/src/ includes resolve file-relative and
+        // don't need it.
+        .clang_arg("-Iraylib/src")
         .clang_arg("-std=c99")
         .clang_arg(plat)
         // RAYMATH_IMPLEMENTATION makes RMAPI expand to `extern inline` so
@@ -474,7 +478,7 @@ fn main() {
     let header;
     #[cfg(feature = "nobuild")]
     {
-        header = "/usr/include/raylib.h"
+        header = "binding/nobuild.h"
     }
     #[cfg(not(feature = "nobuild"))]
     {

--- a/raylib-sys/src/color.rs
+++ b/raylib-sys/src/color.rs
@@ -61,7 +61,7 @@ impl From<(u8, u8, u8, u8)> for Color {
 
 impl Color {
     /// produces Color from a hex string(6 characters long)
-    pub fn from_hex(color_hex_str: &str) -> Result<Color, std::num::ParseIntError> {
+    pub fn from_hex(color_hex_str: &str) -> Result<Color, core::num::ParseIntError> {
         let color = i32::from_str_radix(color_hex_str, 16)?;
         let b = color % 0x100;
         let g = (color - b) / 0x100 % 0x100;

--- a/raylib-sys/src/lib.rs
+++ b/raylib-sys/src/lib.rs
@@ -1,3 +1,12 @@
+//! Raw FFI bindings for [raylib](https://www.raylib.com/).
+//!
+//! The crate is unconditionally `#![no_std]` — it depends only on `core`, so
+//! it builds for embedded/no-std targets (linking raylib's C library for such
+//! a target is the consumer's responsibility; see the `nobuild` and
+//! `nobindgen` features). std consumers are unaffected. The `mint` adapter
+//! feature is no-std-compatible; `glam` and `serde` currently require a
+//! std-capable target.
+#![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/raylib-sys/src/matrix_quat_math.rs
+++ b/raylib-sys/src/matrix_quat_math.rs
@@ -164,7 +164,7 @@ impl Matrix {
     }
 }
 
-impl std::ops::Mul for Matrix {
+impl core::ops::Mul for Matrix {
     type Output = Matrix;
     #[inline]
     fn mul(self, rhs: Matrix) -> Matrix {
@@ -172,14 +172,14 @@ impl std::ops::Mul for Matrix {
         unsafe { crate::MatrixMultiply(self, rhs) }
     }
 }
-impl std::ops::MulAssign for Matrix {
+impl core::ops::MulAssign for Matrix {
     #[inline]
     fn mul_assign(&mut self, rhs: Matrix) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Add for Matrix {
+impl core::ops::Add for Matrix {
     type Output = Matrix;
     #[inline]
     fn add(self, rhs: Matrix) -> Matrix {
@@ -187,14 +187,14 @@ impl std::ops::Add for Matrix {
         unsafe { crate::MatrixAdd(self, rhs) }
     }
 }
-impl std::ops::AddAssign for Matrix {
+impl core::ops::AddAssign for Matrix {
     #[inline]
     fn add_assign(&mut self, rhs: Matrix) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for Matrix {
+impl core::ops::Sub for Matrix {
     type Output = Matrix;
     #[inline]
     fn sub(self, rhs: Matrix) -> Matrix {
@@ -202,7 +202,7 @@ impl std::ops::Sub for Matrix {
         unsafe { crate::MatrixSubtract(self, rhs) }
     }
 }
-impl std::ops::SubAssign for Matrix {
+impl core::ops::SubAssign for Matrix {
     #[inline]
     fn sub_assign(&mut self, rhs: Matrix) {
         *self = *self - rhs;
@@ -388,7 +388,7 @@ impl Quaternion {
     }
 }
 
-impl std::ops::Add for Quaternion {
+impl core::ops::Add for Quaternion {
     type Output = Quaternion;
     #[inline]
     fn add(self, rhs: Quaternion) -> Quaternion {
@@ -396,14 +396,14 @@ impl std::ops::Add for Quaternion {
         unsafe { crate::QuaternionAdd(self, rhs) }
     }
 }
-impl std::ops::AddAssign for Quaternion {
+impl core::ops::AddAssign for Quaternion {
     #[inline]
     fn add_assign(&mut self, rhs: Quaternion) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for Quaternion {
+impl core::ops::Sub for Quaternion {
     type Output = Quaternion;
     #[inline]
     fn sub(self, rhs: Quaternion) -> Quaternion {
@@ -411,14 +411,14 @@ impl std::ops::Sub for Quaternion {
         unsafe { crate::QuaternionSubtract(self, rhs) }
     }
 }
-impl std::ops::SubAssign for Quaternion {
+impl core::ops::SubAssign for Quaternion {
     #[inline]
     fn sub_assign(&mut self, rhs: Quaternion) {
         *self = *self - rhs;
     }
 }
 
-impl std::ops::Mul for Quaternion {
+impl core::ops::Mul for Quaternion {
     type Output = Quaternion;
     #[inline]
     fn mul(self, rhs: Quaternion) -> Quaternion {
@@ -426,14 +426,14 @@ impl std::ops::Mul for Quaternion {
         unsafe { crate::QuaternionMultiply(self, rhs) }
     }
 }
-impl std::ops::MulAssign for Quaternion {
+impl core::ops::MulAssign for Quaternion {
     #[inline]
     fn mul_assign(&mut self, rhs: Quaternion) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Mul<f32> for Quaternion {
+impl core::ops::Mul<f32> for Quaternion {
     type Output = Quaternion;
     #[inline]
     fn mul(self, rhs: f32) -> Quaternion {
@@ -441,14 +441,14 @@ impl std::ops::Mul<f32> for Quaternion {
         unsafe { crate::QuaternionScale(self, rhs) }
     }
 }
-impl std::ops::MulAssign<f32> for Quaternion {
+impl core::ops::MulAssign<f32> for Quaternion {
     #[inline]
     fn mul_assign(&mut self, rhs: f32) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Div for Quaternion {
+impl core::ops::Div for Quaternion {
     type Output = Quaternion;
     #[inline]
     fn div(self, rhs: Quaternion) -> Quaternion {
@@ -456,7 +456,7 @@ impl std::ops::Div for Quaternion {
         unsafe { crate::QuaternionDivide(self, rhs) }
     }
 }
-impl std::ops::DivAssign for Quaternion {
+impl core::ops::DivAssign for Quaternion {
     #[inline]
     fn div_assign(&mut self, rhs: Quaternion) {
         *self = *self / rhs;

--- a/raylib-sys/src/vector_math.rs
+++ b/raylib-sys/src/vector_math.rs
@@ -247,7 +247,7 @@ impl Vector2 {
     }
 }
 
-impl std::ops::Add for Vector2 {
+impl core::ops::Add for Vector2 {
     type Output = Vector2;
     #[inline]
     fn add(self, rhs: Vector2) -> Vector2 {
@@ -255,14 +255,14 @@ impl std::ops::Add for Vector2 {
         unsafe { crate::Vector2Add(self, rhs) }
     }
 }
-impl std::ops::AddAssign for Vector2 {
+impl core::ops::AddAssign for Vector2 {
     #[inline]
     fn add_assign(&mut self, rhs: Vector2) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for Vector2 {
+impl core::ops::Sub for Vector2 {
     type Output = Vector2;
     #[inline]
     fn sub(self, rhs: Vector2) -> Vector2 {
@@ -270,14 +270,14 @@ impl std::ops::Sub for Vector2 {
         unsafe { crate::Vector2Subtract(self, rhs) }
     }
 }
-impl std::ops::SubAssign for Vector2 {
+impl core::ops::SubAssign for Vector2 {
     #[inline]
     fn sub_assign(&mut self, rhs: Vector2) {
         *self = *self - rhs;
     }
 }
 
-impl std::ops::Mul<f32> for Vector2 {
+impl core::ops::Mul<f32> for Vector2 {
     type Output = Vector2;
     #[inline]
     fn mul(self, rhs: f32) -> Vector2 {
@@ -285,14 +285,14 @@ impl std::ops::Mul<f32> for Vector2 {
         unsafe { crate::Vector2Scale(self, rhs) }
     }
 }
-impl std::ops::MulAssign<f32> for Vector2 {
+impl core::ops::MulAssign<f32> for Vector2 {
     #[inline]
     fn mul_assign(&mut self, rhs: f32) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Mul<Vector2> for Vector2 {
+impl core::ops::Mul<Vector2> for Vector2 {
     type Output = Vector2;
     #[inline]
     fn mul(self, rhs: Vector2) -> Vector2 {
@@ -301,7 +301,7 @@ impl std::ops::Mul<Vector2> for Vector2 {
     }
 }
 
-impl std::ops::Div<Vector2> for Vector2 {
+impl core::ops::Div<Vector2> for Vector2 {
     type Output = Vector2;
     #[inline]
     fn div(self, rhs: Vector2) -> Vector2 {
@@ -310,7 +310,7 @@ impl std::ops::Div<Vector2> for Vector2 {
     }
 }
 
-impl std::ops::Neg for Vector2 {
+impl core::ops::Neg for Vector2 {
     type Output = Vector2;
     #[inline]
     fn neg(self) -> Vector2 {
@@ -662,7 +662,7 @@ pub fn vector3_ortho_normalize(v1: &mut Vector3, v2: &mut Vector3) {
     unsafe { crate::Vector3OrthoNormalize(v1 as *mut _, v2 as *mut _) }
 }
 
-impl std::ops::Add for Vector3 {
+impl core::ops::Add for Vector3 {
     type Output = Vector3;
     #[inline]
     fn add(self, rhs: Vector3) -> Vector3 {
@@ -670,14 +670,14 @@ impl std::ops::Add for Vector3 {
         unsafe { crate::Vector3Add(self, rhs) }
     }
 }
-impl std::ops::AddAssign for Vector3 {
+impl core::ops::AddAssign for Vector3 {
     #[inline]
     fn add_assign(&mut self, rhs: Vector3) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for Vector3 {
+impl core::ops::Sub for Vector3 {
     type Output = Vector3;
     #[inline]
     fn sub(self, rhs: Vector3) -> Vector3 {
@@ -685,14 +685,14 @@ impl std::ops::Sub for Vector3 {
         unsafe { crate::Vector3Subtract(self, rhs) }
     }
 }
-impl std::ops::SubAssign for Vector3 {
+impl core::ops::SubAssign for Vector3 {
     #[inline]
     fn sub_assign(&mut self, rhs: Vector3) {
         *self = *self - rhs;
     }
 }
 
-impl std::ops::Mul<f32> for Vector3 {
+impl core::ops::Mul<f32> for Vector3 {
     type Output = Vector3;
     #[inline]
     fn mul(self, rhs: f32) -> Vector3 {
@@ -700,14 +700,14 @@ impl std::ops::Mul<f32> for Vector3 {
         unsafe { crate::Vector3Scale(self, rhs) }
     }
 }
-impl std::ops::MulAssign<f32> for Vector3 {
+impl core::ops::MulAssign<f32> for Vector3 {
     #[inline]
     fn mul_assign(&mut self, rhs: f32) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Mul<Vector3> for Vector3 {
+impl core::ops::Mul<Vector3> for Vector3 {
     type Output = Vector3;
     #[inline]
     fn mul(self, rhs: Vector3) -> Vector3 {
@@ -716,7 +716,7 @@ impl std::ops::Mul<Vector3> for Vector3 {
     }
 }
 
-impl std::ops::Div<Vector3> for Vector3 {
+impl core::ops::Div<Vector3> for Vector3 {
     type Output = Vector3;
     #[inline]
     fn div(self, rhs: Vector3) -> Vector3 {
@@ -725,7 +725,7 @@ impl std::ops::Div<Vector3> for Vector3 {
     }
 }
 
-impl std::ops::Neg for Vector3 {
+impl core::ops::Neg for Vector3 {
     type Output = Vector3;
     #[inline]
     fn neg(self) -> Vector3 {
@@ -904,7 +904,7 @@ impl Vector4 {
     }
 }
 
-impl std::ops::Add for Vector4 {
+impl core::ops::Add for Vector4 {
     type Output = Vector4;
     #[inline]
     fn add(self, rhs: Vector4) -> Vector4 {
@@ -912,14 +912,14 @@ impl std::ops::Add for Vector4 {
         unsafe { crate::Vector4Add(self, rhs) }
     }
 }
-impl std::ops::AddAssign for Vector4 {
+impl core::ops::AddAssign for Vector4 {
     #[inline]
     fn add_assign(&mut self, rhs: Vector4) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for Vector4 {
+impl core::ops::Sub for Vector4 {
     type Output = Vector4;
     #[inline]
     fn sub(self, rhs: Vector4) -> Vector4 {
@@ -927,14 +927,14 @@ impl std::ops::Sub for Vector4 {
         unsafe { crate::Vector4Subtract(self, rhs) }
     }
 }
-impl std::ops::SubAssign for Vector4 {
+impl core::ops::SubAssign for Vector4 {
     #[inline]
     fn sub_assign(&mut self, rhs: Vector4) {
         *self = *self - rhs;
     }
 }
 
-impl std::ops::Mul<f32> for Vector4 {
+impl core::ops::Mul<f32> for Vector4 {
     type Output = Vector4;
     #[inline]
     fn mul(self, rhs: f32) -> Vector4 {
@@ -942,14 +942,14 @@ impl std::ops::Mul<f32> for Vector4 {
         unsafe { crate::Vector4Scale(self, rhs) }
     }
 }
-impl std::ops::MulAssign<f32> for Vector4 {
+impl core::ops::MulAssign<f32> for Vector4 {
     #[inline]
     fn mul_assign(&mut self, rhs: f32) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Mul<Vector4> for Vector4 {
+impl core::ops::Mul<Vector4> for Vector4 {
     type Output = Vector4;
     #[inline]
     fn mul(self, rhs: Vector4) -> Vector4 {
@@ -958,7 +958,7 @@ impl std::ops::Mul<Vector4> for Vector4 {
     }
 }
 
-impl std::ops::Div<Vector4> for Vector4 {
+impl core::ops::Div<Vector4> for Vector4 {
     type Output = Vector4;
     #[inline]
     fn div(self, rhs: Vector4) -> Vector4 {
@@ -967,7 +967,7 @@ impl std::ops::Div<Vector4> for Vector4 {
     }
 }
 
-impl std::ops::Neg for Vector4 {
+impl core::ops::Neg for Vector4 {
     type Output = Vector4;
     #[inline]
     fn neg(self) -> Vector4 {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,4 +4,5 @@
 [toolchain]
 channel = "1.85.0"
 components = ["rustfmt", "clippy"]
-targets = ["wasm32-unknown-emscripten"]
+# thumbv7em-none-eabihf: no-std proof target for raylib-sys (check.yml `no-std` job)
+targets = ["wasm32-unknown-emscripten", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
Closes #251, adapted for 6.0 — with thanks to @nbe1233 for the original patch (co-authored on the adopting commit).

Makes `raylib-sys` unconditionally `#![no_std]`. Spec: `docs/superpowers/specs/2026-06-06-raylib-sys-no-std-design.md` (queue item 18, queued via #307).

**What changed vs #251** (it predates 6.0): unconditional `#![no_std]` instead of a `std` feature + `default` split (nothing in the lib needs std, so the feature would gate nothing); bindgen 0.72.1 `.use_core()` with a verified before/after regen diff (token-identical after path-prefix normalization); the post-WS2a raymath wrapper files swept `std::ops` → `core::ops`.

**Compatibility:** zero feature/Cargo.toml changes. std consumers and `default-features = false` users see no semantic change. `mint` is no-std-clean (CI-proven); `glam`/`serde` currently require a std-capable target (documented; relaxation is future work).

**Proof leg:** new `no-std` job in check.yml — host-generates the binding (`nobuild`, bindgen only, no C compile; located via cargo's build-script JSON message), then `cargo check -p raylib-sys --target thumbv7em-none-eabihf --no-default-features --features nobuild,nobindgen` (+ a `,mint` variant). Verified able-to-fail locally (std canary → E0433). `nobuild` bindings are generated with `layout_tests(false)` so a host-generated binding can be compile-checked cross-target (the layout asserts hardcode host pointer widths); hosted default builds keep layout tests.

**Fixed in passing** (found while wiring the proof leg):
- `nobindgen` now actually skips bindgen in build.rs (previously it ran and discarded the output).
- `nobuild` bindgen couldn't find `raylib.h`: `-I../raylib/src` resolved outside the package (build-script CWD = package root) — broken on any host without a system raylib, likely including docs.rs (`features = ["nobuild"]`). Now `-Iraylib/src` (the vendored submodule).
- Stale `cargo:rerun-if-changed=/usr/include/raylib.h` under `nobuild` (missing file = rerun every build).

**Maintainer follow-ups:** merge #307 (docs-only queue entry) or say the word and I fold it in; if you add `no-std` to the required checks, remember the ruleset (id 17203815) must be updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
