### PR TITLE
fix(raylib)!: wrapper soundness - remove safe &mut ffi access (resolves #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@
   `nobuild` bindings are generated without bindgen layout assertions so they
   can be compile-checked cross-target; hosted default builds keep them.
 
+### Breaking
+
+- **Wrapper soundness (resolves [#276](https://github.com/raylib-rs/raylib-rs/issues/276), supersedes #277 by @AmityWilder):**
+  `DerefMut`/`AsMut<ffi::T>` are removed from wrappers whose safe API trusts
+  raw fields — `Image`, `Mesh`, `Model`, `Material`, `Font`, `Shader`,
+  `ModelAnimation`, their `Weak*` variants, `FilePathList`,
+  `DroppedFilePathList`, `Wave`, `Sound`, `Music`, `AudioStream` (read access
+  via `Deref`/`AsRef` is unchanged). Raw mutation is now
+  `unsafe fn as_raw_mut()` (new `AsRawMut` trait, in the prelude). New safe
+  setters cover the common cases: `RaylibMaterial::set_shader`,
+  `set_map_color`, `set_map_value`. `ImageColors`/`ImagePalette` no longer
+  expose `&mut Box<[Color]>` (use `as_mut_slice`). `Texture2D`,
+  `RenderTexture2D`, `VrStereoConfig` and other inline-data wrappers keep the
+  full deref family — every classification is documented as a `// SOUNDNESS:`
+  comment at its `make_thin_wrapper!` call site. `RSliceGlyphInfo` likewise
+  only exposes elements via `as_mut_slice`. `update_model_animation`/
+  `update_model_animation_ex` now take `impl AsRef<ffi::Model>` (they pass
+  the model by value to C). Additional safe setters: `RaylibMaterial::clear_shader`,
+  `Music::set_looping`.
+
 ### Changed
 
 - **MSRV raised 1.85 → 1.88.** Driver: transitive deps now require newer

--- a/docs/superpowers/notes/wrapper-soundness-complete.md
+++ b/docs/superpowers/notes/wrapper-soundness-complete.md
@@ -1,0 +1,57 @@
+# Wrapper-soundness refactor — done-note (queue item 17)
+
+**Date:** 2026-06-07 · **Spec:** `docs/superpowers/specs/2026-06-06-wrapper-soundness-design.md`
+**Resolves:** #276 · **Supersedes:** PR #277 (analysis by @AmityWilder, credited)
+
+## What landed
+
+- `AsRawMut<T>` trait (`unsafe fn as_raw_mut`) + `readonly` mode on
+  `make_thin_wrapper!`/`make_thin_wrapper_lifetime!` (Deref/AsRef kept, mut
+  half removed); `make_rslice!` no longer exposes the `Box` mutably
+  (`as_mut_slice` exposes elements only).
+- 19 wrappers reclassified `readonly` (P1: slice accessors trust counts;
+  P2: Drop frees pointers): Model/Mesh/Material/ModelAnimation + Weaks,
+  Image, Font/WeakFont, Shader/WeakShader, FilePathList ×2,
+  Wave/Sound/Music/AudioStream. 8 kept full deref (inline-data/GPU-id
+  only). Every macro call site carries a `// SOUNDNESS:` comment — the
+  diffable audit artifact.
+- Six accessor traits rebound `AsMut<ffi::T>` → `AsRawMut<ffi::T>`;
+  ~32 internal sites converted to documented `unsafe` blocks.
+- New safe setters: `RaylibMaterial::{set_shader, clear_shader,
+  set_map_color, set_map_value}`, `Music::set_looping`; showcase also
+  adopted the pre-existing `set_material_texture` for whole-texture
+  installs. Showcase `as_raw_mut` census: 61 → 34 lines; the remainder
+  are genuine raw-pointer work (lightmap texcoords2 install, custom CPU
+  bone-blend, texture-id zeroing to defeat double-free).
+- compile_fail doctests prove `mesh.vertexCount += 5` and
+  `sound.stream.buffer = null` no longer compile.
+
+## Found-and-fixed along the way
+
+- `update_model_animation{,_ex}` took `impl AsMut<ffi::Model>` — became
+  uncallable after the readonly switch (caught by its own doctest in
+  review); both only pass the model BY VALUE to C → bounds relaxed to
+  `AsRef`.
+- **`RSliceGlyphInfo`** was a third, hand-written rslice with the same
+  `mem::take` double-free the generated rslices lost — missed by the
+  audit (it only enumerated `make_rslice!` outputs). Same fix applied.
+- **Stale WS6 claim corrected:** `ws6b-complete.md` says #277's unsound
+  `Sound` impls were folded in WS6 — they were NOT present-tense true on
+  `unstable` (likely lost in the WS3 audio-lifetime redesign). Sound is
+  now readonly like the rest of the audio family.
+
+## Future work seeded
+
+- `impl_rslice!`'s `as_mut_slice` hardcodes `&mut [ffi::Color]` — correct
+  for both current users; any future non-Color rslice hits an immediate
+  compile error. Generalize by emitting the method from `make_rslice!`
+  (where the element type is in scope) if a third generated rslice appears.
+- The `Weak*` types still implement the full accessor traits; a future
+  ergonomics pass could consider whether `WeakShader`'s mutating uniform
+  uploads should require the owning `Shader`.
+
+## Verification
+
+5 clippy `-D warnings` legs, 193 nextest tests, 149 doctests
+(incl. 5 compile_fail), fmt, Tier-2 `material_setters_roundtrip` under
+`software_renderer` — all green locally; CI 28/28 expected on the PR.

--- a/docs/superpowers/plans/2026-06-06-wrapper-soundness.md
+++ b/docs/superpowers/plans/2026-06-06-wrapper-soundness.md
@@ -1,0 +1,536 @@
+# Wrapper-Soundness Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unsound `DerefMut`/`AsMut<ffi::T>` surface from wrappers whose safe APIs trust raw fields (issue #276), replacing it with an `unsafe` raw accessor + targeted safe setters — per the audit classification, with `// SOUNDNESS:` comments at every macro call site.
+
+**Architecture:** New `AsRawMut<T>` trait (`unsafe fn as_raw_mut`) emitted by a new `readonly` macro mode that keeps `Deref`/`AsRef` but drops `DerefMut`/`AsMut`. The six accessor traits bounded on `AsMut<ffi::T>` over unsound types rebind to `AsRawMut<ffi::T>`; their default methods wrap raw access in `unsafe` blocks whose invariants they themselves uphold. Three new safe setters on `RaylibMaterial` absorb ~52 of the ~53 external write sites.
+
+**Tech Stack:** Rust 1.88, macro_rules, compile_fail doctests, nextest + software_renderer Tier-2.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-wrapper-soundness-design.md` (classification table + audit evidence)
+**Branch:** `feat/wrapper-soundness` (off `unstable`, spec committed). PR base: `unstable`, resolves #276, credit @AmityWilder (#277).
+
+**Environment notes:**
+- Windows host, PowerShell. `cargo fmt -p <crate>` before commits (not `--all` in worktrees). Stage files explicitly, never `git add -A`.
+- If executing in the main checkout (current setup), branch is already checked out. If a subagent runs a task: verify `git branch --show-current` = `feat/wrapper-soundness` before committing (memory: subagent-worktree-cwd-trap).
+- CI commands verbatim (memory: plan-clippy-vs-ci-command-divergence). The five clippy legs: see Task 7.
+- Expect Tasks 2–3 to be compiler-driven: Task 2 intentionally breaks compilation; Task 3 fixes ALL of it by the stated rules before anything is committed (Tasks 2+3 land as one commit).
+
+---
+
+### Task 1: `AsRawMut` trait + `readonly` macro mode + rslice mut-half removal
+
+**Files:**
+- Modify: `raylib/src/core/macros.rs`
+- Modify: `raylib/src/core/mod.rs` (re-export)
+
+- [ ] **Step 1: Add the `AsRawMut` trait at the top of `macros.rs`** (before `make_thin_wrapper!`):
+
+```rust
+/// Escape-hatch mutable access to a wrapper's raw FFI value.
+///
+/// Implemented by every thin wrapper. For wrappers classified *sound*
+/// (see the per-type `// SOUNDNESS:` comments at the `make_thin_wrapper!`
+/// call sites) this duplicates `AsMut`; for *readonly* wrappers it is the
+/// only mutable access to the raw struct — and it is `unsafe`, because
+/// the wrapper's safe API trusts invariants of the raw fields (issue #276).
+pub trait AsRawMut<T> {
+    /// Mutable access to the wrapped raw FFI value.
+    ///
+    /// # Safety
+    ///
+    /// Callers must uphold the wrapper's invariants:
+    /// - do **not** corrupt count/dimension/format fields that safe
+    ///   accessors use to derive slice lengths or buffer sizes (e.g.
+    ///   `Mesh::vertexCount`, `Image::width`/`height`/`format`), and
+    /// - do **not** reassign pointer fields that are owned and freed by
+    ///   `Drop` (e.g. `Model::meshes`, `Font::glyphs`), unless you take
+    ///   over ownership of the previous allocation.
+    unsafe fn as_raw_mut(&mut self) -> &mut T;
+}
+```
+
+Note: `macros.rs` holds `macro_rules!` only today — if it is included via `#[macro_use] mod macros;` the trait can still live there, but it must be re-exported. Check `raylib/src/core/mod.rs` for how `macros` is declared; add `pub use macros::AsRawMut;` (or define the trait directly in `core/mod.rs` if `macros` is `#[macro_use]`-only without a normal module path — in that case put the trait in `core/mod.rs` right after the module declarations and adjust the macro bodies to name it as `crate::core::AsRawMut`). Also re-export it from `prelude` (find `raylib/src/prelude.rs` and add it alongside the other trait exports) so trait-method calls resolve for users.
+
+- [ ] **Step 2: Add the `readonly` arm to `make_thin_wrapper!`**
+
+After the existing `true` arm, add:
+
+```rust
+    ($(#[$attrs:meta])* $name:ident, $t:ty, $dropfunc:expr, readonly) => {
+        $(#[$attrs])*
+        #[repr(transparent)]
+        #[derive(Debug)]
+        #[allow(missing_docs)]
+        pub struct $name(pub(crate) $t);
+
+        impl_wrapper!($name, $t, $dropfunc, 0);
+        readonly_deref_impl_wrapper!($name, $t, $dropfunc, 0);
+        gen_from_raw_wrapper!($name, $t, $dropfunc, 0);
+    };
+```
+
+And the matching arm in `make_thin_wrapper_lifetime!` after its `true` arm:
+
+```rust
+    ($(#[$attrs:meta])* $name:ident, $t1:ty, $t2:ty, $dropfunc:expr, readonly) => {
+        $(#[$attrs])*
+        #[derive(Debug)]
+        #[allow(missing_docs)]
+        pub struct $name<'a>(pub(crate) $t1, &'a $t2);
+
+        impl_wrapper!($name<'a>, $t1, $dropfunc, 0);
+        readonly_deref_impl_wrapper!($name<'a>, $t1, $dropfunc, 0);
+    };
+```
+
+- [ ] **Step 3: Add `readonly_deref_impl_wrapper!`** (next to `deref_impl_wrapper!`):
+
+```rust
+/// Internal helper. Read half of the deref family only (`Deref` +
+/// `AsRef`), plus the `unsafe` [`AsRawMut`] escape hatch. Used by the
+/// `readonly` wrapper mode for types whose safe API trusts raw fields
+/// (issue #276) — see the `// SOUNDNESS:` comment at each call site.
+macro_rules! readonly_deref_impl_wrapper {
+    ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
+        impl$(<$lifetime>)? std::convert::AsRef<$t> for $name$(<$lifetime>)? {
+            fn as_ref(&self) -> &$t {
+                &self.$rawfield
+            }
+        }
+
+        impl$(<$lifetime>)? std::ops::Deref for $name$(<$lifetime>)? {
+            type Target = $t;
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                &self.$rawfield
+            }
+        }
+
+        impl$(<$lifetime>)? crate::core::AsRawMut<$t> for $name$(<$lifetime>)? {
+            unsafe fn as_raw_mut(&mut self) -> &mut $t {
+                &mut self.$rawfield
+            }
+        }
+    };
+}
+```
+
+- [ ] **Step 4: Emit `AsRawMut` from the full mode too** (uniformity — sound types get it as a redundant-but-harmless alias). Append to `deref_impl_wrapper!`'s expansion:
+
+```rust
+        impl$(<$lifetime>)? crate::core::AsRawMut<$t> for $name$(<$lifetime>)? {
+            unsafe fn as_raw_mut(&mut self) -> &mut $t {
+                &mut self.$rawfield
+            }
+        }
+```
+
+- [ ] **Step 5: rslice mut-half removal.** In `impl_rslice!`, delete the `AsMut<$t>` and `DerefMut` impls and add a safe element accessor:
+
+```rust
+        impl $name {
+            /// Mutable access to the elements. The `Box` itself is not
+            /// exposed (replacing it would free the raylib-owned buffer
+            /// through the global allocator — see issue #276).
+            #[inline]
+            pub fn as_mut_slice(&mut self) -> &mut [Color] {
+                &mut self.$rawfield
+            }
+        }
+```
+
+NOTE: `$t` in `impl_rslice!` is `Box<[Color]>`; `&mut self.0` where `self.0: ManuallyDrop<Box<[Color]>>` derefs to `&mut [Color]` via auto-deref — if inference complains, use `&mut self.$rawfield[..]`. The element type is always `Color` for both current rslices; if a future rslice uses another element type, generalize to `&mut [$elem]` by threading the element type through `make_rslice!` (it already receives it as `$t` there — pass it down).
+
+- [ ] **Step 6: Compile check** — Run: `cargo check -p raylib`
+Expected: errors are acceptable ONLY if they come from `ImageColors`/`ImagePalette` users of the removed mut surface (audit says zero) — i.e. expected: PASS. The `readonly` arms are not yet used by any call site.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+cargo fmt -p raylib
+git add raylib/src/core/macros.rs raylib/src/core/mod.rs raylib/src/prelude.rs
+git commit -m @'
+feat(raylib): AsRawMut trait + readonly wrapper mode (issue #276 groundwork)
+
+readonly emits Deref/AsRef + an unsafe as_raw_mut escape hatch instead
+of the full deref family; rslices drop the Box-exposing mut half (which
+allowed mem::take -> double free) in favor of a safe as_mut_slice.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 2: Reclassify every call site with `// SOUNDNESS:` comments
+
+**Files:** `raylib/src/core/{models,texture,text,shaders,file,audio,vr,automation}.rs`
+
+For each row, change the macro's trailing mode and add the `// SOUNDNESS:` comment line **directly above the macro invocation**. Sites without a trailing arg currently default to `true` — readonly sites must gain an explicit `, readonly`, sound sites stay as-is (add `, true` only if you must touch the line anyway; otherwise leave). The classification and the comments (verbatim):
+
+| Site | New mode | `// SOUNDNESS:` comment |
+|---|---|---|
+| `models.rs:23` `Model` | `readonly` | `// SOUNDNESS: readonly — P1 (meshes/materials/bones slices trust meshCount/materialCount/boneCount) + P2 (Drop=UnloadModel frees meshes/materials/skeleton arrays).` |
+| `models.rs:59` `WeakModel` | `readonly` | `// SOUNDNESS: readonly — P1 (same RaylibModel slice accessors); no_drop removes P2.` |
+| `models.rs:60` `Mesh` | `readonly` | `// SOUNDNESS: readonly — P1 (vertices/normals/etc. slices trust vertexCount/triangleCount) + P2 (Drop=UnloadMesh frees every pointer field).` |
+| `models.rs:92` `WeakMesh` | `readonly` | `// SOUNDNESS: readonly — P1 (same RaylibMesh slice accessors); no_drop removes P2.` |
+| `models.rs:105` `WeakMaterial` | `readonly` | `// SOUNDNESS: readonly — P1 (maps slice trusts the maps pointer); no_drop removes P2.` |
+| `models.rs:106` `Material` | `readonly` | `// SOUNDNESS: readonly — P1 (maps slice trusts the maps pointer) + P2 (Drop=UnloadMaterial frees maps).` |
+| `models.rs:112` (`BoneInfo`) | keep `true` | `// SOUNDNESS: full deref — inline name[32]/parent only; no trusted counts, no owned pointers.` |
+| `models.rs:118` `WeakModelAnimation` | `readonly` | `// SOUNDNESS: readonly — P1 (keyframe accessors trust framePoses/frameCount); no_drop removes P2.` |
+| `models.rs:119` `ModelAnimation` | `readonly` | `// SOUNDNESS: readonly — P1 (keyframe accessors trust framePoses/frameCount); freed by the owning ModelAnimations, not this wrapper.` |
+| `texture.rs:61` (`Image`) | `readonly` | `// SOUNDNESS: readonly — P1 (pixel readers trust width/height/format to size data) + P2 (Drop=UnloadImage frees data).` |
+| `texture.rs:92` (`Texture2D`) | keep `true` | `// SOUNDNESS: full deref — inline id/width/height/mipmaps/format; corrupting them confuses raylib C-side only, no Rust-side UB.` |
+| `texture.rs:119` `WeakTexture2D` | keep `true` | `// SOUNDNESS: full deref — same inline-only fields as Texture2D.` |
+| `texture.rs:126` (`RenderTexture2D`) | keep `true` | `// SOUNDNESS: full deref — id + two inline Texture structs; no trusted counts, no owned CPU pointers.` |
+| `texture.rs:161` `WeakRenderTexture2D` | keep `true` | `// SOUNDNESS: full deref — same inline-only fields as RenderTexture2D.` |
+| `text.rs:16` (`Font`) | `readonly` | `// SOUNDNESS: readonly — P1 (chars slice trusts glyphs×glyphCount) + P2 (Drop=UnloadFont frees recs/glyphs).` |
+| `text.rs:53` `WeakFont` | `readonly` | `// SOUNDNESS: readonly — P1 (same RaylibFont accessors); no_drop removes P2.` |
+| `text.rs:54` (`GlyphInfo`) | keep `true` | `// SOUNDNESS: full deref — inline scalars + inline Image value; this wrapper neither sizes nor frees the image data.` |
+| `shaders.rs:12` (`Shader`) | `readonly` | `// SOUNDNESS: readonly — P1 (locs slice trusts the locs pointer) + P2 (Drop=UnloadShader frees locs).` |
+| `shaders.rs:54` `WeakShader` | `readonly` | `// SOUNDNESS: readonly — P1 (same locs accessor); no_drop removes P2.` |
+| `file.rs:142` `FilePathList` | `readonly` | `// SOUNDNESS: readonly — P1 (paths slice trusts paths×count) + P2 (Drop=UnloadDirectoryFiles frees paths and each string).` |
+| `file.rs:143` `DroppedFilePathList` | `readonly` | `// SOUNDNESS: readonly — P1/P2 like FilePathList (Drop=UnloadDroppedFiles).` |
+| `audio.rs:13` (`Wave`) | `readonly` | `// SOUNDNESS: readonly — P2 (Drop=UnloadWave frees data); no Rust-side slice trusts frameCount.` |
+| `audio.rs:27` (`Sound`) | `readonly` | `// SOUNDNESS: readonly — P2 (Drop=UnloadSound frees stream.buffer/processor). Closes the gap #277 originally targeted.` |
+| `audio.rs:54` (`Music`) | `readonly` | `// SOUNDNESS: readonly — P2 (Drop=UnloadMusicStream frees stream + ctxData).` |
+| `audio.rs:69` (`AudioStream`) | `readonly` | `// SOUNDNESS: readonly — P2 (Drop=UnloadAudioStream frees buffer/processor).` |
+| `vr.rs:5` (`VrStereoConfig`) | keep `true` | `// SOUNDNESS: full deref — all fields inline Matrix/f32 arrays; nothing to invalid-free, no trusted counts.` |
+| `automation.rs:94/136` | keep `false` | `// SOUNDNESS: opted out (false) — hand-written accessor surface; nothing raw leaks.` |
+| `texture.rs:14/15` rslices | (Task 1 handled) | `// SOUNDNESS: rslice — Box mut-half removed (mem::take would double-free); element access via as_mut_slice.` |
+
+(For wrappers where the macro spans multiple lines with doc attrs, the mode token goes where `true`/`false` would: after the drop fn. For `MaterialMap` — if it exists as a separate call site inside models.rs not listed above, classify `true` with the inline-fields comment; the audit found it SOUND.)
+
+- [ ] **Step 1:** Apply the table.
+- [ ] **Step 2:** Run `cargo check -p raylib 2>&1 | Select-String 'error\[' | Measure-Object -Line` — expect a sizeable error count (trait bounds + internal `as_mut()` uses). This is the intentionally-broken midpoint. **Do not commit** — Task 3 completes the change.
+
+---
+
+### Task 3: Trait-bound migration + internal sweep (completes Task 2's commit)
+
+**Files:** `raylib/src/core/{models,text,shaders,texture,databuf}.rs` (+ any file the compiler flags)
+
+- [ ] **Step 1: Rebind the six unsound-type traits.** Pattern (worked example, `models.rs:982`):
+
+```rust
+// before
+pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
+// after
+pub trait RaylibMaterial: AsRef<ffi::Material> + crate::core::AsRawMut<ffi::Material> {
+```
+
+Apply identically to: `RaylibModel` (models.rs:384), `RaylibMesh` (models.rs:608), `RaylibModelAnimation` (models.rs:1283), `RaylibFont` (text.rs:370), `RaylibShader` (shaders.rs:396). **Leave `RaylibTexture2D` and `RaylibRenderTexture2D` alone** (sound types keep `AsMut`).
+
+- [ ] **Step 2: Convert default-method bodies.** Rule for every `self.as_mut()` inside the six rebound traits (and any inherent impl on a readonly wrapper):
+  - If already inside an `unsafe` block/fn: change to `self.as_raw_mut()` and extend the existing `// SAFETY:` comment (or add one) with: `raw mut access: this method upholds the wrapper invariants itself (no count/pointer corruption).`
+  - If in safe code (e.g. `Model::set_transform` at models.rs:413): use direct field access `self.0` for inherent impls on the concrete wrapper, or wrap in `unsafe { self.as_raw_mut() }` with the SAFETY comment for trait default methods. Worked examples:
+
+```rust
+// shader_mut (models.rs:992) — already unsafe-transmute body:
+fn shader_mut(&mut self) -> &mut crate::shaders::WeakShader {
+    // SAFETY: transmuting the inline shader field; raw mut access cannot
+    // corrupt maps (the only trusted pointer) — invariants upheld.
+    unsafe { std::mem::transmute(&mut self.as_raw_mut().shader) }
+}
+
+// set_material_texture (models.rs:1020):
+fn set_material_texture(
+    &mut self,
+    map_type: crate::consts::MaterialMapIndex,
+    texture: impl AsRef<ffi::Texture2D>,
+) {
+    // SAFETY: SetMaterialTexture writes one map's texture handle; counts
+    // and owned pointers are untouched.
+    unsafe {
+        ffi::SetMaterialTexture(self.as_raw_mut(), (map_type as u32) as i32, *texture.as_ref())
+    }
+}
+
+// Model::set_transform (models.rs:413) — inherent on the trait; keep safe:
+fn set_transform(&mut self, mat: &Matrix) {
+    // SAFETY: transform is an inline Matrix — not a trusted count or owned pointer.
+    unsafe { self.as_raw_mut().transform = (*mat).into(); }
+}
+```
+
+(Adjust the exact bodies to the existing code — the *rule* is fixed: every raw-mut touch sits in `unsafe` with a SAFETY line asserting which invariant class it cannot violate.)
+
+- [ ] **Step 3: Compiler-driven sweep to green.** Iterate `cargo check -p raylib` and apply the Step-2 rule to every remaining error (31 known `self.as_mut()` sites across models/text/texture/shaders/databuf; plus any `&mut *wrapper` deref-mut uses the compiler flags). HARD RULE: never restore `AsMut`/`DerefMut` on a readonly type; never add `allow` attributes; if a site genuinely cannot satisfy the rule, STOP and report BLOCKED.
+Run: `cargo check -p raylib` → expected PASS.
+Run: `cargo nextest run -p raylib` → expected PASS (audit: no test write-sites).
+
+- [ ] **Step 4: Commit (Tasks 2+3 together — the tree is only green now):**
+
+```powershell
+cargo fmt -p raylib
+git add raylib/src/core/models.rs raylib/src/core/texture.rs raylib/src/core/text.rs raylib/src/core/shaders.rs raylib/src/core/file.rs raylib/src/core/audio.rs raylib/src/core/vr.rs raylib/src/core/automation.rs raylib/src/core/databuf.rs
+git commit -m @'
+fix(raylib)!: remove safe &mut ffi access where wrapper invariants forbid it
+
+Resolves #276; supersedes PR #277 (analysis by AmityWilder). Per-type
+audit: wrappers whose safe accessors trust count/dim/pointer fields
+(P1) or whose Drop frees pointer fields (P2) move to the readonly mode
+(Deref/AsRef + unsafe as_raw_mut); inline-data/GPU-id wrappers keep the
+full deref family. Every macro call site carries a SOUNDNESS comment
+recording its classification. The six accessor traits over unsound
+types rebind AsMut -> AsRawMut; their methods uphold the invariants
+inside documented unsafe blocks.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 4: `RaylibMaterial` safe setters + tests
+
+**Files:**
+- Modify: `raylib/src/core/models.rs` (inside `trait RaylibMaterial`)
+- Test: `raylib/tests/integration_models.rs` (or a new `raylib/tests/material_setters.rs` following the existing Tier-2 `with_headless` pattern — copy the harness usage from `raylib/tests/render_shapes.rs`)
+
+- [ ] **Step 1: Add the setters** (after `maps_mut` in the trait):
+
+```rust
+    /// Replace the material's shader.
+    ///
+    /// Copies the shader's inline FFI struct into the material — the same
+    /// semantics as raylib C's `material.shader = shader`. The [`Shader`]
+    /// wrapper keeps ownership of the shader (and frees it on drop), so it
+    /// must outlive every use of this material.
+    ///
+    /// [`Shader`]: crate::shaders::Shader
+    #[inline]
+    fn set_shader(&mut self, shader: impl AsRef<ffi::Shader>) {
+        // SAFETY: shader is an inline value field — writing it cannot
+        // corrupt the maps pointer (the only field the safe API trusts).
+        unsafe {
+            self.as_raw_mut().shader = *shader.as_ref();
+        }
+    }
+
+    /// Set one material map's color (e.g. albedo tint).
+    ///
+    /// # Panics
+    /// Never — `index` is an enum bounded by `MAX_MATERIAL_MAPS`.
+    #[inline]
+    fn set_map_color(&mut self, index: crate::consts::MaterialMapIndex, color: impl Into<ffi::Color>) {
+        self.maps_mut()[index as usize].color = color.into();
+    }
+
+    /// Set one material map's scalar value (e.g. metalness/roughness).
+    #[inline]
+    fn set_map_value(&mut self, index: crate::consts::MaterialMapIndex, value: f32) {
+        self.maps_mut()[index as usize].value = value;
+    }
+```
+
+(`MaterialMap` keeps full deref — sound — so field assignment through `maps_mut()`'s `&mut [MaterialMap]` compiles. If `color` field types disagree (`Color` wrapper vs `ffi::Color`), adapt with the crate's existing conversion — both are `repr(C)`-identical; check how neighboring code assigns map colors.)
+
+- [ ] **Step 2: Tier-2 test** (software_renderer; follow the `with_headless` pattern used by existing Tier-2 tests — check `raylib/src/test_harness.rs` usage in `render_shapes.rs`):
+
+```rust
+//! Tier-2: Material safe-setter round-trips (issue #276 follow-up).
+#![cfg(feature = "software_renderer")]
+
+// (copy the exact harness imports/setup from raylib/tests/render_shapes.rs)
+
+#[test]
+fn material_setters_roundtrip() {
+    with_headless(|rl, thread| {
+        let mut mat = rl.load_material_default(thread);
+        let shader_before = mat.shader().id;
+
+        mat.set_map_color(
+            raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO,
+            raylib::prelude::Color::RED,
+        );
+        mat.set_map_value(raylib::consts::MaterialMapIndex::MATERIAL_MAP_METALNESS, 0.5);
+
+        let maps = mat.maps();
+        assert_eq!(maps[raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO as usize].color.r, 255);
+        assert_eq!(maps[raylib::consts::MaterialMapIndex::MATERIAL_MAP_METALNESS as usize].value, 0.5);
+        // set_shader with the material's own current shader is identity-safe:
+        let weak = *mat.shader();
+        mat.set_shader(&weak);
+        assert_eq!(mat.shader().id, shader_before);
+    });
+}
+```
+
+(Adapt names — `load_material_default`'s exact receiver/signature, `with_headless`'s shape, and field paths must match the real harness; the assertions are the contract. If `set_shader(&weak)` trips a type mismatch, use the form the trait accepts: anything `AsRef<ffi::Shader>` — `WeakShader` implements it.)
+
+- [ ] **Step 3: Run** the Tier-2 command verbatim:
+`cargo nextest run -p raylib --no-default-features --features software_renderer,SUPPORT_MODULE_RTEXTURES,SUPPORT_MODULE_RSHAPES,SUPPORT_MODULE_RTEXT,SUPPORT_MODULE_RMODELS,SUPPORT_MODULE_RAUDIO,SUPPORT_IMAGE_GENERATION,SUPPORT_MESH_GENERATION -E 'binary(material_setters)'`
+Expected: PASS (and confirm the test RAN, not filtered out — pitfall: feature-gated silent skip).
+
+- [ ] **Step 4: Commit**
+
+```powershell
+cargo fmt -p raylib
+git add raylib/src/core/models.rs raylib/tests/material_setters.rs
+git commit -m @'
+feat(raylib): RaylibMaterial::set_shader / set_map_color / set_map_value
+
+Safe setters for the legitimate material mutations the readonly mode
+removed: shader assignment copies the inline FFI struct (documented
+aliasing: the Shader wrapper keeps ownership), map color/value write
+through the bounds-safe maps_mut slice. Tier-2 round-trip test.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 5: Showcase conversion sweep
+
+**Files:** the ~30 showcase example files listed in the audit (see spec; canonical list below).
+
+Conversion rules:
+1. `<material>.as_mut().shader = *<shader>` / `<material>.shader = …` / `materials_mut()[i].as_mut().shader = …` → `materials_mut()[i].set_shader(&<shader>)` (or `.set_shader(<shader>.as_ref())` where a `&ffi::Shader` is in hand). Sites: models_loading_vox.rs:201, models_skybox_rendering.rs:79, models_animation_blend_custom.rs:355, models_animation_gpu_skinning.rs:68, shaders_basic_pbr.rs:256/324/603/607, shaders_cel_shading.rs:145/203/205/263/268/270/327, shaders_deferred_rendering.rs:286/287/630/634, shaders_fog_rendering.rs:202-204/302/306/310, shaders_mesh_instancing.rs:184/270, shaders_normalmap_rendering.rs:103, shaders_shadowmap_rendering.rs:204/210/367/373, shaders_simple_mask.rs:132/133, shaders_texture_tiling.rs:84, shaders_vertex_displacement.rs:86/138.
+2. `unsafe { (*mat.maps.offset(i)).color = c }`-style raw map writes → `mat.set_map_color(<index enum>, c)` / `.set_map_value(<index>, v)`, dropping the `unsafe` block if nothing else needs it. Sites: shaders_basic_pbr.rs:261/299/328/362/615/636, shaders_custom_uniform.rs:65/169, shaders_fog_rendering.rs:142/147/152/318, shaders_model_shader.rs:75/133, shaders_normalmap_rendering.rs:261, shaders_simple_mask.rs:213, shaders_texture_tiling.rs:140.
+3. The mesh pointer install (shaders_lightmap_rendering.rs:69): keep the existing `unsafe` block, change the access to `mesh.as_raw_mut().texcoords2 = …` (needs `use raylib::core::AsRawMut;` or the prelude import).
+4. RenderTexture2D `target.texture.width = …` writes (shaders_depth_rendering.rs:64-73, shaders_depth_writing.rs:65+): NO change — RenderTexture2D keeps DerefMut.
+5. Raw `ffi::Mesh` construction (models_mesh_generation.rs etc.): NO change — they mutate the raw struct before wrapping.
+6. Line numbers are from the 2026-06-06 audit on `unstable` — verify each with the compiler: the authoritative worklist is whatever `cargo clippy -p raylib-showcase --examples -- -D warnings` flags after Tasks 1–4.
+
+**Style note (memory: showcase-c-rust-port-style):** ports mirror the C example line-for-line; keep the conversion minimal — same line position, same surrounding comments. `set_shader(&shader)` replacing `materials[0].shader = shader` is in the C spirit.
+
+- [ ] **Step 1:** Apply rules until both showcase clippy legs are green (verbatim):
+`cargo clippy -p raylib-showcase --examples -- -D warnings`
+`cargo clippy -p raylib-showcase --examples --features SUPPORT_CUSTOM_FRAME_CONTROL -- -D warnings`
+Expected: PASS, both. (Remember the second leg compiles an extra example.)
+
+- [ ] **Step 2:** `cargo nextest run -p raylib-showcase` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+cargo fmt -p raylib-showcase
+git add showcase/examples
+git commit -m @'
+refactor(showcase): material writes via the new safe setters
+
+set_shader / set_map_color / set_map_value replace as_mut() field
+writes and raw maps.offset() pokes; the one genuine raw-pointer install
+(lightmap texcoords2) uses the unsafe as_raw_mut escape hatch.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+(`git add showcase/examples` adds a directory of tracked modifications — acceptable here as the change is scoped to exactly that tree; verify with `git status --porcelain` that nothing unexpected is staged.)
+
+---
+
+### Task 6: compile_fail doctests, book sweep, CHANGELOG
+
+**Files:**
+- Modify: `raylib/src/core/models.rs` (Mesh call-site doc attr), `raylib/src/core/audio.rs` (Sound doc attr)
+- Modify: `book/src/**` (grep-driven), `CHANGELOG.md`
+
+- [ ] **Step 1: compile_fail doctests.** Add to the `Mesh` macro call site's doc comment (models.rs:60, inside the existing `///` block):
+
+```rust
+    /// Mutable access to the raw FFI struct is `unsafe` — corrupting the
+    /// counts the slice accessors trust is no longer possible in safe code:
+    ///
+    /// ```compile_fail
+    /// # use raylib::prelude::*;
+    /// fn corrupt(mesh: &mut Mesh) {
+    ///     mesh.vertexCount += 5; // no DerefMut on Mesh (issue #276)
+    /// }
+    /// ```
+```
+
+And to `Sound`'s doc block (audio.rs:27):
+
+```rust
+    /// ```compile_fail
+    /// # use raylib::prelude::*;
+    /// fn corrupt(sound: &mut Sound) {
+    ///     sound.stream.buffer = std::ptr::null_mut(); // no DerefMut on Sound (issue #276)
+    /// }
+    /// ```
+```
+
+(If `Sound<'_>`'s lifetime makes the signature awkward, `fn corrupt(sound: &mut Sound<'_>)`.)
+Run: `cargo test -p raylib --doc --features full` → expected PASS with the two compile_fail tests listed as passing.
+
+- [ ] **Step 2: Book sweep.** `Grep -r "as_mut" book/src` — for each hit on a readonly type, rewrite the snippet using the new setters or `unsafe as_raw_mut` with a sentence explaining why it's unsafe. If zero hits: state that in the commit message.
+
+- [ ] **Step 3: CHANGELOG** — under `## Unreleased`, add to `### Breaking` (create the subsection if absent, before `### Changed`):
+
+```markdown
+### Breaking
+
+- **Wrapper soundness (resolves [#276](https://github.com/raylib-rs/raylib-rs/issues/276), supersedes #277 by @AmityWilder):**
+  `DerefMut`/`AsMut<ffi::T>` are removed from wrappers whose safe API trusts
+  raw fields — `Image`, `Mesh`, `Model`, `Material`, `Font`, `Shader`,
+  `ModelAnimation`, their `Weak*` variants, `FilePathList`,
+  `DroppedFilePathList`, `Wave`, `Sound`, `Music`, `AudioStream` (read access
+  via `Deref`/`AsRef` is unchanged). Raw mutation is now
+  `unsafe fn as_raw_mut()` (new `AsRawMut` trait, in the prelude). New safe
+  setters cover the common cases: `RaylibMaterial::set_shader`,
+  `set_map_color`, `set_map_value`. `ImageColors`/`ImagePalette` no longer
+  expose `&mut Box<[Color]>` (use `as_mut_slice`). `Texture2D`,
+  `RenderTexture2D`, `VrStereoConfig` and other inline-data wrappers keep the
+  full deref family — every classification is documented as a `// SOUNDNESS:`
+  comment at its `make_thin_wrapper!` call site.
+```
+
+- [ ] **Step 4: Commit**
+
+```powershell
+cargo fmt -p raylib
+git add raylib/src/core/models.rs raylib/src/core/audio.rs CHANGELOG.md
+git commit -m @'
+docs: compile_fail proofs + CHANGELOG for wrapper soundness
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+'@
+```
+
+(Add any changed book files to the same commit.)
+
+---
+
+### Task 7: Full gates, push, PR
+
+- [ ] **Step 1: The five clippy legs + tests + doctests (verbatim):**
+
+```powershell
+cargo clippy -p raylib --lib --bins --features full -- -D warnings
+cargo clippy -p raylib-sys --features full -- -D warnings
+cargo clippy -p raylib --tests --no-default-features --features software_renderer,SUPPORT_MODULE_RTEXTURES,SUPPORT_MODULE_RSHAPES,SUPPORT_MODULE_RTEXT,SUPPORT_MODULE_RMODELS,SUPPORT_MODULE_RAUDIO,SUPPORT_IMAGE_GENERATION,SUPPORT_MESH_GENERATION,raygui -- -D warnings
+cargo clippy -p raylib-showcase --examples -- -D warnings
+cargo clippy -p raylib-showcase --examples --features SUPPORT_CUSTOM_FRAME_CONTROL -- -D warnings
+cargo nextest run -p raylib -p raylib-sys -p raylib-showcase
+cargo test -p raylib --doc --features full
+cargo fmt --all --check
+```
+
+All expected: exit 0.
+
+- [ ] **Step 2: Push + PR.** Write the body to `$env:TEMP\wrapper-soundness-pr.md` (mention: resolves #276, supersedes #277 with credit to @AmityWilder, the P1/P2 rule, the classification table pointer to the spec, the setters, breaking-change framing "rides 6.0.0 final"), then:
+
+```powershell
+git push -u origin feat/wrapper-soundness
+gh pr create --base unstable --title "fix(raylib)!: wrapper soundness - remove safe &mut ffi access (resolves #276)" --body-file "$env:TEMP\wrapper-soundness-pr.md"
+gh pr checks --watch
+```
+
+Expected: all 28 checks green.
+
+- [ ] **Step 3:** Done-note `docs/superpowers/notes/wrapper-soundness-complete.md`: the classification table as-landed, the trait-rebind pattern, fallout counts, the stale-WS6-Sound-claim correction, and any new future-work seeded. Commit to the PR branch before merge or as a follow-up docs commit.
+
+---
+
+## Done criteria (from the spec)
+
+- [ ] Readonly wrappers expose no safe `&mut ffi::T` (compile_fail-proven)
+- [ ] Every macro call site has a `// SOUNDNESS:` comment
+- [ ] All five clippy legs + tests + doctests green; CI 28/28
+- [ ] CHANGELOG Breaking entry; #276 closeable; @AmityWilder credited

--- a/docs/superpowers/specs/2026-06-06-wrapper-soundness-design.md
+++ b/docs/superpowers/specs/2026-06-06-wrapper-soundness-design.md
@@ -1,0 +1,123 @@
+# Wrapper-soundness refactor — design
+
+**Date:** 2026-06-06
+**Status:** approved (maintainer sign-off on the audit-first direction and this design, this session)
+**Queue:** post-release flexible-queue item 17 (full PR #277 refactor, from WS6 tracked-deferred)
+**Resolves:** issue #276 (`AsRef`/`AsMut` undermine safety); supersedes PR #277
+(AmityWilder) — adopt-with-attribution.
+
+## The unsoundness, precisely
+
+`deref_impl_wrapper!` gives every thin wrapper `Deref`/`DerefMut`/`AsRef`/`AsMut`
+to its raw FFI struct. The **mut half** is unsound exactly where the wrapper's
+safe API trusts raw fields for memory safety:
+
+- **(P1)** safe accessors build slices from count/dim/pointer fields
+  (`mesh.vertexCount += 5; mesh.vertices()` → OOB in safe code), or
+- **(P2)** `Drop` frees pointer fields (`model.meshes = p` → invalid free).
+
+If safe code can put a value into a state where other safe code commits UB,
+the API is unsound. The **read half** (`Deref`/`AsRef`) cannot violate these
+invariants and stays.
+
+This is deliberately **not** a blanket removal (what #277 did): types whose
+FFI structs hold only inline data or GPU ids (corrupting an id confuses
+raylib's C side but causes no Rust-side UB) keep full deref.
+
+## Classification (2026-06-06 audit; evidence file:line in the audit notes)
+
+| Verdict | Types |
+|---|---|
+| **readonly (P1+P2)** | `Image`, `Mesh`, `Model`, `Material`, `Font`, `Shader`, `FilePathList`, `DroppedFilePathList` |
+| **readonly (P1; `no_drop`)** | `WeakMesh`, `WeakModel`, `WeakMaterial`, `WeakFont`, `WeakShader`, `ModelAnimation`, `WeakModelAnimation` |
+| **readonly (P2 only)** | `Wave`, `Sound`, `Music`, `AudioStream` |
+| **rslice mut-half removed (P2)** | `ImageColors`, `ImagePalette` (`AsMut<Box<[T]>>` allows `mem::take` → the taken Box frees via the global allocator while `Drop` still calls `UnloadImage*`) |
+| **keep full deref (SOUND)** | `Texture2D`, `WeakTexture2D`, `RenderTexture2D`, `WeakRenderTexture2D`, `VrStereoConfig`, `BoneInfo`, `GlyphInfo`, `MaterialMap` |
+| **already opted out** | `AutomationEventList`, `AutomationEvent` |
+
+Audit surprises baked into this table:
+- `Sound` still has the full deref family — the WS6 note claiming #277's
+  Sound fix was folded is stale (likely lost in the WS3 audio redesign).
+- The `Weak*` family is the *live* unsound surface: showcase writes go
+  through `model.materials_mut()[0].as_mut().shader`.
+- `VrStereoConfig` is SOUND despite the `Unload*` drop fn — all fields are
+  inline `Matrix`/`f32`.
+
+## Mechanism
+
+1. **Third macro mode.** `make_thin_wrapper!` / `make_thin_wrapper_lifetime!`
+   gain a `readonly` mode (alongside `true`/`false`): emits `Deref` + `AsRef`
+   only, plus:
+
+   ```rust
+   /// # Safety
+   /// Callers must uphold the wrapper's invariants: do not corrupt
+   /// count/dimension/format fields that safe accessors trust (P1) and do
+   /// not reassign pointer fields owned and freed by `Drop` (P2).
+   pub unsafe fn as_raw_mut(&mut self) -> &mut ffi::T
+   ```
+
+2. **`make_rslice!`** drops the `Box`-exposing mut half (`AsMut<Box<[T]>>`
+   and `DerefMut<Target = Box<[T]>>` — those allow `mem::take`, the actual
+   P2). In their place: a safe `as_mut_slice(&mut self) -> &mut [T]`
+   exposing the *elements* but not the `Box` itself — element mutation
+   cannot corrupt the allocation. Reads keep `Deref`/`AsRef`. Zero current
+   users of the removed surface (audit-verified), so no fallout.
+
+3. **`// SOUNDNESS:` comments at every macro call site** stating the
+   classification and the one-line P1/P2 evidence (maintainer requirement;
+   makes the next audit diffable).
+
+4. **Safe setters** for legitimate mutations on locked types:
+   - `RaylibMaterial::set_shader(&Shader)` — same bitwise-copy semantics as
+     today's manual `material.shader = *shader` writes (~35 showcase sites).
+     Documented aliasing caveat: the `Shader` wrapper still owns `locs`; the
+     material holds a copy of the inline struct, so the shader must outlive
+     the material's use (pre-existing semantics, now documented).
+   - `RaylibMaterial::set_map_color(index, Color)` and
+     `set_map_value(index, f32)` — bounds-checked writes into the `maps`
+     array (~17 sites currently doing raw `maps.offset(i)` writes in ad-hoc
+     `unsafe` blocks become safe calls).
+   - `Model::set_transform` stays (reimplemented via `.0`).
+   - `Shader::locs_mut() -> &mut [i32]` stays — writing *into* the array is
+     safe; only pointer reassignment was the hazard.
+
+5. **Genuine raw cases** use `as_raw_mut()`: the `texcoords2` pointer
+   install in `shaders_lightmap_rendering.rs:69` (already inside `unsafe`).
+
+## Fallout (audit §2)
+
+- ~35 showcase `*.shader = …` writes → `set_shader`.
+- ~17 showcase map-color/value raw writes → `set_map_color`/`set_map_value`.
+- 1 mesh pointer install → `as_raw_mut()`.
+- `raylib/src` internal: `Model::set_transform` only (switch to `.0`);
+  internal code generally uses `.0` already. Plan re-verifies with a build.
+- `raylib/tests/`: zero write sites (audit-verified).
+- Mesh-from-scratch examples build raw `ffi::Mesh` values before wrapping —
+  unaffected.
+
+## Testing
+
+- **compile_fail doctests** on representative types (`Mesh`, `Sound`):
+  `wrapper.as_mut()` / `*wrapper = …` no longer compiles.
+- Tier-2 (software_renderer) test for `set_shader` + `set_map_color`/`value`
+  round-trip via `LoadMaterialDefault`.
+- Existing Tier-1/Tier-2 suites must stay green; full quality gates
+  (fmt, clippy `-Dwarnings` all legs incl. showcase, doctests, MSRV 1.88).
+
+## Documentation & release
+
+- CHANGELOG **Breaking** entry (rides the 6.0.0 final — last call before
+  publish): mut-half removed from the listed wrappers, new setters, new
+  `unsafe as_raw_mut`, rslice mut removal.
+- Book sweep for `as_mut()` patterns on locked types (plan task).
+- Stale WS6 claim about Sound corrected in the done-note.
+- PR resolves #276; credits @AmityWilder (#277) as the originating analysis.
+
+## Done criteria
+
+- All UNSOUND-classified wrappers no longer expose safe `&mut ffi::T`
+  (compile_fail-proven); SOUND types unchanged.
+- Every macro call site carries a `// SOUNDNESS:` comment.
+- Showcase + book + tests green across all CI legs.
+- Queue item 17 closed; #276 closed.

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -49,6 +49,13 @@ make_thin_wrapper_lifetime!(
     /// // Later, trigger playback:
     /// unsafe { raylib::ffi::PlaySound(*sound) };
     /// ```
+    ///
+    /// ```compile_fail
+    /// # use raylib::prelude::*;
+    /// fn corrupt(sound: &mut Sound<'_>) {
+    ///     sound.stream.buffer = std::ptr::null_mut(); // no DerefMut on Sound (issue #276)
+    /// }
+    /// ```
     Sound,
     ffi::Sound,
     RaylibAudio,

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -1,6 +1,7 @@
 //! Contains code related to audio. [`RaylibAudio`] plays sounds and music.
 
 use crate::{
+    core::AsRawMut,
     error::{AudioInitError, LoadSoundError, UpdateAudioStreamError},
     ffi,
 };
@@ -703,6 +704,15 @@ impl Music<'_> {
     #[inline]
     pub fn set_pan(&self, pan: f32) {
         unsafe { ffi::SetMusicPan(self.0, pan) }
+    }
+
+    /// Set whether the music stream loops when it reaches the end.
+    #[inline]
+    pub fn set_looping(&mut self, looping: bool) {
+        // SAFETY: looping is an inline bool — not a trusted count or owned pointer.
+        unsafe {
+            self.as_raw_mut().looping = looping;
+        }
     }
 
     /// Checks if a music stream is valid (context and buffers initialized)

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use super::error::ExportWaveError;
 
+// SOUNDNESS: readonly — P2 (Drop=UnloadWave frees data); no Rust-side slice trusts frameCount.
 make_thin_wrapper_lifetime!(
     /// CPU-side waveform data loaded into RAM.
     ///
@@ -21,9 +22,11 @@ make_thin_wrapper_lifetime!(
     Wave,
     ffi::Wave,
     RaylibAudio,
-    ffi::UnloadWave
+    ffi::UnloadWave,
+    readonly
 );
 
+// SOUNDNESS: readonly — P2 (Drop=UnloadSound frees stream.buffer/processor). Closes the gap #277 originally targeted.
 make_thin_wrapper_lifetime!(
     /// Audio-device-ready playable sound sample.
     ///
@@ -49,8 +52,9 @@ make_thin_wrapper_lifetime!(
     ffi::Sound,
     RaylibAudio,
     (ffi::UnloadSound),
-    true
+    readonly
 );
+// SOUNDNESS: readonly — P2 (Drop=UnloadMusicStream frees stream + ctxData).
 make_thin_wrapper_lifetime!(
     /// Streamed audio for long-form playback.
     ///
@@ -64,8 +68,10 @@ make_thin_wrapper_lifetime!(
     Music,
     ffi::Music,
     RaylibAudio,
-    ffi::UnloadMusicStream
+    ffi::UnloadMusicStream,
+    readonly
 );
+// SOUNDNESS: readonly — P2 (Drop=UnloadAudioStream frees buffer/processor).
 make_thin_wrapper_lifetime!(
     /// Low-level raw PCM streaming primitive.
     ///
@@ -93,7 +99,8 @@ make_thin_wrapper_lifetime!(
     AudioStream,
     ffi::AudioStream,
     RaylibAudio,
-    ffi::UnloadAudioStream
+    ffi::UnloadAudioStream,
+    readonly
 );
 
 /// Owned buffer of decoded PCM samples for a [`Wave`], freed via `UnloadWaveSamples` on drop.

--- a/raylib/src/core/automation.rs
+++ b/raylib/src/core/automation.rs
@@ -91,6 +91,7 @@ impl ExactSizeIterator for AutomationEventIter<'_> {
     }
 }
 
+// SOUNDNESS: opted out (false) — hand-written accessor surface; nothing raw leaks.
 make_thin_wrapper!(
     AutomationEventList,
     ffi::AutomationEventList,
@@ -133,6 +134,7 @@ impl AutomationEventList {
     }
 }
 
+// SOUNDNESS: opted out (false) — hand-written accessor surface; nothing raw leaks.
 make_thin_wrapper!(
     AutomationEvent,
     ffi::AutomationEvent,

--- a/raylib/src/core/file.rs
+++ b/raylib/src/core/file.rs
@@ -139,11 +139,19 @@ impl ExactSizeIterator for FilePathIter<'_> {
     }
 }
 
-make_thin_wrapper!(FilePathList, ffi::FilePathList, ffi::UnloadDirectoryFiles);
+// SOUNDNESS: readonly — P1 (paths slice trusts paths×count) + P2 (Drop=UnloadDirectoryFiles frees paths and each string).
+make_thin_wrapper!(
+    FilePathList,
+    ffi::FilePathList,
+    ffi::UnloadDirectoryFiles,
+    readonly
+);
+// SOUNDNESS: readonly — P1/P2 like FilePathList (Drop=UnloadDroppedFiles).
 make_thin_wrapper!(
     DroppedFilePathList,
     ffi::FilePathList,
-    ffi::UnloadDroppedFiles
+    ffi::UnloadDroppedFiles,
+    readonly
 );
 
 impl FilePathList {

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -1,3 +1,25 @@
+/// Escape-hatch mutable access to a wrapper's raw FFI value.
+///
+/// Implemented by every thin wrapper. For wrappers classified *sound*
+/// (see the per-type `// SOUNDNESS:` comments at the `make_thin_wrapper!`
+/// call sites) this duplicates `AsMut`; for *readonly* wrappers it is the
+/// only mutable access to the raw struct — and it is `unsafe`, because
+/// the wrapper's safe API trusts invariants of the raw fields (issue #276).
+pub trait AsRawMut<T> {
+    /// Mutable access to the wrapped raw FFI value.
+    ///
+    /// # Safety
+    ///
+    /// Callers must uphold the wrapper's invariants:
+    /// - do **not** corrupt count/dimension/format fields that safe
+    ///   accessors use to derive slice lengths or buffer sizes (e.g.
+    ///   `Mesh::vertexCount`, `Image::width`/`height`/`format`), and
+    /// - do **not** reassign pointer fields that are owned and freed by
+    ///   `Drop` (e.g. `Model::meshes`, `Font::glyphs`), unless you take
+    ///   over ownership of the previous allocation.
+    unsafe fn as_raw_mut(&mut self) -> &mut T;
+}
+
 /// Internal helper. Generates a `#[repr(transparent)]` newtype wrapping an
 /// FFI value, with `Drop` calling the supplied `Unload*` raylib function.
 ///
@@ -62,6 +84,17 @@ macro_rules! make_thin_wrapper {
         deref_impl_wrapper!($name, $t, $dropfunc, 0);
         gen_from_raw_wrapper!($name, $t, $dropfunc, 0);
     };
+    ($(#[$attrs:meta])* $name:ident, $t:ty, $dropfunc:expr, readonly) => {
+        $(#[$attrs])*
+        #[repr(transparent)]
+        #[derive(Debug)]
+        #[allow(missing_docs)]
+        pub struct $name(pub(crate) $t);
+
+        impl_wrapper!($name, $t, $dropfunc, 0);
+        readonly_deref_impl_wrapper!($name, $t, $dropfunc, 0);
+        gen_from_raw_wrapper!($name, $t, $dropfunc, 0);
+    };
 }
 
 /// Internal helper. Like [`make_thin_wrapper!`] but with a lifetime
@@ -121,6 +154,15 @@ macro_rules! make_thin_wrapper_lifetime {
 
         impl_wrapper!($name<'a>, $t1, $dropfunc, 0);
         deref_impl_wrapper!($name<'a>, $t1, $dropfunc, 0);
+    };
+    ($(#[$attrs:meta])* $name:ident, $t1:ty, $t2:ty, $dropfunc:expr, readonly) => {
+        $(#[$attrs])*
+        #[derive(Debug)]
+        #[allow(missing_docs)]
+        pub struct $name<'a>(pub(crate) $t1, &'a $t2);
+
+        impl_wrapper!($name<'a>, $t1, $dropfunc, 0);
+        readonly_deref_impl_wrapper!($name<'a>, $t1, $dropfunc, 0);
     };
 }
 
@@ -240,6 +282,7 @@ macro_rules! gen_from_raw_wrapper {
 /// impl[<'a>] AsMut<$t>  for $name[<'a>] { fn as_mut(&mut self) -> &mut $t { &mut self.$rawfield } }
 /// impl[<'a>] Deref      for $name[<'a>] { type Target = $t; fn deref(&self) -> &$t { ... } }
 /// impl[<'a>] DerefMut   for $name[<'a>] { fn deref_mut(&mut self) -> &mut $t { ... } }
+/// impl[<'a>] AsRawMut<$t> for $name[<'a>] { unsafe fn as_raw_mut(&mut self) -> &mut $t { ... } }
 /// ```
 macro_rules! deref_impl_wrapper {
     ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
@@ -266,6 +309,40 @@ macro_rules! deref_impl_wrapper {
         impl$(<$lifetime>)? std::ops::DerefMut for $name$(<$lifetime>)? {
             #[inline]
             fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.$rawfield
+            }
+        }
+
+        impl$(<$lifetime>)? crate::core::AsRawMut<$t> for $name$(<$lifetime>)? {
+            unsafe fn as_raw_mut(&mut self) -> &mut $t {
+                &mut self.$rawfield
+            }
+        }
+    };
+}
+
+/// Internal helper. Read half of the deref family only (`Deref` +
+/// `AsRef`), plus the `unsafe` [`AsRawMut`] escape hatch. Used by the
+/// `readonly` wrapper mode for types whose safe API trusts raw fields
+/// (issue #276) — see the `// SOUNDNESS:` comment at each call site.
+macro_rules! readonly_deref_impl_wrapper {
+    ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
+        impl$(<$lifetime>)? std::convert::AsRef<$t> for $name$(<$lifetime>)? {
+            fn as_ref(&self) -> &$t {
+                &self.$rawfield
+            }
+        }
+
+        impl$(<$lifetime>)? std::ops::Deref for $name$(<$lifetime>)? {
+            type Target = $t;
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                &self.$rawfield
+            }
+        }
+
+        impl$(<$lifetime>)? crate::core::AsRawMut<$t> for $name$(<$lifetime>)? {
+            unsafe fn as_raw_mut(&mut self) -> &mut $t {
                 &mut self.$rawfield
             }
         }
@@ -312,8 +389,8 @@ macro_rules! make_rslice {
     };
 }
 
-/// Internal helper. Emits the `Drop` + `AsRef` / `AsMut` / `Deref` /
-/// `DerefMut` impls for an rslice wrapper produced by [`make_rslice!`].
+/// Internal helper. Emits the `Drop` + `AsRef` / `Deref` impls for an
+/// rslice wrapper produced by [`make_rslice!`].
 ///
 /// The `Drop` impl is the load-bearing piece: it takes the inner
 /// `ManuallyDrop<Box<[T]>>`, calls `Box::leak` to recover the raw pointer
@@ -322,6 +399,12 @@ macro_rules! make_rslice {
 /// `MemFree`). This keeps the wrapper correct under raylib builds that
 /// use a custom allocator.
 ///
+/// The `AsMut<Box<[T]>>` and `DerefMut` impls are intentionally absent:
+/// exposing `&mut Box<[Color]>` would allow `mem::take` to drop the inner
+/// `Box` through the global allocator, bypassing the raylib-owned `Unload*`
+/// free path — a double-free. Use `as_mut_slice` for element mutation
+/// instead (see issue #276).
+///
 /// Not intended to be called outside of [`make_rslice!`].
 ///
 /// Expansion shape (conceptual):
@@ -329,9 +412,8 @@ macro_rules! make_rslice {
 /// ```text
 /// impl Drop for $name { /* see above */ }
 /// impl AsRef<Box<[T]>> for $name { ... }
-/// impl AsMut<Box<[T]>> for $name { ... }
 /// impl Deref     for $name { type Target = Box<[T]>; ... }
-/// impl DerefMut  for $name { ... }
+/// impl $name { pub fn as_mut_slice(&mut self) -> &mut [Color] { ... } }
 /// ```
 macro_rules! impl_rslice {
     ($name:ident, $t:ty, $dropfunc:expr, $rawfield:tt) => {
@@ -351,12 +433,6 @@ macro_rules! impl_rslice {
             }
         }
 
-        impl std::convert::AsMut<$t> for $name {
-            fn as_mut(&mut self) -> &mut $t {
-                &mut self.$rawfield
-            }
-        }
-
         impl std::ops::Deref for $name {
             type Target = $t;
             #[inline]
@@ -365,10 +441,13 @@ macro_rules! impl_rslice {
             }
         }
 
-        impl std::ops::DerefMut for $name {
+        impl $name {
+            /// Mutable access to the elements. The `Box` itself is not
+            /// exposed (replacing it would free the raylib-owned buffer
+            /// through the global allocator — see issue #276).
             #[inline]
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.$rawfield
+            pub fn as_mut_slice(&mut self) -> &mut [crate::ffi::Color] {
+                &mut self.$rawfield[..]
             }
         }
     };

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -373,9 +373,10 @@ macro_rules! readonly_deref_impl_wrapper {
 ///
 /// impl Drop      for $name { /* takes the Box, leaks it back to raw, and calls ($dropfunc)(ptr) */ }
 /// impl AsRef<Box<[$t]>>  for $name { ... }
-/// impl AsMut<Box<[$t]>>  for $name { ... }
 /// impl Deref     for $name { type Target = Box<[$t]>; ... }
-/// impl DerefMut  for $name { ... }
+/// impl $name { pub fn as_mut_slice(&mut self) -> &mut [$t] { ... } }
+/// // No AsMut/DerefMut to the Box: swapping the allocation out (mem::take)
+/// // would free the raylib-owned buffer via the global allocator (issue #276).
 /// ```
 macro_rules! make_rslice {
     ($(#[$attrs:meta])* $name:ident, $t:ty, $dropfunc:expr) => {

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 mod macros;
 
+pub use macros::AsRawMut;
+
 pub mod audio;
 /// Automation event recording and playback for deterministic input replay.
 ///

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -323,12 +323,12 @@ impl RaylibHandle {
     pub fn update_model_animation(
         &mut self,
         _: &RaylibThread,
-        mut model: impl AsMut<ffi::Model>,
+        model: impl AsRef<ffi::Model>,
         anim: impl AsRef<ffi::ModelAnimation>,
         frame: f32,
     ) {
         unsafe {
-            ffi::UpdateModelAnimation(*model.as_mut(), *anim.as_ref(), frame);
+            ffi::UpdateModelAnimation(*model.as_ref(), *anim.as_ref(), frame);
         }
     }
 
@@ -341,7 +341,7 @@ impl RaylibHandle {
     pub fn update_model_animation_ex(
         &mut self,
         _: &RaylibThread,
-        mut model: impl AsMut<ffi::Model>,
+        model: impl AsRef<ffi::Model>,
         anim_a: impl AsRef<ffi::ModelAnimation>,
         frame_a: f32,
         anim_b: impl AsRef<ffi::ModelAnimation>,
@@ -350,7 +350,7 @@ impl RaylibHandle {
     ) {
         unsafe {
             ffi::UpdateModelAnimationEx(
-                *model.as_mut(),
+                *model.as_ref(),
                 *anim_a.as_ref(),
                 frame_a,
                 *anim_b.as_ref(),

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -428,7 +428,7 @@ pub trait RaylibModel: AsRef<ffi::Model> + crate::core::AsRawMut<ffi::Model> {
     fn set_transform(&mut self, mat: &Matrix) {
         // SAFETY: transform is an inline Matrix — not a trusted count or owned pointer.
         unsafe {
-            self.as_raw_mut().transform = (*mat).into();
+            self.as_raw_mut().transform = *mat;
         }
     }
 

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -1082,6 +1082,22 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + crate::core::AsRawMut<ffi::Mate
         }
     }
 
+    /// Reset the material's shader to "none" (`id: 0`, no locations array).
+    ///
+    /// Used when tearing down a material whose shader is owned elsewhere, so
+    /// the material no longer references it.
+    #[inline]
+    fn clear_shader(&mut self) {
+        // SAFETY: shader is an inline value field — writing it cannot
+        // corrupt the maps pointer (the only field the safe API trusts).
+        unsafe {
+            self.as_raw_mut().shader = ffi::Shader {
+                id: 0,
+                locs: std::ptr::null_mut(),
+            };
+        }
+    }
+
     /// Set one material map's color (e.g. albedo tint).
     ///
     /// # Panics

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -20,6 +20,7 @@ use std::ffi::CString;
 use std::os::raw::c_void;
 
 fn no_drop<T>(_thing: T) {}
+// SOUNDNESS: readonly — P1 (meshes/materials/bones slices trust meshCount/materialCount/boneCount) + P2 (Drop=UnloadModel frees meshes/materials/skeleton arrays).
 make_thin_wrapper!(
     /// Loaded 3-D model with its associated meshes and materials.
     ///
@@ -54,9 +55,12 @@ make_thin_wrapper!(
     /// ```
     Model,
     ffi::Model,
-    ffi::UnloadModel
+    ffi::UnloadModel,
+    readonly
 );
-make_thin_wrapper!(WeakModel, ffi::Model, no_drop);
+// SOUNDNESS: readonly — P1 (same RaylibModel slice accessors); no_drop removes P2.
+make_thin_wrapper!(WeakModel, ffi::Model, no_drop, readonly);
+// SOUNDNESS: readonly — P1 (vertices/normals/etc. slices trust vertexCount/triangleCount) + P2 (Drop=UnloadMesh frees every pointer field).
 make_thin_wrapper!(
     /// Per-mesh vertex and index data uploaded to the GPU.
     ///
@@ -87,9 +91,12 @@ make_thin_wrapper!(
     /// ```
     Mesh,
     ffi::Mesh,
-    |mesh: ffi::Mesh| ffi::UnloadMesh(mesh)
+    |mesh: ffi::Mesh| ffi::UnloadMesh(mesh),
+    readonly
 );
-make_thin_wrapper!(WeakMesh, ffi::Mesh, no_drop);
+// SOUNDNESS: readonly — P1 (same RaylibMesh slice accessors); no_drop removes P2.
+make_thin_wrapper!(WeakMesh, ffi::Mesh, no_drop, readonly);
+// SOUNDNESS: readonly — P1 (maps slice trusts the maps pointer) + P2 (Drop=UnloadMaterial frees maps).
 make_thin_wrapper!(
     /// Rendering material: a shader plus up to `MAX_MATERIAL_MAPS` texture maps.
     ///
@@ -100,27 +107,36 @@ make_thin_wrapper!(
     /// Freed via `UnloadMaterial` on drop.
     Material,
     ffi::Material,
-    ffi::UnloadMaterial
+    ffi::UnloadMaterial,
+    readonly
 );
-make_thin_wrapper!(WeakMaterial, ffi::Material, no_drop);
+// SOUNDNESS: readonly — P1 (maps slice trusts the maps pointer); no_drop removes P2.
+make_thin_wrapper!(WeakMaterial, ffi::Material, no_drop, readonly);
+// SOUNDNESS: full deref — inline name[32]/parent only; no trusted counts, no owned pointers.
 make_thin_wrapper!(
     /// Bone, skeletal animation bone
     BoneInfo,
     ffi::BoneInfo,
-    no_drop
+    no_drop,
+    true
 );
+// SOUNDNESS: readonly — P1 (keyframe accessors trust framePoses/frameCount); freed by the owning ModelAnimations, not this wrapper.
 make_thin_wrapper!(
     /// A single model animation: a non-owning view into a `ModelAnimations` collection.
     ModelAnimation,
     ffi::ModelAnimation,
-    no_drop
+    no_drop,
+    readonly
 );
-make_thin_wrapper!(WeakModelAnimation, ffi::ModelAnimation, no_drop);
+// SOUNDNESS: readonly — P1 (keyframe accessors trust framePoses/frameCount); no_drop removes P2.
+make_thin_wrapper!(WeakModelAnimation, ffi::ModelAnimation, no_drop, readonly);
+// SOUNDNESS: full deref — inline texture/color/value fields; no trusted counts, no owned pointers.
 make_thin_wrapper!(
     /// MaterialMap
     MaterialMap,
     ffi::MaterialMap,
-    no_drop
+    no_drop,
+    true
 );
 
 // Weak things can be clone
@@ -381,7 +397,7 @@ impl Model {
 /// - [`Model`] — the owned model type this trait extends
 /// - [`RaylibMesh`] — sibling trait for per-mesh accessors
 /// - [`RaylibMaterial`] — sibling trait for per-material accessors
-pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
+pub trait RaylibModel: AsRef<ffi::Model> + crate::core::AsRawMut<ffi::Model> {
     #[inline]
     #[must_use]
     /// Local transform matrix
@@ -410,7 +426,10 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
     /// - [`RaylibModel::transform`] — read the current transform
     #[inline]
     fn set_transform(&mut self, mat: &Matrix) {
-        self.as_mut().transform = *mat;
+        // SAFETY: transform is an inline Matrix — not a trusted count or owned pointer.
+        unsafe {
+            self.as_raw_mut().transform = (*mat).into();
+        }
     }
 
     /// Meshes array
@@ -449,11 +468,11 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
     #[inline]
     #[must_use]
     fn meshes_mut(&mut self) -> &mut [WeakMesh] {
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (no count/pointer corruption — reads meshes/meshCount then returns a slice).
         unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().meshes as *mut WeakMesh,
-                self.as_mut().meshCount as usize,
-            )
+            let m = self.as_raw_mut();
+            std::slice::from_raw_parts_mut(m.meshes as *mut WeakMesh, m.meshCount as usize)
         }
     }
     /// Materials array
@@ -471,10 +490,13 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
     #[inline]
     #[must_use]
     fn materials_mut(&mut self) -> &mut [WeakMaterial] {
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (no count/pointer corruption — reads materials/materialCount then returns a slice).
         unsafe {
+            let m = self.as_raw_mut();
             std::slice::from_raw_parts_mut(
-                self.as_mut().materials as *mut WeakMaterial,
-                self.as_mut().materialCount as usize,
+                m.materials as *mut WeakMaterial,
+                m.materialCount as usize,
             )
         }
     }
@@ -501,10 +523,13 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
             return None;
         }
 
+        // SAFETY: bones is non-null (checked above); raw mut access: this method upholds
+        // the wrapper invariants itself (no count/pointer corruption — only reads the bones slice).
         Some(unsafe {
+            let m = self.as_raw_mut();
             std::slice::from_raw_parts_mut(
-                self.as_mut().skeleton.bones as *mut BoneInfo,
-                self.as_mut().skeleton.boneCount as usize,
+                m.skeleton.bones as *mut BoneInfo,
+                m.skeleton.boneCount as usize,
             )
         })
     }
@@ -528,7 +553,8 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
         }
         // SAFETY: bindPose is non-null (checked above) and points to a valid ffi::Transform.
         // Transform is #[repr(C)] over ffi::Transform, so the cast is sound.
-        Some(unsafe { &mut *(self.as_mut().skeleton.bindPose as *mut Transform) })
+        // Raw mut access: this method upholds the wrapper invariants itself (no count/pointer corruption).
+        Some(unsafe { &mut *(self.as_raw_mut().skeleton.bindPose as *mut Transform) })
     }
     #[inline]
     #[must_use]
@@ -563,7 +589,9 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
         } else if material_id >= self.as_ref().materialCount {
             Err(SetMaterialError::MaterialIdOutOfBounds)
         } else {
-            unsafe { ffi::SetModelMeshMaterial(self.as_mut(), mesh_id, material_id) };
+            // SAFETY: SetModelMeshMaterial writes the mesh->material index mapping;
+            // it does not corrupt count or pointer fields — invariants upheld.
+            unsafe { ffi::SetModelMeshMaterial(self.as_raw_mut(), mesh_id, material_id) };
             Ok(())
         }
     }
@@ -605,7 +633,7 @@ impl Mesh {
 /// - [`Mesh`] — the owned mesh type this trait extends
 /// - [`MeshBuilder`] — assemble a custom mesh from typed vertex slices
 /// - [`RaylibModel`] — sibling trait for whole-model accessors
-pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
+pub trait RaylibMesh: AsRef<ffi::Mesh> + crate::core::AsRawMut<ffi::Mesh> {
     /// Upload mesh vertex data in GPU and provide VAO/VBO ids
     ///
     /// # Safety
@@ -614,7 +642,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     /// must not already have GPU buffers allocated (i.e., `vaoId` and all `vboId` must be 0).
     #[inline]
     unsafe fn upload(&mut self, dynamic: bool) {
-        unsafe { ffi::UploadMesh(self.as_mut(), dynamic) };
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (UploadMesh writes vaoId/vboId — not trusted count or vertex pointer fields).
+        unsafe { ffi::UploadMesh(self.as_raw_mut(), dynamic) };
     }
     /// Update mesh vertex data in GPU for a specific buffer index
     ///
@@ -650,7 +680,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn vertices_mut(&mut self) -> &mut [Vector3] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads vertices/vertexCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.vertices.is_null() || m.vertexCount == 0 {
             return &mut [];
         }
@@ -674,7 +706,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn normals_mut(&mut self) -> &mut [Vector3] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads normals/vertexCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.normals.is_null() || m.vertexCount == 0 {
             return &mut [];
         }
@@ -697,7 +731,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn texcoords_mut(&mut self) -> &mut [Vector2] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads texcoords/vertexCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.texcoords.is_null() || m.vertexCount == 0 {
             return &mut [];
         }
@@ -723,7 +759,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn texcoords2_mut(&mut self) -> &mut [Vector2] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads texcoords2/vertexCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.texcoords2.is_null() || m.vertexCount == 0 {
             return &mut [];
         }
@@ -747,7 +785,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn tangents_mut(&mut self) -> &mut [Vector3] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads tangents/vertexCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.tangents.is_null() || m.vertexCount == 0 {
             return &mut [];
         }
@@ -771,7 +811,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn colors_mut(&mut self) -> &mut [Color] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads colors/vertexCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.colors.is_null() || m.vertexCount == 0 {
             return &mut [];
         }
@@ -794,7 +836,9 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     #[inline]
     #[must_use]
     fn indices_mut(&mut self) -> &mut [u16] {
-        let m = self.as_mut();
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (only reads indices/triangleCount to build a slice — no count/pointer corruption).
+        let m = unsafe { self.as_raw_mut() };
         if m.indices.is_null() || m.triangleCount == 0 {
             return &mut [];
         }
@@ -894,8 +938,10 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     // NOTE: New VBO for tangents is generated at default location and also binded to mesh VAO
     #[inline]
     fn gen_mesh_tangents(&mut self, _: &RaylibThread) {
+        // SAFETY: GenMeshTangents computes and stores tangent data into the mesh arrays;
+        // raw mut access: this method upholds the wrapper invariants itself (no count corruption).
         unsafe {
-            ffi::GenMeshTangents(self.as_mut());
+            ffi::GenMeshTangents(self.as_raw_mut());
         }
     }
 
@@ -979,7 +1025,7 @@ impl RaylibMaterial for Material {}
 /// - [`Material`] — the owned material type this trait extends
 /// - [`MaterialMap`] — per-slot texture / color / value triple
 /// - [`RaylibModel::materials_mut`] — borrow a model's materials
-pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
+pub trait RaylibMaterial: AsRef<ffi::Material> + crate::core::AsRawMut<ffi::Material> {
     /// Material shader
     #[must_use]
     #[inline]
@@ -990,7 +1036,9 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
     #[inline]
     /// Material shader
     fn shader_mut(&mut self) -> &mut crate::shaders::WeakShader {
-        unsafe { std::mem::transmute(&mut self.as_mut().shader) }
+        // SAFETY: transmuting the inline shader field; raw mut access cannot
+        // corrupt maps (the only trusted pointer) — invariants upheld.
+        unsafe { std::mem::transmute(&mut self.as_raw_mut().shader) }
     }
     #[must_use]
     #[inline]
@@ -1007,9 +1055,11 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
     #[inline]
     /// Material maps array (MAX_MATERIAL_MAPS)
     fn maps_mut(&mut self) -> &mut [MaterialMap] {
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (reads the maps pointer to build a fixed-length slice — does not corrupt the pointer).
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().maps as *mut MaterialMap,
+                self.as_raw_mut().maps as *mut MaterialMap,
                 consts::MAX_MATERIAL_MAPS as usize,
             )
         }
@@ -1022,8 +1072,14 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + AsMut<ffi::Material> {
         map_type: crate::consts::MaterialMapIndex,
         texture: impl AsRef<ffi::Texture2D>,
     ) {
+        // SAFETY: SetMaterialTexture writes one map's texture handle; counts
+        // and owned pointers are untouched.
         unsafe {
-            ffi::SetMaterialTexture(self.as_mut(), (map_type as u32) as i32, *texture.as_ref())
+            ffi::SetMaterialTexture(
+                self.as_raw_mut(),
+                (map_type as u32) as i32,
+                *texture.as_ref(),
+            )
         }
     }
 
@@ -1280,7 +1336,9 @@ impl ModelAnimation {
 ///
 /// - [`ModelAnimation`] — the parent animation type
 /// - [`ModelAnimations`] — RAII owner that yields `&ModelAnimation` slices
-pub trait RaylibModelAnimation: AsRef<ffi::ModelAnimation> + AsMut<ffi::ModelAnimation> {
+pub trait RaylibModelAnimation:
+    AsRef<ffi::ModelAnimation> + crate::core::AsRawMut<ffi::ModelAnimation>
+{
     #[must_use]
     /// Poses array by frame
     fn frame_poses(&self) -> Vec<&[Transform]> {

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -1065,6 +1065,43 @@ pub trait RaylibMaterial: AsRef<ffi::Material> + crate::core::AsRawMut<ffi::Mate
         }
     }
 
+    /// Replace the material's shader.
+    ///
+    /// Copies the shader's inline FFI struct into the material — the same
+    /// semantics as raylib C's `material.shader = shader`. The [`Shader`]
+    /// wrapper keeps ownership of the shader (and frees it on drop), so it
+    /// must outlive every use of this material.
+    ///
+    /// [`Shader`]: crate::shaders::Shader
+    #[inline]
+    fn set_shader(&mut self, shader: impl AsRef<ffi::Shader>) {
+        // SAFETY: shader is an inline value field — writing it cannot
+        // corrupt the maps pointer (the only field the safe API trusts).
+        unsafe {
+            self.as_raw_mut().shader = *shader.as_ref();
+        }
+    }
+
+    /// Set one material map's color (e.g. albedo tint).
+    ///
+    /// # Panics
+    ///
+    /// Never — `index` is an enum bounded by `MAX_MATERIAL_MAPS`.
+    #[inline]
+    fn set_map_color(
+        &mut self,
+        index: crate::consts::MaterialMapIndex,
+        color: impl Into<ffi::Color>,
+    ) {
+        *self.maps_mut()[index as usize].color_mut() = color.into();
+    }
+
+    /// Set one material map's scalar value (e.g. metalness/roughness).
+    #[inline]
+    fn set_map_value(&mut self, index: crate::consts::MaterialMapIndex, value: f32) {
+        *self.maps_mut()[index as usize].value_mut() = value;
+    }
+
     /// Set texture for a material map type (MATERIAL_MAP_ALBEDO, MATERIAL_MAP_SPECULAR, etc.).
     #[inline]
     fn set_material_texture(

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -89,6 +89,16 @@ make_thin_wrapper!(
     /// let verts = mesh.vertices();
     /// println!("cube has {} vertices", verts.len());
     /// ```
+    ///
+    /// Mutable access to the raw FFI struct is `unsafe` — corrupting the
+    /// counts the slice accessors trust is no longer possible in safe code:
+    ///
+    /// ```compile_fail
+    /// # use raylib::prelude::*;
+    /// fn corrupt(mesh: &mut Mesh) {
+    ///     mesh.vertexCount += 5; // no DerefMut on Mesh (issue #276)
+    /// }
+    /// ```
     Mesh,
     ffi::Mesh,
     |mesh: ffi::Mesh| ffi::UnloadMesh(mesh),

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -9,6 +9,7 @@ use std::ffi::CString;
 use std::os::raw::c_void;
 
 fn no_drop<T>(_thing: T) {}
+// SOUNDNESS: readonly — P1 (locs slice trusts the locs pointer) + P2 (Drop=UnloadShader frees locs).
 make_thin_wrapper!(
     /// GLSL shader program (vertex + fragment).
     ///
@@ -49,9 +50,11 @@ make_thin_wrapper!(
     /// ```
     Shader,
     ffi::Shader,
-    ffi::UnloadShader
+    ffi::UnloadShader,
+    readonly
 );
-make_thin_wrapper!(WeakShader, ffi::Shader, no_drop);
+// SOUNDNESS: readonly — P1 (same locs accessor); no_drop removes P2.
+make_thin_wrapper!(WeakShader, ffi::Shader, no_drop, readonly);
 
 // #[cfg(feature = "nightly")]
 // impl !Send for Shader {}
@@ -393,7 +396,7 @@ impl RaylibShader for Shader {}
 ///
 /// - [`Shader`] — owning shader handle.
 /// - [`ShaderV`] — values that can be uploaded as uniforms.
-pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
+pub trait RaylibShader: AsRef<ffi::Shader> + crate::core::AsRawMut<ffi::Shader> {
     /// Shader locations array (RL_MAX_SHADER_LOCATIONS)
     #[inline]
     #[must_use]
@@ -405,7 +408,9 @@ pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
     #[inline]
     #[must_use]
     fn locs_mut(&mut self) -> &mut [i32] {
-        unsafe { std::slice::from_raw_parts_mut(self.as_mut().locs, 32) }
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (reads the locs pointer to build a fixed-length slice — does not corrupt the pointer).
+        unsafe { std::slice::from_raw_parts_mut(self.as_raw_mut().locs, 32) }
     }
 
     /// Gets shader uniform location by name.
@@ -427,9 +432,11 @@ pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
     /// Sets shader uniform value
     #[inline]
     fn set_shader_value<S: ShaderV>(&mut self, uniform_loc: i32, value: S) {
+        // SAFETY: SetShaderValue uploads a uniform; does not corrupt the locs pointer
+        // (the only trusted field) — invariants upheld.
         unsafe {
             ffi::SetShaderValue(
-                *self.as_mut(),
+                *self.as_raw_mut(),
                 uniform_loc,
                 value.value(),
                 (S::UNIFORM_TYPE as u32) as i32,
@@ -440,9 +447,11 @@ pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
     /// Set shader uniform value vector
     #[inline]
     fn set_shader_value_v<S: ShaderV>(&mut self, uniform_loc: i32, value: &[S]) {
+        // SAFETY: SetShaderValueV uploads a uniform array; does not corrupt the locs pointer
+        // (the only trusted field) — invariants upheld.
         unsafe {
             ffi::SetShaderValueV(
-                *self.as_mut(),
+                *self.as_raw_mut(),
                 uniform_loc,
                 value.as_ptr() as *const ::std::os::raw::c_void,
                 (S::UNIFORM_TYPE as u32) as i32,
@@ -454,16 +463,20 @@ pub trait RaylibShader: AsRef<ffi::Shader> + AsMut<ffi::Shader> {
     /// Sets shader uniform value (matrix 4x4).
     #[inline]
     fn set_shader_value_matrix(&mut self, uniform_loc: i32, mat: impl Into<Matrix>) {
+        // SAFETY: SetShaderValueMatrix uploads a matrix uniform; does not corrupt the locs pointer
+        // (the only trusted field) — invariants upheld.
         unsafe {
-            ffi::SetShaderValueMatrix(*self.as_mut(), uniform_loc, mat.into());
+            ffi::SetShaderValueMatrix(*self.as_raw_mut(), uniform_loc, mat.into());
         }
     }
 
     /// Sets shader uniform value (matrix 4x4).
     #[inline]
     fn set_shader_value_texture(&mut self, uniform_loc: i32, texture: impl AsRef<ffi::Texture2D>) {
+        // SAFETY: SetShaderValueTexture uploads a texture uniform; does not corrupt the locs pointer
+        // (the only trusted field) — invariants upheld.
         unsafe {
-            ffi::SetShaderValueTexture(*self.as_mut(), uniform_loc, *texture.as_ref());
+            ffi::SetShaderValueTexture(*self.as_raw_mut(), uniform_loc, *texture.as_ref());
         }
     }
 }

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -67,9 +67,9 @@ make_thin_wrapper!(
 ///
 /// Wraps a raylib-allocated `Box<[GlyphInfo]>` and calls `UnloadFontData` on drop so the
 /// glyph buffer is returned to raylib's allocator rather than Rust's. Implements
-/// [`Deref`](std::ops::Deref) + [`DerefMut`](std::ops::DerefMut) to `Box<[GlyphInfo]>` so
-/// it acts like a slice: index with `slice[i]`, iterate with `slice.iter()`, or read
-/// `slice.len()` directly.
+/// [`Deref`](std::ops::Deref) to `Box<[GlyphInfo]>` so it acts like a slice: index with
+/// `slice[i]`, iterate with `slice.iter()`, or read `slice.len()` directly. For mutable
+/// element access use [`as_mut_slice`](RSliceGlyphInfo::as_mut_slice).
 ///
 /// # Construction
 ///
@@ -82,6 +82,8 @@ make_thin_wrapper!(
 ///
 /// - [`GlyphInfo`] — per-codepoint metrics held in the slice.
 /// - [`Font`] — owning font built from this glyph data.
+// SOUNDNESS: rslice — Box mut-half removed (mem::take would double-free via UnloadFontData);
+// element access via as_mut_slice.
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct RSliceGlyphInfo(pub(crate) std::mem::ManuallyDrop<std::boxed::Box<[GlyphInfo]>>);
@@ -106,12 +108,6 @@ impl std::convert::AsRef<Box<[GlyphInfo]>> for RSliceGlyphInfo {
     }
 }
 
-impl std::convert::AsMut<Box<[GlyphInfo]>> for RSliceGlyphInfo {
-    fn as_mut(&mut self) -> &mut Box<[GlyphInfo]> {
-        &mut self.0
-    }
-}
-
 impl std::ops::Deref for RSliceGlyphInfo {
     type Target = Box<[GlyphInfo]>;
     #[inline]
@@ -120,10 +116,13 @@ impl std::ops::Deref for RSliceGlyphInfo {
     }
 }
 
-impl std::ops::DerefMut for RSliceGlyphInfo {
+impl RSliceGlyphInfo {
+    /// Mutable access to the elements. The `Box` itself is not exposed
+    /// (replacing it would free the raylib-owned buffer through the
+    /// global allocator — see issue #276).
     #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    pub fn as_mut_slice(&mut self) -> &mut [GlyphInfo] {
+        &mut self.0[..]
     }
 }
 

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -8,11 +8,12 @@ use crate::error::LoadFontError;
 use crate::ffi;
 use crate::ffi::Rectangle;
 
-use std::convert::{AsMut, AsRef, TryInto};
+use std::convert::{AsRef, TryInto};
 use std::ffi::{CString, OsString};
 use std::mem::ManuallyDrop;
 
 fn no_drop<T>(_thing: T) {}
+// SOUNDNESS: readonly — P1 (chars slice trusts glyphs×glyphCount) + P2 (Drop=UnloadFont frees recs/glyphs).
 make_thin_wrapper!(
     /// Font: a glyph atlas texture plus per-glyph metrics.
     ///
@@ -48,14 +49,18 @@ make_thin_wrapper!(
     /// ```
     Font,
     ffi::Font,
-    ffi::UnloadFont
+    ffi::UnloadFont,
+    readonly
 );
-make_thin_wrapper!(WeakFont, ffi::Font, no_drop);
+// SOUNDNESS: readonly — P1 (same RaylibFont accessors); no_drop removes P2.
+make_thin_wrapper!(WeakFont, ffi::Font, no_drop, readonly);
+// SOUNDNESS: full deref — inline scalars + inline Image value; this wrapper neither sizes nor frees the image data.
 make_thin_wrapper!(
     /// GlyphInfo, font characters glyphs info
     GlyphInfo,
     ffi::GlyphInfo,
-    no_drop
+    no_drop,
+    true
 );
 
 /// An owned slice of [`GlyphInfo`] data allocated by raylib, freed via `UnloadFontData` on drop.
@@ -367,7 +372,7 @@ impl RaylibFont for Font {}
 ///
 /// - [`Font`] — owning font handle.
 /// - [`GlyphInfo`] — per-codepoint metrics returned by [`get_glyph_info`](Self::get_glyph_info).
-pub trait RaylibFont: AsRef<ffi::Font> + AsMut<ffi::Font> {
+pub trait RaylibFont: AsRef<ffi::Font> + crate::core::AsRawMut<ffi::Font> {
     /// Base size (default chars height)
     #[inline]
     #[must_use]
@@ -395,11 +400,11 @@ pub trait RaylibFont: AsRef<ffi::Font> + AsMut<ffi::Font> {
     #[inline]
     #[must_use]
     fn chars_mut(&mut self) -> &mut [GlyphInfo] {
+        // SAFETY: raw mut access: this method upholds the wrapper invariants itself
+        // (reads glyphs/glyphCount to build a slice — does not corrupt the pointer or count).
         unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().glyphs as *mut GlyphInfo,
-                self.as_ref().glyphCount as usize,
-            )
+            let f = self.as_raw_mut();
+            std::slice::from_raw_parts_mut(f.glyphs as *mut GlyphInfo, f.glyphCount as usize)
         }
     }
 
@@ -492,18 +497,19 @@ impl Font {
     ) -> Result<Font, LoadFontError> {
         let f = unsafe {
             let mut f = std::mem::zeroed::<Font>();
-            f.baseSize = base_size;
+            // Direct field access on the concrete Font wrapper (inherent impl, not trait method).
+            f.0.baseSize = base_size;
             f.set_chars(chars);
 
             let atlas = ffi::GenImageFontAtlas(
-                f.glyphs,
+                f.0.glyphs,
                 &mut f.0.recs,
-                f.baseSize,
-                f.glyphCount,
+                f.0.baseSize,
+                f.0.glyphCount,
                 padding,
                 pack_method,
             );
-            f.texture = ffi::LoadTextureFromImage(atlas);
+            f.0.texture = ffi::LoadTextureFromImage(atlas);
             ffi::UnloadImage(atlas);
             f
         };
@@ -515,22 +521,26 @@ impl Font {
 
     /// Sets the character data on the current Font.
     fn set_chars(&mut self, chars: &[ffi::GlyphInfo]) {
+        // Direct field access on the concrete Font wrapper (inherent impl, not trait method).
+        // SAFETY: we are building a fresh Font struct (called from from_data with zeroed Font);
+        // writing glyphCount then glyphs does not corrupt other invariants.
         unsafe {
-            self.glyphCount = chars.len() as i32;
-            let data_size = self.glyphCount as usize * std::mem::size_of::<ffi::GlyphInfo>();
+            self.0.glyphCount = chars.len() as i32;
+            let data_size = self.0.glyphCount as usize * std::mem::size_of::<ffi::GlyphInfo>();
             let ci_arr_ptr = ffi::MemAlloc(data_size.try_into().unwrap()); // raylib frees this data in UnloadFont
             std::ptr::copy(
                 chars.as_ptr(),
                 ci_arr_ptr as *mut ffi::GlyphInfo,
                 chars.len(),
             );
-            self.glyphs = ci_arr_ptr as *mut ffi::GlyphInfo;
+            self.0.glyphs = ci_arr_ptr as *mut ffi::GlyphInfo;
         }
     }
 
     /// Sets the texture on the current Font, and takes ownership of `tex`.
     fn set_texture(&mut self, tex: Texture2D) {
-        self.texture = tex.0;
+        // Direct field access on the concrete Font wrapper (inherent impl, not trait method).
+        self.0.texture = tex.0;
         std::mem::forget(tex); // UnloadFont will also unload the texture
     }
 }

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -11,7 +11,9 @@ use std::mem::{ManuallyDrop, MaybeUninit};
 
 use super::error::{InvalidImageError, LoadTextureError, UpdateTextureError};
 
+// SOUNDNESS: rslice — Box mut-half removed (mem::take would double-free); element access via as_mut_slice.
 make_rslice!(ImagePalette, Color, ffi::UnloadImagePalette);
+// SOUNDNESS: rslice — Box mut-half removed (mem::take would double-free); element access via as_mut_slice.
 make_rslice!(ImageColors, Color, ffi::UnloadImageColors);
 
 /// NPatchInfo, n-patch layout info
@@ -58,6 +60,7 @@ impl From<&NPatchInfo> for ffi::NPatchInfo {
 }
 
 fn no_drop<T>(_thing: T) {}
+// SOUNDNESS: readonly — P1 (pixel readers trust width/height/format to size data) + P2 (Drop=UnloadImage frees data).
 make_thin_wrapper!(
     /// CPU-side pixel buffer.
     ///
@@ -87,8 +90,10 @@ make_thin_wrapper!(
     /// ```
     Image,
     ffi::Image,
-    ffi::UnloadImage
+    ffi::UnloadImage,
+    readonly
 );
+// SOUNDNESS: full deref — inline id/width/height/mipmaps/format; corrupting them confuses raylib C-side only, no Rust-side UB.
 make_thin_wrapper!(
     /// GPU-side texture stored in VRAM.
     ///
@@ -114,15 +119,18 @@ make_thin_wrapper!(
     /// ```
     Texture2D,
     ffi::Texture2D,
-    ffi::UnloadTexture
+    ffi::UnloadTexture,
+    true
 );
-make_thin_wrapper!(WeakTexture2D, ffi::Texture2D, no_drop);
+// SOUNDNESS: full deref — same inline-only fields as Texture2D.
+make_thin_wrapper!(WeakTexture2D, ffi::Texture2D, no_drop, true);
 #[allow(clippy::derivable_impls)] // Cannot use #[derive(Default)] on a macro-generated struct
 impl Default for WeakTexture2D {
     fn default() -> Self {
         Self(ffi::Texture::default())
     }
 }
+// SOUNDNESS: full deref — id + two inline Texture structs; no trusted counts, no owned CPU pointers.
 make_thin_wrapper!(
     /// Off-screen GPU framebuffer for render-to-texture.
     ///
@@ -156,9 +164,11 @@ make_thin_wrapper!(
     /// ```
     RenderTexture2D,
     ffi::RenderTexture2D,
-    ffi::UnloadRenderTexture
+    ffi::UnloadRenderTexture,
+    true
 );
-make_thin_wrapper!(WeakRenderTexture2D, ffi::RenderTexture2D, no_drop);
+// SOUNDNESS: full deref — same inline-only fields as RenderTexture2D.
+make_thin_wrapper!(WeakRenderTexture2D, ffi::RenderTexture2D, no_drop, true);
 
 // Weak things can be clone
 impl Clone for WeakTexture2D {

--- a/raylib/src/core/vr.rs
+++ b/raylib/src/core/vr.rs
@@ -2,11 +2,13 @@
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 
+// SOUNDNESS: full deref — all fields inline Matrix/f32 arrays; nothing to invalid-free, no trusted counts.
 make_thin_wrapper!(
     /// VrStereoConfig, VR stereo rendering configuration for simulator
     VrStereoConfig,
     ffi::VrStereoConfig,
-    ffi::UnloadVrStereoConfig
+    ffi::UnloadVrStereoConfig,
+    true
 );
 
 /// VrDeviceInfo, Head-Mounted-Display device parameters

--- a/raylib/tests/material_setters.rs
+++ b/raylib/tests/material_setters.rs
@@ -1,0 +1,57 @@
+//! Tier-2: Material safe-setter round-trips (issue #276 follow-up).
+//!
+//! Verifies that `set_shader`, `set_map_color`, and `set_map_value` write through
+//! correctly and that the identity shader re-set leaves the shader id unchanged.
+#![cfg(feature = "software_renderer")]
+
+use raylib::prelude::*;
+use raylib::test_harness::with_headless;
+
+#[test]
+fn material_setters_roundtrip() {
+    with_headless(32, 32, |rl, thread| {
+        let mut mat = rl.load_material_default(thread);
+        let shader_id_before = mat.shader().id;
+
+        mat.set_map_color(
+            raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO,
+            Color::RED,
+        );
+        mat.set_map_value(
+            raylib::consts::MaterialMapIndex::MATERIAL_MAP_METALNESS,
+            0.5,
+        );
+
+        let maps = mat.maps();
+        assert_eq!(
+            maps[raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO as usize]
+                .color()
+                .r,
+            255,
+            "albedo map color.r must be 255 (RED)"
+        );
+        assert_eq!(
+            maps[raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO as usize]
+                .color()
+                .g,
+            0,
+            "albedo map color.g must be 0"
+        );
+        assert_eq!(
+            maps[raylib::consts::MaterialMapIndex::MATERIAL_MAP_METALNESS as usize].value(),
+            &0.5_f32,
+            "metalness map value must be 0.5"
+        );
+
+        // set_shader with the material's current default shader is identity-safe.
+        // WeakShader implements AsRef<ffi::Shader>; get_shader_default() returns the
+        // same shader object that load_material_default assigns, so the id is preserved.
+        let default_shader = RaylibHandle::get_shader_default();
+        mat.set_shader(&default_shader);
+        assert_eq!(
+            mat.shader().id,
+            shader_id_before,
+            "set_shader with the same default shader must preserve the shader id"
+        );
+    });
+}

--- a/showcase/examples/audio/audio_module_playing.rs
+++ b/showcase/examples/audio/audio_module_playing.rs
@@ -85,7 +85,10 @@ fn main() {
     }
 
     let mut music = audio.new_music("resources/audio/mini1111.xm").unwrap();
-    music.looping = false; // Rust: Music DerefMut exposes the ffi struct; mutate the field directly.
+    // SAFETY: looping is an inline bool field — not a trusted count or owned pointer.
+    unsafe {
+        music.as_raw_mut().looping = false;
+    }
     let mut pitch: f32 = 1.0;
 
     music.play_stream();

--- a/showcase/examples/audio/audio_module_playing.rs
+++ b/showcase/examples/audio/audio_module_playing.rs
@@ -85,10 +85,7 @@ fn main() {
     }
 
     let mut music = audio.new_music("resources/audio/mini1111.xm").unwrap();
-    // SAFETY: looping is an inline bool field — not a trusted count or owned pointer.
-    unsafe {
-        music.as_raw_mut().looping = false;
-    }
+    music.set_looping(false);
     let mut pitch: f32 = 1.0;
 
     music.play_stream();

--- a/showcase/examples/models/models_animation_blend_custom.rs
+++ b/showcase/examples/models/models_animation_blend_custom.rs
@@ -352,7 +352,7 @@ fn main() {
     );
     // Mirror C's `model.materials[1].shader = skinningShader;`. The model only stores a
     // non-owning handle; skinning_shader retains ownership and is unloaded on drop.
-    *model.materials_mut()[1].shader_mut().as_mut() = *skinning_shader.as_ref();
+    model.materials_mut()[1].set_shader(&skinning_shader);
 
     // Load gltf model animations
     let anims = rl
@@ -407,7 +407,8 @@ fn main() {
         // When upperBodyBlend is OFF: uniform blend at 0.5 (50% walk, 50% attack)
         let blend_factor = if upper_body_blend { 1.0 } else { 0.5 };
         update_model_animation_bones(
-            model.as_mut(),
+            // SAFETY: update_model_animation_bones only writes bone/pose fields; it does not touch meshCount/materialCount or owned mesh/material pointers.
+            unsafe { model.as_raw_mut() },
             &anim0,
             anim_current_frame0,
             &anim1,

--- a/showcase/examples/models/models_animation_gpu_skinning.rs
+++ b/showcase/examples/models/models_animation_gpu_skinning.rs
@@ -65,7 +65,7 @@ fn main() {
     );
     // Mirror C's `model.materials[1].shader = skinningShader;`. The model
     // does not own the shader — `skinning_shader` continues to manage its lifetime.
-    *model.materials_mut()[1].shader_mut().as_mut() = *skinning_shader.as_ref();
+    model.materials_mut()[1].set_shader(&skinning_shader);
 
     // Load gltf model animations
     let anims = rl

--- a/showcase/examples/models/models_loading_vox.rs
+++ b/showcase/examples/models/models_loading_vox.rs
@@ -179,7 +179,7 @@ fn main() {
     // SAFETY: Shader.locs is a *mut c_int array of MAX_SHADER_LOCS valid for the lifetime of `shader`.
     unsafe {
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }
@@ -198,7 +198,7 @@ fn main() {
         for j in 0..mat_count {
             // Copy the shader's ffi handle into the model's material[j].shader.
             // Shader RAII still owns the GPU resource; the Model materials reference it by id.
-            models[i].materials_mut()[j].as_mut().shader = *shader.as_ref();
+            models[i].materials_mut()[j].set_shader(&shader);
         }
     }
 

--- a/showcase/examples/models/models_skybox_rendering.rs
+++ b/showcase/examples/models/models_skybox_rendering.rs
@@ -76,7 +76,7 @@ fn main() {
     skybox_shader.set_shader_value(vflipped_loc, if use_hdr { 1i32 } else { 0i32 });
 
     // Assign the skybox shader to the model's material[0]
-    skybox.materials_mut()[0].as_mut().shader = *skybox_shader.as_ref();
+    skybox.materials_mut()[0].set_shader(&skybox_shader);
 
     // Load cubemap shader and setup required shader locations
     // NOTE: kept for visual parity with the C example, though only used in the HDR branch below.

--- a/showcase/examples/shaders/shaders_basic_lighting.rs
+++ b/showcase/examples/shaders/shaders_basic_lighting.rs
@@ -141,7 +141,7 @@ fn main() {
     // SAFETY: Shader.locs is a *mut c_int array of MAX_SHADER_LOCS valid for the lifetime of `shader`.
     unsafe {
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }

--- a/showcase/examples/shaders/shaders_basic_pbr.rs
+++ b/showcase/examples/shaders/shaders_basic_pbr.rs
@@ -278,26 +278,14 @@ fn main() {
     let car_emission = rl
         .load_texture(&thread, "resources/shaders/old_car_e.png")
         .unwrap();
-    // SAFETY: copy ffi::Texture2D handles into car.materials[0].maps[*].texture; lifetimes managed by Texture2D RAII.
-    unsafe {
-        let mat = car.materials_mut()[0].as_raw_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *car_albedo.as_ref();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS as isize))
-        .texture = *car_mra.as_ref();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL as isize))
-        .texture = *car_normal.as_ref();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
-        .texture = *car_emission.as_ref();
-    }
+    car.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &car_albedo);
+    car.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS, &car_mra);
+    car.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL, &car_normal);
+    car.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION, &car_emission);
 
     // Load floor model mesh and assign material parameters
     let mut floor = rl
@@ -324,22 +312,12 @@ fn main() {
     let floor_normal = rl
         .load_texture(&thread, "resources/shaders/road_n.png")
         .unwrap();
-    // SAFETY: copy ffi::Texture2D handles into floor.materials[0].maps[*].texture; lifetimes managed by Texture2D RAII.
-    unsafe {
-        let mat = floor.materials_mut()[0].as_raw_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *floor_albedo.as_ref();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS as isize))
-        .texture = *floor_mra.as_ref();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL as isize))
-        .texture = *floor_normal.as_ref();
-    }
+    floor.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &floor_albedo);
+    floor.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS, &floor_mra);
+    floor.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL, &floor_normal);
 
     // Models texture tiling parameter can be stored in the Material struct if required (CURRENTLY NOT USED)
     // NOTE: Material.params[4] are available for generic parameters storage (float)
@@ -567,15 +545,8 @@ fn main() {
     //--------------------------------------------------------------------------------------
     // Unbind (disconnect) shader from car.material[0] / floor.material[0] before they drop —
     // RAII drop of `shader` would otherwise be aliased by the materials' shader field.
-    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
-    unsafe {
-        let null_shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
-        car.materials_mut()[0].as_raw_mut().shader = null_shader;
-        floor.materials_mut()[0].as_raw_mut().shader = null_shader;
-    }
+    car.materials_mut()[0].clear_shader();
+    floor.materials_mut()[0].clear_shader();
     // The Texture2D RAII handles still own the GPU textures; unbind from the material maps so
     // car/floor's Drop (UnloadModel → UnloadMaterial) doesn't double-free.
     // SAFETY: zero out the .texture fields of materials[0].maps so UnloadMaterial doesn't free.

--- a/showcase/examples/shaders/shaders_basic_pbr.rs
+++ b/showcase/examples/shaders/shaders_basic_pbr.rs
@@ -182,7 +182,7 @@ fn main() {
     unsafe {
         let albedo_loc = shader.get_shader_location("albedoMap");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MAP_ALBEDO as isize) = albedo_loc;
         // WARNING: Metalness, roughness, and ambient occlusion are all packed into a MRA texture
@@ -190,12 +190,12 @@ fn main() {
         // shader already takes care of it accordingly
         let mra_loc = shader.get_shader_location("mraMap");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MAP_METALNESS as isize) = mra_loc;
         let normal_loc = shader.get_shader_location("normalMap");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MAP_NORMAL as isize) = normal_loc;
         // WARNING: Similar to the MRA map, the emissive map packs different information
@@ -203,19 +203,19 @@ fn main() {
         // It is binded to SHADER_LOC_MAP_EMISSION location an properly processed on shader
         let emissive_loc = shader.get_shader_location("emissiveMap");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MAP_EMISSION as isize) = emissive_loc;
         let albedo_color_loc = shader.get_shader_location("albedoColor");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_COLOR_DIFFUSE as isize) = albedo_color_loc;
 
         // Setup additional required shader locations, including lights data
         let view_loc = shader.get_shader_location("viewPos");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }
@@ -253,33 +253,17 @@ fn main() {
         .unwrap();
 
     // Assign already setup PBR shader to model.materials[0], used by models.meshes[0]
-    car.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    car.materials_mut()[0].set_shader(&shader);
 
     // Setup materials[0].maps default parameters
-    // SAFETY: indexing into materials[0].maps (raw FFI pointer array).
-    unsafe {
-        let mat = car.materials_mut()[0].as_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .color = Color::WHITE;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS as isize))
-        .value = 1.0;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ROUGHNESS as isize))
-        .value = 0.0;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_OCCLUSION as isize))
-        .value = 1.0;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
-        .color = Color::new(255, 162, 0, 255);
-    }
+    car.materials_mut()[0].set_map_color(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, Color::WHITE);
+    car.materials_mut()[0].set_map_value(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS, 1.0);
+    car.materials_mut()[0].set_map_value(ffi::MaterialMapIndex::MATERIAL_MAP_ROUGHNESS, 0.0);
+    car.materials_mut()[0].set_map_value(ffi::MaterialMapIndex::MATERIAL_MAP_OCCLUSION, 1.0);
+    car.materials_mut()[0].set_map_color(
+        ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION,
+        Color::new(255, 162, 0, 255),
+    );
 
     // Setup materials[0].maps default textures
     let car_albedo = rl
@@ -296,7 +280,7 @@ fn main() {
         .unwrap();
     // SAFETY: copy ffi::Texture2D handles into car.materials[0].maps[*].texture; lifetimes managed by Texture2D RAII.
     unsafe {
-        let mat = car.materials_mut()[0].as_mut();
+        let mat = car.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
@@ -321,32 +305,15 @@ fn main() {
         .unwrap();
 
     // Assign material shader for our floor model, same PBR shader
-    floor.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    floor.materials_mut()[0].set_shader(&shader);
 
-    // SAFETY: indexing into materials[0].maps (raw FFI pointer array).
-    unsafe {
-        let mat = floor.materials_mut()[0].as_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .color = Color::WHITE;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS as isize))
-        .value = 0.8;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ROUGHNESS as isize))
-        .value = 0.1;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_OCCLUSION as isize))
-        .value = 1.0;
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
-        .color = Color::BLACK;
-    }
+    floor.materials_mut()[0]
+        .set_map_color(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, Color::WHITE);
+    floor.materials_mut()[0].set_map_value(ffi::MaterialMapIndex::MATERIAL_MAP_METALNESS, 0.8);
+    floor.materials_mut()[0].set_map_value(ffi::MaterialMapIndex::MATERIAL_MAP_ROUGHNESS, 0.1);
+    floor.materials_mut()[0].set_map_value(ffi::MaterialMapIndex::MATERIAL_MAP_OCCLUSION, 1.0);
+    floor.materials_mut()[0]
+        .set_map_color(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION, Color::BLACK);
 
     let floor_albedo = rl
         .load_texture(&thread, "resources/shaders/road_a.png")
@@ -359,7 +326,7 @@ fn main() {
         .unwrap();
     // SAFETY: copy ffi::Texture2D handles into floor.materials[0].maps[*].texture; lifetimes managed by Texture2D RAII.
     unsafe {
-        let mat = floor.materials_mut()[0].as_mut();
+        let mat = floor.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
@@ -600,19 +567,20 @@ fn main() {
     //--------------------------------------------------------------------------------------
     // Unbind (disconnect) shader from car.material[0] / floor.material[0] before they drop —
     // RAII drop of `shader` would otherwise be aliased by the materials' shader field.
-    car.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
-    floor.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
+    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+    unsafe {
+        let null_shader = ffi::Shader {
+            id: 0,
+            locs: std::ptr::null_mut(),
+        };
+        car.materials_mut()[0].as_raw_mut().shader = null_shader;
+        floor.materials_mut()[0].as_raw_mut().shader = null_shader;
+    }
     // The Texture2D RAII handles still own the GPU textures; unbind from the material maps so
     // car/floor's Drop (UnloadModel → UnloadMaterial) doesn't double-free.
     // SAFETY: zero out the .texture fields of materials[0].maps so UnloadMaterial doesn't free.
     unsafe {
-        let mat = car.materials_mut()[0].as_mut();
+        let mat = car.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
@@ -633,7 +601,7 @@ fn main() {
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
         .texture
         .id = 0;
-        let mat = floor.materials_mut()[0].as_mut();
+        let mat = floor.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_cel_shading.rs
+++ b/showcase/examples/shaders/shaders_cel_shading.rs
@@ -135,14 +135,14 @@ fn main() {
     unsafe {
         let view_loc = cel_shader.get_shader_location("viewPos");
         *cel_shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }
 
     // Apply cel shader to model, keep copy of default shader
     let default_shader = model.materials_mut()[0].as_ref().shader;
-    model.materials_mut()[0].as_mut().shader = *cel_shader.as_ref();
+    model.materials_mut()[0].set_shader(&cel_shader);
 
     // numBands: controls toon quantization steps (2 = hard binary, 20 = near-smooth)
     let mut num_bands: f32 = 10.0;
@@ -200,9 +200,12 @@ fn main() {
         if rl.is_key_pressed(KeyboardKey::KEY_Z) {
             cel_enabled = !cel_enabled;
             if cel_enabled {
-                model.materials_mut()[0].as_mut().shader = *cel_shader.as_ref(); // Apply cel shader to model
+                model.materials_mut()[0].set_shader(&cel_shader); // Apply cel shader to model
             } else {
-                model.materials_mut()[0].as_mut().shader = default_shader; // Apply default shader to model
+                // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+                unsafe {
+                    model.materials_mut()[0].as_raw_mut().shader = default_shader;
+                } // Apply default shader to model
             }
         }
 
@@ -260,14 +263,17 @@ fn main() {
                     ffi::rlSetCullFace(ffi::rlCullMode::RL_CULL_FACE_FRONT as i32);
                 }
 
-                model.materials_mut()[0].as_mut().shader = *outline_shader.as_ref();
+                model.materials_mut()[0].set_shader(&outline_shader);
 
                 c.draw_model(&model, Vector3::zero(), 0.75, Color::WHITE);
 
                 if cel_enabled {
-                    model.materials_mut()[0].as_mut().shader = *cel_shader.as_ref(); // Apply cel shader to model
+                    model.materials_mut()[0].set_shader(&cel_shader); // Apply cel shader to model
                 } else {
-                    model.materials_mut()[0].as_mut().shader = default_shader; // Apply default shader to model
+                    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+                    unsafe {
+                        model.materials_mut()[0].as_raw_mut().shader = default_shader;
+                    } // Apply default shader to model
                 }
 
                 // SAFETY: pure rlgl state restore.
@@ -324,6 +330,9 @@ fn main() {
     // UnloadModel / UnloadShader / CloseWindow handled by RAII drops.
     // First, clear the cel_shader / outline_shader pointer from model.materials[0] so the model's
     // Drop (UnloadModel → UnloadMaterial) doesn't try to free a shader we still own via RAII.
-    model.materials_mut()[0].as_mut().shader = default_shader;
+    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+    unsafe {
+        model.materials_mut()[0].as_raw_mut().shader = default_shader;
+    }
     //--------------------------------------------------------------------------------------
 }

--- a/showcase/examples/shaders/shaders_custom_uniform.rs
+++ b/showcase/examples/shaders/shaders_custom_uniform.rs
@@ -60,14 +60,8 @@ fn main() {
     let texture = rl
         .load_texture(&thread, "resources/shaders/models/barracks_diffuse.png")
         .unwrap(); // Load model texture (diffuse map)
-    // SAFETY: copy ffi::Texture2D handle into materials[0].maps[ALBEDO/DIFFUSE].texture; Texture2D RAII keeps it alive.
-    unsafe {
-        let mat = model.materials_mut()[0].as_raw_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref(); // Set model diffuse texture
-    }
+    model.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture); // Set model diffuse texture
 
     let position = Vector3::new(0.0, 0.0, 0.0); // Set model position
 

--- a/showcase/examples/shaders/shaders_custom_uniform.rs
+++ b/showcase/examples/shaders/shaders_custom_uniform.rs
@@ -62,7 +62,7 @@ fn main() {
         .unwrap(); // Load model texture (diffuse map)
     // SAFETY: copy ffi::Texture2D handle into materials[0].maps[ALBEDO/DIFFUSE].texture; Texture2D RAII keeps it alive.
     unsafe {
-        let mat = model.materials_mut()[0].as_mut();
+        let mat = model.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
@@ -166,7 +166,7 @@ fn main() {
     // Unbind texture from model.material so Drop doesn't double-free; Texture2D RAII owns it.
     // SAFETY: zero out the texture id in the ALBEDO map.
     unsafe {
-        let mat = model.materials_mut()[0].as_mut();
+        let mat = model.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_deferred_rendering.rs
+++ b/showcase/examples/shaders/shaders_deferred_rendering.rs
@@ -627,15 +627,8 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from materials so UnloadModel doesn't double-unload it (gbuffer_shader RAII owns it).
-    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
-    unsafe {
-        let null_shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
-        model.materials_mut()[0].as_raw_mut().shader = null_shader;
-        cube.materials_mut()[0].as_raw_mut().shader = null_shader;
-    }
+    model.materials_mut()[0].clear_shader();
+    cube.materials_mut()[0].clear_shader();
 
     // Unload geometry buffer and all attached textures
     // SAFETY: matched against the rlgl loaders above.

--- a/showcase/examples/shaders/shaders_deferred_rendering.rs
+++ b/showcase/examples/shaders/shaders_deferred_rendering.rs
@@ -166,7 +166,7 @@ fn main() {
     unsafe {
         let view_loc = deferred_shader.get_shader_location("viewPosition");
         *deferred_shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }
@@ -283,8 +283,8 @@ fn main() {
     }
 
     // Assign our lighting shader to model
-    model.materials_mut()[0].as_mut().shader = *gbuffer_shader.as_ref();
-    cube.materials_mut()[0].as_mut().shader = *gbuffer_shader.as_ref();
+    model.materials_mut()[0].set_shader(&gbuffer_shader);
+    cube.materials_mut()[0].set_shader(&gbuffer_shader);
 
     // Create lights
     //--------------------------------------------------------------------------------------
@@ -627,14 +627,15 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from materials so UnloadModel doesn't double-unload it (gbuffer_shader RAII owns it).
-    model.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
-    cube.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
+    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+    unsafe {
+        let null_shader = ffi::Shader {
+            id: 0,
+            locs: std::ptr::null_mut(),
+        };
+        model.materials_mut()[0].as_raw_mut().shader = null_shader;
+        cube.materials_mut()[0].as_raw_mut().shader = null_shader;
+    }
 
     // Unload geometry buffer and all attached textures
     // SAFETY: matched against the rlgl loaders above.

--- a/showcase/examples/shaders/shaders_fog_rendering.rs
+++ b/showcase/examples/shaders/shaders_fog_rendering.rs
@@ -139,17 +139,17 @@ fn main() {
     // Assign texture to default model material
     // SAFETY: copying ffi::Texture2D handle into the material map slot; Texture2D RAII keeps it alive.
     unsafe {
-        let mat = model_a.materials_mut()[0].as_mut();
+        let mat = model_a.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *texture.as_ref();
-        let mat = model_b.materials_mut()[0].as_mut();
+        let mat = model_b.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *texture.as_ref();
-        let mat = model_c.materials_mut()[0].as_mut();
+        let mat = model_c.materials_mut()[0].as_raw_mut();
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
@@ -170,12 +170,12 @@ fn main() {
     unsafe {
         let model_loc = shader.get_shader_location("matModel");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MATRIX_MODEL as isize) = model_loc;
         let view_loc = shader.get_shader_location("viewPos");
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }
@@ -199,9 +199,9 @@ fn main() {
     shader.set_shader_value(fog_density_loc, fog_density);
 
     // NOTE: All models share the same shader
-    model_a.materials_mut()[0].as_mut().shader = *shader.as_ref();
-    model_b.materials_mut()[0].as_mut().shader = *shader.as_ref();
-    model_c.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    model_a.materials_mut()[0].set_shader(&shader);
+    model_b.materials_mut()[0].set_shader(&shader);
+    model_c.materials_mut()[0].set_shader(&shader);
 
     // Using just 1 point lights
     let _ = create_light(
@@ -299,23 +299,21 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from models so UnloadModel doesn't try to free our owned Shader.
-    model_a.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
-    model_b.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
-    model_c.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
+    // SAFETY: shader is an inline value field — writing it cannot corrupt maps pointer.
+    unsafe {
+        let null_shader = ffi::Shader {
+            id: 0,
+            locs: std::ptr::null_mut(),
+        };
+        model_a.materials_mut()[0].as_raw_mut().shader = null_shader;
+        model_b.materials_mut()[0].as_raw_mut().shader = null_shader;
+        model_c.materials_mut()[0].as_raw_mut().shader = null_shader;
+    }
     // Also unbind texture (Texture2D RAII still owns the GL texture).
     // SAFETY: zero out the texture handle so UnloadMaterial doesn't double-free.
     unsafe {
         for m in [&mut model_a, &mut model_b, &mut model_c] {
-            let mat = m.materials_mut()[0].as_mut();
+            let mat = m.materials_mut()[0].as_raw_mut();
             (*mat
                 .maps
                 .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_fog_rendering.rs
+++ b/showcase/examples/shaders/shaders_fog_rendering.rs
@@ -137,24 +137,12 @@ fn main() {
         .unwrap();
 
     // Assign texture to default model material
-    // SAFETY: copying ffi::Texture2D handle into the material map slot; Texture2D RAII keeps it alive.
-    unsafe {
-        let mat = model_a.materials_mut()[0].as_raw_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref();
-        let mat = model_b.materials_mut()[0].as_raw_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref();
-        let mat = model_c.materials_mut()[0].as_raw_mut();
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref();
-    }
+    model_a.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture);
+    model_b.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture);
+    model_c.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture);
 
     // Load shader and set up some uniforms
     let mut shader = rl.load_shader(
@@ -299,16 +287,9 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from models so UnloadModel doesn't try to free our owned Shader.
-    // SAFETY: shader is an inline value field — writing it cannot corrupt maps pointer.
-    unsafe {
-        let null_shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
-        model_a.materials_mut()[0].as_raw_mut().shader = null_shader;
-        model_b.materials_mut()[0].as_raw_mut().shader = null_shader;
-        model_c.materials_mut()[0].as_raw_mut().shader = null_shader;
-    }
+    model_a.materials_mut()[0].clear_shader();
+    model_b.materials_mut()[0].clear_shader();
+    model_c.materials_mut()[0].clear_shader();
     // Also unbind texture (Texture2D RAII still owns the GL texture).
     // SAFETY: zero out the texture handle so UnloadMaterial doesn't double-free.
     unsafe {

--- a/showcase/examples/shaders/shaders_lightmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_lightmap_rendering.rs
@@ -62,7 +62,7 @@ fn main() {
     // second UV channel by allocating texcoords2 via raylib's MemAlloc (libc::malloc would be
     // wrong under custom allocators). raylib will free texcoords2 in UnloadMesh.
     unsafe {
-        let mesh_ref = mesh.as_mut();
+        let mesh_ref = mesh.as_raw_mut();
         let count = (mesh_ref.vertexCount as usize) * 2;
         let bytes = count * std::mem::size_of::<f32>();
         let ptr = ffi::MemAlloc(bytes as u32) as *mut f32;

--- a/showcase/examples/shaders/shaders_mesh_instancing.rs
+++ b/showcase/examples/shaders/shaders_mesh_instancing.rs
@@ -155,11 +155,11 @@ fn main() {
     // SAFETY: Shader.locs is a *mut c_int array of MAX_SHADER_LOCS valid for the lifetime of `shader`.
     unsafe {
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MATRIX_MVP as isize) = mvp_loc;
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_loc;
     }
@@ -181,28 +181,14 @@ fn main() {
     // NOTE: We are assigning the intancing shader to material.shader
     // to be used on mesh drawing with DrawMeshInstanced()
     let mut mat_instances = rl.load_material_default(&thread);
-    mat_instances.as_mut().shader = *shader.as_ref();
-    // SAFETY: write diffuse color into the just-loaded default material's ALBEDO map.
-    unsafe {
-        (*mat_instances
-            .as_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .color = Color::RED;
-    }
+    mat_instances.set_shader(&shader);
+    mat_instances.set_map_color(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, Color::RED);
 
     // Load default material (using raylib intenral default shader) for non-instanced mesh drawing
     // WARNING: Default shader enables vertex color attribute BUT GenMeshCube() does not generate vertex colors, so,
     // when drawing the color attribute is disabled and a default color value is provided as input for thevertex attribute
     let mut mat_default = rl.load_material_default(&thread);
-    // SAFETY: write diffuse color into the default material's ALBEDO map.
-    unsafe {
-        (*mat_default
-            .as_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .color = Color::BLUE;
-    }
+    mat_default.set_map_color(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, Color::BLUE);
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second
     let mut viewer = SourceViewer::for_current_example();
@@ -267,10 +253,13 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Clear external shader handle from the instancing material so its Drop won't free our shader twice.
-    mat_instances.as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
+    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+    unsafe {
+        mat_instances.as_raw_mut().shader = ffi::Shader {
+            id: 0,
+            locs: std::ptr::null_mut(),
+        };
+    }
     // Materials are WeakMaterial — they don't auto-unload. Leak is benign at shutdown
     // (matches the C source which also doesn't explicitly UnloadMaterial here).
     // UnloadShader / CloseWindow handled by RAII drops.

--- a/showcase/examples/shaders/shaders_mesh_instancing.rs
+++ b/showcase/examples/shaders/shaders_mesh_instancing.rs
@@ -253,13 +253,7 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Clear external shader handle from the instancing material so its Drop won't free our shader twice.
-    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
-    unsafe {
-        mat_instances.as_raw_mut().shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
-    }
+    mat_instances.clear_shader();
     // Materials are WeakMaterial — they don't auto-unload. Leak is benign at shutdown
     // (matches the C source which also doesn't explicitly UnloadMaterial here).
     // UnloadShader / CloseWindow handled by RAII drops.

--- a/showcase/examples/shaders/shaders_model_shader.rs
+++ b/showcase/examples/shaders/shaders_model_shader.rs
@@ -70,15 +70,9 @@ fn main() {
         )),
     );
 
-    // SAFETY: assign shader and diffuse texture into material[0]; both kept alive by RAII guards.
-    unsafe {
-        let mat = model.materials_mut()[0].as_raw_mut();
-        mat.shader = *shader.as_ref(); // Set shader effect to 3d model
-        (*mat
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref(); // Bind texture to model
-    }
+    model.materials_mut()[0].set_shader(&shader); // Set shader effect to 3d model
+    model.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture); // Bind texture to model
 
     let position = Vector3::new(0.0, 0.0, 0.0); // Set model position
 
@@ -128,13 +122,10 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind so model Drop doesn't double-free what RAII guards own.
-    // SAFETY: clear the shader+diffuse texture handles in material[0].
+    model.materials_mut()[0].clear_shader();
+    // SAFETY: zero out the texture id so UnloadMaterial doesn't double-free.
     unsafe {
         let mat = model.materials_mut()[0].as_raw_mut();
-        mat.shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_model_shader.rs
+++ b/showcase/examples/shaders/shaders_model_shader.rs
@@ -72,7 +72,7 @@ fn main() {
 
     // SAFETY: assign shader and diffuse texture into material[0]; both kept alive by RAII guards.
     unsafe {
-        let mat = model.materials_mut()[0].as_mut();
+        let mat = model.materials_mut()[0].as_raw_mut();
         mat.shader = *shader.as_ref(); // Set shader effect to 3d model
         (*mat
             .maps
@@ -130,7 +130,7 @@ fn main() {
     // Unbind so model Drop doesn't double-free what RAII guards own.
     // SAFETY: clear the shader+diffuse texture handles in material[0].
     unsafe {
-        let mat = model.materials_mut()[0].as_mut();
+        let mat = model.materials_mut()[0].as_raw_mut();
         mat.shader = ffi::Shader {
             id: 0,
             locs: std::ptr::null_mut(),

--- a/showcase/examples/shaders/shaders_normalmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_normalmap_rendering.rs
@@ -77,11 +77,11 @@ fn main() {
     // SAFETY: write into shader.locs[NORMAL] and [VECTOR_VIEW]; backing array lives as long as the shader.
     unsafe {
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MAP_NORMAL as isize) = normal_map_loc;
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_pos_loc;
     }
@@ -100,7 +100,7 @@ fn main() {
         .unwrap();
 
     // Set the plane model's shader and texture maps
-    plane.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    plane.materials_mut()[0].set_shader(&shader);
     let mut diffuse_texture = rl
         .load_texture(&thread, "resources/shaders/tiles_diffuse.png")
         .unwrap();
@@ -110,12 +110,12 @@ fn main() {
     // SAFETY: install diffuse + normal textures into material[0]; Texture2D RAII keeps ids alive.
     unsafe {
         (*plane.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *diffuse_texture.as_ref();
         (*plane.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL as isize))
         .texture = *normal_texture.as_ref();
@@ -258,7 +258,7 @@ fn main() {
     // Unbind external resources so plane's Drop doesn't double-free.
     // SAFETY: clear shader handle and texture ids on the loaded model's materials[0].
     unsafe {
-        let mat = plane.materials_mut()[0].as_mut();
+        let mat = plane.materials_mut()[0].as_raw_mut();
         mat.shader = ffi::Shader {
             id: 0,
             locs: std::ptr::null_mut(),

--- a/showcase/examples/shaders/shaders_normalmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_normalmap_rendering.rs
@@ -107,19 +107,10 @@ fn main() {
     let mut normal_texture = rl
         .load_texture(&thread, "resources/shaders/tiles_normal.png")
         .unwrap();
-    // SAFETY: install diffuse + normal textures into material[0]; Texture2D RAII keeps ids alive.
-    unsafe {
-        (*plane.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *diffuse_texture.as_ref();
-        (*plane.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL as isize))
-        .texture = *normal_texture.as_ref();
-    }
+    plane.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &diffuse_texture);
+    plane.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_NORMAL, &normal_texture);
 
     // Generate Mipmaps and use TRILINEAR filtering to help with texture aliasing
     diffuse_texture.gen_texture_mipmaps();
@@ -256,13 +247,10 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind external resources so plane's Drop doesn't double-free.
-    // SAFETY: clear shader handle and texture ids on the loaded model's materials[0].
+    plane.materials_mut()[0].clear_shader();
+    // SAFETY: zero out the texture ids so UnloadMaterial doesn't double-free.
     unsafe {
         let mat = plane.materials_mut()[0].as_raw_mut();
-        mat.shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_postprocessing.rs
+++ b/showcase/examples/shaders/shaders_postprocessing.rs
@@ -104,14 +104,8 @@ fn main() {
     let texture = rl
         .load_texture(&thread, "resources/shaders/models/church_diffuse.png")
         .unwrap(); // Load model texture (diffuse map)
-    // SAFETY: install diffuse texture into material[0]; Texture2D RAII keeps id alive.
-    unsafe {
-        (*model.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref(); // Set model diffuse texture
-    }
+    model.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture); // Set model diffuse texture
 
     let position = Vector3::new(0.0, 0.0, 0.0); // Set model position
 

--- a/showcase/examples/shaders/shaders_postprocessing.rs
+++ b/showcase/examples/shaders/shaders_postprocessing.rs
@@ -107,7 +107,7 @@ fn main() {
     // SAFETY: install diffuse texture into material[0]; Texture2D RAII keeps id alive.
     unsafe {
         (*model.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *texture.as_ref(); // Set model diffuse texture
@@ -239,7 +239,7 @@ fn main() {
     // SAFETY: clear diffuse texture id in materials[0].
     unsafe {
         (*model.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture

--- a/showcase/examples/shaders/shaders_shadowmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_shadowmap_rendering.rs
@@ -171,7 +171,7 @@ fn main() {
     // SAFETY: write shader.locs[SHADER_LOC_VECTOR_VIEW]; backing array lives as long as the shader.
     unsafe {
         *shadow_shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as isize) = view_pos_loc;
     }
@@ -201,13 +201,13 @@ fn main() {
     let mut cube = rl
         .load_model_from_mesh(&thread, unsafe { cube_mesh.make_weak() })
         .unwrap();
-    cube.materials_mut()[0].as_mut().shader = *shadow_shader.as_ref();
+    cube.materials_mut()[0].set_shader(&shadow_shader);
     let mut robot = rl
         .load_model(&thread, "resources/shaders/models/robot.glb")
         .unwrap();
     let mat_count = robot.materials().len();
     for i in 0..mat_count {
-        robot.materials_mut()[i].as_mut().shader = *shadow_shader.as_ref();
+        robot.materials_mut()[i].set_shader(&shadow_shader);
     }
 
     let mut anims = rl
@@ -364,16 +364,17 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from materials so model Drop doesn't double-free.
-    cube.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
-    let mat_count = robot.materials().len();
-    for i in 0..mat_count {
-        robot.materials_mut()[i].as_mut().shader = ffi::Shader {
+    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+    unsafe {
+        let null_shader = ffi::Shader {
             id: 0,
             locs: std::ptr::null_mut(),
         };
+        cube.materials_mut()[0].as_raw_mut().shader = null_shader;
+        let mat_count = robot.materials().len();
+        for i in 0..mat_count {
+            robot.materials_mut()[i].as_raw_mut().shader = null_shader;
+        }
     }
     let _ = &mut anims; // ModelAnimations are unloaded via RAII drop
     unload_shadowmap_render_texture(&shadow_map);

--- a/showcase/examples/shaders/shaders_shadowmap_rendering.rs
+++ b/showcase/examples/shaders/shaders_shadowmap_rendering.rs
@@ -364,17 +364,10 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from materials so model Drop doesn't double-free.
-    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
-    unsafe {
-        let null_shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
-        cube.materials_mut()[0].as_raw_mut().shader = null_shader;
-        let mat_count = robot.materials().len();
-        for i in 0..mat_count {
-            robot.materials_mut()[i].as_raw_mut().shader = null_shader;
-        }
+    cube.materials_mut()[0].clear_shader();
+    let mat_count = robot.materials().len();
+    for i in 0..mat_count {
+        robot.materials_mut()[i].clear_shader();
     }
     let _ = &mut anims; // ModelAnimations are unloaded via RAII drop
     unload_shadowmap_render_texture(&shadow_map);

--- a/showcase/examples/shaders/shaders_simple_mask.rs
+++ b/showcase/examples/shaders/shaders_simple_mask.rs
@@ -87,12 +87,12 @@ fn main() {
     // SAFETY: install diffuse texture into both models' material[0]; Texture2D RAII keeps id alive.
     unsafe {
         (*model1.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *tex_diffuse.as_ref();
         (*model2.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *tex_diffuse.as_ref();
@@ -106,12 +106,12 @@ fn main() {
     // SAFETY: install mask texture into both models' MATERIAL_MAP_EMISSION slot; Texture2D RAII keeps id alive.
     unsafe {
         (*model1.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
         .texture = *tex_mask.as_ref();
         (*model2.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
         .texture = *tex_mask.as_ref();
@@ -120,7 +120,7 @@ fn main() {
     // SAFETY: write shader.locs[SHADER_LOC_MAP_EMISSION] for the active shader.
     unsafe {
         *shader
-            .as_mut()
+            .as_raw_mut()
             .locs
             .offset(ffi::ShaderLocationIndex::SHADER_LOC_MAP_EMISSION as isize) = mask_loc;
     }
@@ -129,8 +129,8 @@ fn main() {
     let shader_frame = shader.get_shader_location("frame");
 
     // Apply the shader to the two models
-    model1.materials_mut()[0].as_mut().shader = *shader.as_ref();
-    model2.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    model1.materials_mut()[0].set_shader(&shader);
+    model2.materials_mut()[0].set_shader(&shader);
 
     let mut frames_counter: i32 = 0;
     let mut rotation = Vector3::new(0.0, 0.0, 0.0); // Model rotation angles
@@ -210,7 +210,7 @@ fn main() {
     // SAFETY: clear the shader handle and the diffuse/emission texture ids in materials[0].
     unsafe {
         for model in [&mut model1, &mut model2] {
-            let mat = model.materials_mut()[0].as_mut();
+            let mat = model.materials_mut()[0].as_raw_mut();
             mat.shader = ffi::Shader {
                 id: 0,
                 locs: std::ptr::null_mut(),

--- a/showcase/examples/shaders/shaders_simple_mask.rs
+++ b/showcase/examples/shaders/shaders_simple_mask.rs
@@ -84,38 +84,20 @@ fn main() {
     let tex_diffuse = rl
         .load_texture(&thread, "resources/shaders/plasma.png")
         .unwrap();
-    // SAFETY: install diffuse texture into both models' material[0]; Texture2D RAII keeps id alive.
-    unsafe {
-        (*model1.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *tex_diffuse.as_ref();
-        (*model2.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *tex_diffuse.as_ref();
-    }
+    model1.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &tex_diffuse);
+    model2.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &tex_diffuse);
 
     // Using MATERIAL_MAP_EMISSION as a spare slot to use for 2nd texture
     // NOTE: Don't use MATERIAL_MAP_IRRADIANCE, MATERIAL_MAP_PREFILTER or  MATERIAL_MAP_CUBEMAP as they are bound as cube maps
     let tex_mask = rl
         .load_texture(&thread, "resources/shaders/mask.png")
         .unwrap();
-    // SAFETY: install mask texture into both models' MATERIAL_MAP_EMISSION slot; Texture2D RAII keeps id alive.
-    unsafe {
-        (*model1.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
-        .texture = *tex_mask.as_ref();
-        (*model2.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION as isize))
-        .texture = *tex_mask.as_ref();
-    }
+    model1.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION, &tex_mask);
+    model2.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_EMISSION, &tex_mask);
     let mask_loc = shader.get_shader_location("mask");
     // SAFETY: write shader.locs[SHADER_LOC_MAP_EMISSION] for the active shader.
     unsafe {
@@ -207,14 +189,13 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader and external textures from materials so model Drop doesn't double-free.
-    // SAFETY: clear the shader handle and the diffuse/emission texture ids in materials[0].
+    for model in [&mut model1, &mut model2] {
+        model.materials_mut()[0].clear_shader();
+    }
+    // SAFETY: zero out the texture ids so UnloadMaterial doesn't double-free.
     unsafe {
         for model in [&mut model1, &mut model2] {
             let mat = model.materials_mut()[0].as_raw_mut();
-            mat.shader = ffi::Shader {
-                id: 0,
-                locs: std::ptr::null_mut(),
-            };
             (*mat
                 .maps
                 .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_texture_tiling.rs
+++ b/showcase/examples/shaders/shaders_texture_tiling.rs
@@ -63,7 +63,7 @@ fn main() {
     // SAFETY: install diffuse texture into model.material[0]; Texture2D RAII keeps id alive.
     unsafe {
         (*model.materials_mut()[0]
-            .as_mut()
+            .as_raw_mut()
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
         .texture = *texture.as_ref();
@@ -81,7 +81,7 @@ fn main() {
     texture.set_texture_wrap(&thread, TextureWrap::TEXTURE_WRAP_REPEAT);
     let tiling_loc = shader.get_shader_location("tiling");
     shader.set_shader_value(tiling_loc, tiling);
-    model.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    model.materials_mut()[0].set_shader(&shader);
 
     rl.disable_cursor(); // Limit cursor to relative movement inside the window
 
@@ -137,7 +137,7 @@ fn main() {
     // Unbind shader and external diffuse texture so model Drop doesn't double-free.
     // SAFETY: clear shader handle + diffuse texture id in materials[0].
     unsafe {
-        let mat = model.materials_mut()[0].as_mut();
+        let mat = model.materials_mut()[0].as_raw_mut();
         mat.shader = ffi::Shader {
             id: 0,
             locs: std::ptr::null_mut(),

--- a/showcase/examples/shaders/shaders_texture_tiling.rs
+++ b/showcase/examples/shaders/shaders_texture_tiling.rs
@@ -60,14 +60,8 @@ fn main() {
     let texture = rl
         .load_texture(&thread, "resources/shaders/cubicmap_atlas.png")
         .unwrap();
-    // SAFETY: install diffuse texture into model.material[0]; Texture2D RAII keeps id alive.
-    unsafe {
-        (*model.materials_mut()[0]
-            .as_raw_mut()
-            .maps
-            .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))
-        .texture = *texture.as_ref();
-    }
+    model.materials_mut()[0]
+        .set_material_texture(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO, &texture);
 
     // Set the texture tiling using a shader
     let tiling = [3.0f32, 3.0f32];
@@ -135,13 +129,10 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader and external diffuse texture so model Drop doesn't double-free.
-    // SAFETY: clear shader handle + diffuse texture id in materials[0].
+    model.materials_mut()[0].clear_shader();
+    // SAFETY: zero out the texture id so UnloadMaterial doesn't double-free.
     unsafe {
         let mat = model.materials_mut()[0].as_raw_mut();
-        mat.shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
         (*mat
             .maps
             .offset(ffi::MaterialMapIndex::MATERIAL_MAP_ALBEDO as isize))

--- a/showcase/examples/shaders/shaders_vertex_displacement.rs
+++ b/showcase/examples/shaders/shaders_vertex_displacement.rs
@@ -83,7 +83,7 @@ fn main() {
         .load_model_from_mesh(&thread, unsafe { plane_mesh.make_weak() })
         .unwrap();
     // Set plane model material
-    plane_model.materials_mut()[0].as_mut().shader = *shader.as_ref();
+    plane_model.materials_mut()[0].set_shader(&shader);
 
     let mut time = 0.0f32;
 
@@ -135,10 +135,13 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from model.material so Drop doesn't double-free.
-    plane_model.materials_mut()[0].as_mut().shader = ffi::Shader {
-        id: 0,
-        locs: std::ptr::null_mut(),
-    };
+    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
+    unsafe {
+        plane_model.materials_mut()[0].as_raw_mut().shader = ffi::Shader {
+            id: 0,
+            locs: std::ptr::null_mut(),
+        };
+    }
     // UnloadShader / UnloadModel / UnloadTexture / CloseWindow handled by RAII drops.
     //--------------------------------------------------------------------------------------
 }

--- a/showcase/examples/shaders/shaders_vertex_displacement.rs
+++ b/showcase/examples/shaders/shaders_vertex_displacement.rs
@@ -135,13 +135,7 @@ fn main() {
     // De-Initialization
     //--------------------------------------------------------------------------------------
     // Unbind shader from model.material so Drop doesn't double-free.
-    // SAFETY: shader is an inline value field — writing it cannot corrupt the maps pointer.
-    unsafe {
-        plane_model.materials_mut()[0].as_raw_mut().shader = ffi::Shader {
-            id: 0,
-            locs: std::ptr::null_mut(),
-        };
-    }
+    plane_model.materials_mut()[0].clear_shader();
     // UnloadShader / UnloadModel / UnloadTexture / CloseWindow handled by RAII drops.
     //--------------------------------------------------------------------------------------
 }

--- a/showcase/examples/text/text_font_filters.rs
+++ b/showcase/examples/text/text_font_filters.rs
@@ -50,7 +50,7 @@ fn main() {
     // SAFETY: font owns its texture; raylib's GenTextureMipmaps takes a `*mut Texture2D`
     // and mutates id/mipmaps in-place. We never use the texture concurrently.
     unsafe {
-        let f: &mut raylib::ffi::Font = std::convert::AsMut::as_mut(&mut font);
+        let f: &mut raylib::ffi::Font = font.as_raw_mut();
         raylib::ffi::GenTextureMipmaps(&mut f.texture);
     }
 

--- a/showcase/examples/textures/textures_cellular_automata.rs
+++ b/showcase/examples/textures/textures_cellular_automata.rs
@@ -153,9 +153,9 @@ fn main() {
 
             // Reset image
             // SAFETY: ImageClearBackground takes the image by pointer. We have exclusive
-            // access via `&mut image` (raylib reads no other state); single-threaded use.
+            // access (raylib reads no other state); single-threaded use.
             unsafe {
-                raylib::ffi::ImageClearBackground(&mut *image, Color::RAYWHITE);
+                raylib::ffi::ImageClearBackground(image.as_raw_mut(), Color::RAYWHITE);
             }
             image.draw_pixel(IMAGE_WIDTH / 2, 0, Color::BLACK);
             line = 1;

--- a/typos.toml
+++ b/typos.toml
@@ -16,6 +16,10 @@ easer = "easer"
 # `mis` appears as a token boundary in valid hyphenated English ("mis-wire",
 # "mis-routing") that typos splits on the hyphen. Allow the prefix through.
 mis = "mis"
+# raylib's MATERIAL_MAP_METALNESS / PBR "metalness" is standard PBR
+# terminology and the upstream enum name (typos suggests "metallicity",
+# which is astronomy, not graphics).
+metalness = "metalness"
 
 [type.fs]
 extend-glob = ["*.fs"]


### PR DESCRIPTION
Resolves #276; supersedes #277 — with credit to @AmityWilder for the original analysis. Closes queue item 17 (the full wrapper-soundness refactor deferred from WS6). Spec with the full per-type classification: `docs/superpowers/specs/2026-06-06-wrapper-soundness-design.md`; done-note: `docs/superpowers/notes/wrapper-soundness-complete.md`.

**The rule (narrower than #277's blanket removal):** exposing safe `&mut ffi::T` is unsound exactly where (P1) safe accessors derive slice lengths/buffer sizes from raw fields (`mesh.vertexCount += 5; mesh.vertices()` → OOB in safe code) or (P2) `Drop` frees pointer fields (`model.meshes = p` → invalid free). The read half (`Deref`/`AsRef`) is sound and stays everywhere.

**What changed:**
- New `readonly` wrapper mode + `AsRawMut` trait (`unsafe fn as_raw_mut`, in the prelude) — 19 wrappers move to it (`Image`, `Mesh`, `Model`, `Material`, `Font`, `Shader`, `ModelAnimation` + `Weak*`s, `FilePathList`×2, `Wave`/`Sound`/`Music`/`AudioStream`); 8 inline-data/GPU-id wrappers (`Texture2D`, `RenderTexture2D`, `VrStereoConfig`, …) deliberately keep full deref. **Every macro call site carries a `// SOUNDNESS:` comment** recording its classification and evidence.
- The six accessor traits over unsound types rebind `AsMut → AsRawMut`; ~32 internal sites now sit in documented `unsafe` blocks.
- All three rslices (`ImageColors`, `ImagePalette`, and the hand-written `RSliceGlyphInfo` the audit initially missed) stop exposing the `Box` mutably (`mem::take` was a double-free); elements via `as_mut_slice`.
- New safe setters absorb the example fallout: `RaylibMaterial::{set_shader, clear_shader, set_map_color, set_map_value}`, `Music::set_looping` (+ adopting the existing `set_material_texture`). Showcase `as_raw_mut` sites: 61 → 34, the remainder genuinely raw (e.g. the lightmap `texcoords2` install).
- Found-and-fixed: `update_model_animation{,_ex}` bounds were `AsMut` (uncallable post-change; they pass the model by value to C) → `AsRef`.
- `compile_fail` doctests prove the canonical exploits no longer compile; Tier-2 `material_setters_roundtrip` covers the new setters.

**Breaking** (CHANGELOG entry included; rides the 6.0.0 final): safe `&mut ffi::T` access on the listed wrappers is gone — use the setters, or `unsafe as_raw_mut()` with the documented invariants.

**Gates run locally:** five clippy `-D warnings` legs (lib/sys/SR-tests/showcase×2), 193 nextest tests, 149 doctests (5 compile_fail), fmt, Tier-2 setter test — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
