### PR TITLE
feat(sys): tuple/array From conversions for Vector2/3/4 (queue item 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   in that check). `glam`/`serde` currently require a std-capable target.
   `nobuild` bindings are generated without bindgen layout assertions so they
   can be compile-checked cross-target; hosted default builds keep them.
+- `Vector2`/`Vector3`/`Vector4` gain `From` conversions from tuples and arrays
+  (`(f32, f32)`/`[f32; 2]`, etc.), matching `Color`'s existing tuple `From`.
+  Combined with the `impl Into<Vector2>` draw-API parameters this lets call
+  sites pass coordinates directly, e.g. `d.draw_pixel_v((10.0, 20.0), c)`.
 
 ### Breaking
 

--- a/docs/superpowers/notes/color-vector-ergonomics-complete.md
+++ b/docs/superpowers/notes/color-vector-ergonomics-complete.md
@@ -1,0 +1,43 @@
+# Color/Vector conversion ergonomics audit — done-note (queue item 14)
+
+**Date:** 2026-06-07 · **Spec:** `docs/superpowers/specs/2026-06-07-vector-tuple-conversions-design.md`
+
+## Audit conclusion
+
+The named finding (PR review comment 5) — the redundant
+`impl From<&Color> for Color` identity impl — was **already resolved** in
+the 6.0 breaking changes (prior artifacts:
+`docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md` + plan;
+CHANGELOG 6.0.0 Breaking entry). Re-verified on `unstable`:
+
+- Zero `From<&T> for T` identity impls remain on the math/color types.
+- The surviving `From<&T>` impls in the safe crate (`&Camera2D`, `&Ray`,
+  `&BoundingBox`, `&Transform`, `&NPatchInfo`, `&VrDeviceInfo`, `&Camera3D`)
+  convert wrapper → *distinct* FFI type — genuine, kept.
+- Draw API already takes `impl Into<ffi::Color>` / `impl Into<Vector2>`
+  pervasively (~393 sites); values pass directly.
+
+## What changed
+
+The one real asymmetry: `Color` had `From<(u8,u8,u8,u8)>` but the vectors
+had no tuple/array `From`. Added six impls in
+`raylib-sys/src/vector_math.rs` — `From<(f32,…)>` and `From<[f32; N]>` for
+Vector2/3/4. Purely additive (no blanket-`From` conflict; glam/mint are
+distinct named types), `no_std`-clean. Tier-1 round-trip + `Into`-inference
+tests in `raylib-sys/tests/conversions.rs` (unconditional module). Ships in
+6.0.0.
+
+## Not done (deliberately, YAGNI)
+
+- No `Color` `From<[u8;4]>` / 3-tuple-alpha-255 forms — nobody asked, and the
+  maintainer scoped item 14 to the vector gap. Easy additive follow-up if a
+  user files it.
+- No `From<&...>` forms on the vectors — that is the ceremony the
+  From<&Color> removal established the project avoids.
+
+## Verification
+
+`cargo nextest run -p raylib-sys` (81 tests, +4 new), clippy
+`-D warnings`, `cargo check -p raylib`, and the thumbv7em no-std proof leg
+(the new impls compile cross-target) — all green locally. Queue item 14
+closed.

--- a/docs/superpowers/specs/2026-06-07-vector-tuple-conversions-design.md
+++ b/docs/superpowers/specs/2026-06-07-vector-tuple-conversions-design.md
@@ -1,0 +1,72 @@
+# Vector tuple/array `From` conversions — design
+
+**Date:** 2026-06-07
+**Status:** approved (maintainer sign-off this session)
+**Queue:** post-release flexible-queue item 14 ("Color/Vector conversion ergonomics audit", PR review comment 5)
+
+## Audit conclusion (the named finding is already resolved)
+
+Item 14's specific concern — the redundant `impl From<&Color> for Color`
+identity impl — was **already removed** in the 6.0 breaking changes
+(prior artifacts: `docs/superpowers/specs/2026-06-03-color-ref-from-removal-design.md`
++ plan). Verified on current `unstable`:
+
+- Zero `From<&T> for T` identity impls remain on the math/color types.
+- The `From<&T>` impls left in the safe crate (`&Camera2D → ffi::Camera2D`,
+  `&Ray → ffi::Ray`, `&BoundingBox`, `&Transform`, `&NPatchInfo`,
+  `&VrDeviceInfo`, `&Camera3D`) are genuine wrapper→FFI conversions between
+  *distinct* types — correct, not ceremony.
+- The draw API already takes `impl Into<ffi::Color>` / `impl Into<Vector2>`
+  pervasively (~393 sites), so `Color`/`Vector2` values pass directly.
+
+## The one real gap
+
+`Color` has `impl From<(u8, u8, u8, u8)>` (raylib-sys/src/color.rs:56), but
+`Vector2/3/4` have **no** tuple or array `From` impls. The WS2b plan
+explicitly deferred `From<(f32,f32)> for Vector2` ("only if cheap"). So
+`draw_pixel_v((10.0, 20.0), c)` fails despite the param being
+`impl Into<Vector2>` — callers must write `Vector2::new(10.0, 20.0)`.
+
+## Change (purely additive, non-breaking)
+
+Add six impls in `raylib-sys/src/vector_math.rs` (same crate/module as the
+existing operator impls and the `From<Color> for Vector4` precedent):
+
+```rust
+impl From<(f32, f32)> for Vector2        // { x, y }
+impl From<[f32; 2]> for Vector2
+impl From<(f32, f32, f32)> for Vector3   // { x, y, z }
+impl From<[f32; 3]> for Vector3
+impl From<(f32, f32, f32, f32)> for Vector4  // { x, y, z, w }
+impl From<[f32; 4]> for Vector4
+```
+
+Each `#[inline]` with a one-line doc comment (`deny(missing_docs)` is
+crate-wide). Pure struct construction → `no_std`-clean. **No `From<&...>`
+forms** — that is exactly the ceremony the From<&Color> removal established
+we avoid; pass tuples/arrays by value.
+
+**Conflict check:** no blanket `From<T>` on the vectors exists; `glam`/`mint`
+conversions are over distinct named types — zero overlap. Additive, so no
+caller breaks.
+
+## Testing
+
+Tier-1 round-trip unit tests in `raylib-sys/tests/conversions.rs`, in a new
+**unconditional** top-level module (the existing modules are mint/glam/serde
+feature-gated): `Vector2::from((1.0, 2.0))` + `Vector2::from([1.0, 2.0])`
+field-equality, ×3 types. No FFI/window — runs in the default
+`cargo nextest run -p raylib-sys` leg.
+
+## Docs / release
+
+- CHANGELOG **Added** entry (additive; rides 6.0.0 final).
+- Done-note recording the audit conclusion (named finding already resolved,
+  prior-spec pointer) + this tuple-asymmetry closure. No book change.
+
+## Done criteria
+
+- Six `From` impls land; tuple/array round-trip tests green.
+- `cargo nextest run -p raylib-sys` + clippy `-Dwarnings` + the no-std proof
+  leg (these impls compile for thumb) green.
+- CHANGELOG entry; done-note; queue item 14 closed.

--- a/raylib-sys/src/vector_math.rs
+++ b/raylib-sys/src/vector_math.rs
@@ -247,6 +247,21 @@ impl Vector2 {
     }
 }
 
+impl From<(f32, f32)> for Vector2 {
+    /// Construct from an `(x, y)` tuple.
+    #[inline]
+    fn from((x, y): (f32, f32)) -> Self {
+        Vector2 { x, y }
+    }
+}
+impl From<[f32; 2]> for Vector2 {
+    /// Construct from an `[x, y]` array.
+    #[inline]
+    fn from([x, y]: [f32; 2]) -> Self {
+        Vector2 { x, y }
+    }
+}
+
 impl core::ops::Add for Vector2 {
     type Output = Vector2;
     #[inline]
@@ -662,6 +677,21 @@ pub fn vector3_ortho_normalize(v1: &mut Vector3, v2: &mut Vector3) {
     unsafe { crate::Vector3OrthoNormalize(v1 as *mut _, v2 as *mut _) }
 }
 
+impl From<(f32, f32, f32)> for Vector3 {
+    /// Construct from an `(x, y, z)` tuple.
+    #[inline]
+    fn from((x, y, z): (f32, f32, f32)) -> Self {
+        Vector3 { x, y, z }
+    }
+}
+impl From<[f32; 3]> for Vector3 {
+    /// Construct from an `[x, y, z]` array.
+    #[inline]
+    fn from([x, y, z]: [f32; 3]) -> Self {
+        Vector3 { x, y, z }
+    }
+}
+
 impl core::ops::Add for Vector3 {
     type Output = Vector3;
     #[inline]
@@ -901,6 +931,21 @@ impl Vector4 {
     pub fn equals(self, other: Vector4) -> bool {
         // SAFETY: pure value-in/out, no preconditions.
         unsafe { crate::Vector4Equals(self, other) != 0 }
+    }
+}
+
+impl From<(f32, f32, f32, f32)> for Vector4 {
+    /// Construct from an `(x, y, z, w)` tuple.
+    #[inline]
+    fn from((x, y, z, w): (f32, f32, f32, f32)) -> Self {
+        Vector4 { x, y, z, w }
+    }
+}
+impl From<[f32; 4]> for Vector4 {
+    /// Construct from an `[x, y, z, w]` array.
+    #[inline]
+    fn from([x, y, z, w]: [f32; 4]) -> Self {
+        Vector4 { x, y, z, w }
     }
 }
 

--- a/raylib-sys/tests/conversions.rs
+++ b/raylib-sys/tests/conversions.rs
@@ -335,3 +335,47 @@ mod serde_tests {
         assert_eq!(serde_json::from_str::<Color>(&j).unwrap(), c);
     }
 }
+
+/// Tuple/array `From` conversions for the vector types (no features needed).
+mod tuple_conversions {
+    use raylib_sys::{Vector2, Vector3, Vector4};
+
+    #[test]
+    fn vector2_from_tuple_and_array() {
+        assert_eq!(Vector2::from((1.0, 2.0)), Vector2 { x: 1.0, y: 2.0 });
+        assert_eq!(Vector2::from([1.0, 2.0]), Vector2 { x: 1.0, y: 2.0 });
+    }
+
+    #[test]
+    fn vector3_from_tuple_and_array() {
+        let expected = Vector3 {
+            x: 1.0,
+            y: 2.0,
+            z: 3.0,
+        };
+        assert_eq!(Vector3::from((1.0, 2.0, 3.0)), expected);
+        assert_eq!(Vector3::from([1.0, 2.0, 3.0]), expected);
+    }
+
+    #[test]
+    fn vector4_from_tuple_and_array() {
+        let expected = Vector4 {
+            x: 1.0,
+            y: 2.0,
+            z: 3.0,
+            w: 4.0,
+        };
+        assert_eq!(Vector4::from((1.0, 2.0, 3.0, 4.0)), expected);
+        assert_eq!(Vector4::from([1.0, 2.0, 3.0, 4.0]), expected);
+    }
+
+    #[test]
+    fn into_inference_at_call_sites() {
+        // The point of the impls: `impl Into<Vector2>` params accept tuples/arrays.
+        fn takes(v: impl Into<Vector2>) -> Vector2 {
+            v.into()
+        }
+        assert_eq!(takes((5.0, 6.0)), Vector2 { x: 5.0, y: 6.0 });
+        assert_eq!(takes([5.0, 6.0]), Vector2 { x: 5.0, y: 6.0 });
+    }
+}


### PR DESCRIPTION
Closes queue item 14 ("Color/Vector conversion ergonomics audit", PR review comment 5). Spec: `docs/superpowers/specs/2026-06-07-vector-tuple-conversions-design.md`; audit done-note: `docs/superpowers/notes/color-vector-ergonomics-complete.md`.

**Audit first — the named finding was already done.** The `impl From<&Color> for Color` identity impl the review flagged was removed back in the 6.0 breaking changes (prior spec `2026-06-03-color-ref-from-removal-design.md`). Verified: zero `From<&T> for T` identity impls remain on the math/color types; the `From<&T>` impls still present in the safe crate all convert wrapper → *distinct* FFI type (genuine, kept); the draw API already takes `impl Into<ffi::Color>` / `impl Into<Vector2>` everywhere.

**The one real gap closed here:** `Color` had `From<(u8,u8,u8,u8)>` but `Vector2/3/4` had no tuple/array `From`. This adds the six impls — `From<(f32,…)>` and `From<[f32; N]>` for each vector — so call sites can pass coordinates directly:

```rust
d.draw_pixel_v((10.0, 20.0), Color::RED);   // was: Vector2::new(10.0, 20.0)
d.draw_line_v([0.0, 0.0], [w, h], color);
```

**Properties:** purely additive (no caller breaks; no blanket-`From` conflict — glam/mint conversions are over distinct named types); `no_std`-clean; lives in `raylib-sys/src/vector_math.rs` next to the existing operator impls and the `From<(u8,u8,u8,u8)> for Color` precedent.

**Tests:** Tier-1 round-trip + `Into`-inference tests in `raylib-sys/tests/conversions.rs` (unconditional module). Local gates green: `nextest -p raylib-sys` (81, +4), clippy `-D warnings`, `cargo check -p raylib`, and the thumbv7em no-std proof leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
