### PR TITLE
ci: nobuild-prebuilt matrix proves nobuild links vs prebuilt raylib (queue item 13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Download prebuilt raylib 6.0 (Linux)
         if: runner.os == 'Linux'
         run: |
-          curl -sSL -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_linux_amd64.tar.gz
+          curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_linux_amd64.tar.gz
           mkdir -p "$RUNNER_TEMP/raylib"
           tar -xzf raylib.tar.gz --strip-components=1 -C "$RUNNER_TEMP/raylib"
           echo "::group::extracted lib dir"
@@ -186,7 +186,7 @@ jobs:
       - name: Download prebuilt raylib 6.0 (macOS)
         if: runner.os == 'macOS'
         run: |
-          curl -sSL -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_macos.tar.gz
+          curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_macos.tar.gz
           mkdir -p "$RUNNER_TEMP/raylib"
           tar -xzf raylib.tar.gz --strip-components=1 -C "$RUNNER_TEMP/raylib"
           echo "::group::extracted lib dir"
@@ -205,7 +205,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip -OutFile raylib.zip
+          # curl.exe (built into windows-latest) has --retry; Invoke-WebRequest
+          # does not, and the GitHub release CDN intermittently 504s.
+          curl.exe -sSL --retry 5 --retry-all-errors --retry-delay 5 -o raylib.zip https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip
           Expand-Archive raylib.zip -DestinationPath "$env:RUNNER_TEMP/raylib_extract" -Force
           $root = (Get-ChildItem "$env:RUNNER_TEMP/raylib_extract" -Directory | Select-Object -First 1).FullName
           # Link dynamically via the DLL import lib: the `dylib=raylib` directive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest] # Windows added once these are green
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -201,3 +201,25 @@ jobs:
           RUSTFLAGS: "-L native=${{ runner.temp }}/raylib/lib -C link-arg=-Wl,-rpath,${{ runner.temp }}/raylib/lib"
           DYLD_LIBRARY_PATH: "${{ runner.temp }}/raylib/lib"
         run: cargo nextest run -p raylib-sys --no-default-features --features nobuild -E 'binary(raymath_wrappers) + binary(symbol_presence)'
+      - name: Download prebuilt raylib 6.0 (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip -OutFile raylib.zip
+          Expand-Archive raylib.zip -DestinationPath "$env:RUNNER_TEMP/raylib_extract" -Force
+          $root = (Get-ChildItem "$env:RUNNER_TEMP/raylib_extract" -Directory | Select-Object -First 1).FullName
+          # Link dynamically via the DLL import lib: the `dylib=raylib` directive
+          # resolves `raylib.lib`, so overwrite it with `raylibdll.lib`. The static
+          # raylib.lib would instead pull rcore.obj -> winmm/user32/gdi32 symbols
+          # that nobuild's link() does not emit. raylib.dll goes on PATH at runtime.
+          Copy-Item "$root/lib/raylibdll.lib" "$root/lib/raylib.lib" -Force
+          "RAYLIB_PREBUILT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "lib dir:"; Get-ChildItem "$root/lib" | Select-Object Name
+      - name: Run window-independent tests against the prebuilt dll (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          RUSTFLAGS: "-L native=${{ env.RAYLIB_PREBUILT }}/lib"
+        run: |
+          $env:PATH = "$env:RAYLIB_PREBUILT/lib;" + $env:PATH
+          cargo nextest run -p raylib-sys --no-default-features --features nobuild -E 'binary(raymath_wrappers) + binary(symbol_presence)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # macOS + Windows added incrementally once Linux is green
+        os: [ubuntu-latest, macos-latest] # Windows added once these are green
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -182,4 +182,22 @@ jobs:
         env:
           RUSTFLAGS: "-L native=${{ runner.temp }}/raylib/lib"
           LD_LIBRARY_PATH: "${{ runner.temp }}/raylib/lib"
+        run: cargo nextest run -p raylib-sys --no-default-features --features nobuild -E 'binary(raymath_wrappers) + binary(symbol_presence)'
+      - name: Download prebuilt raylib 6.0 (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          curl -sSL -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_macos.tar.gz
+          mkdir -p "$RUNNER_TEMP/raylib"
+          tar -xzf raylib.tar.gz --strip-components=1 -C "$RUNNER_TEMP/raylib"
+          echo "::group::extracted lib dir"
+          ls -R "$RUNNER_TEMP/raylib/lib"
+          echo "::endgroup::"
+      # Belt-and-suspenders for dyld: bake an rpath into the test binaries AND set
+      # DYLD_LIBRARY_PATH, since macOS strips DYLD_* in some spawn paths and the
+      # prebuilt dylib's install_name may or may not be @rpath-relative.
+      - name: Run window-independent tests against the prebuilt dylib (macOS)
+        if: runner.os == 'macOS'
+        env:
+          RUSTFLAGS: "-L native=${{ runner.temp }}/raylib/lib -C link-arg=-Wl,-rpath,${{ runner.temp }}/raylib/lib"
+          DYLD_LIBRARY_PATH: "${{ runner.temp }}/raylib/lib"
         run: cargo nextest run -p raylib-sys --no-default-features --features nobuild -E 'binary(raymath_wrappers) + binary(symbol_presence)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,3 +134,52 @@ jobs:
       # complete.md when the workstream closes.
       # - name: Doctests (software_renderer)
       #   run: cargo test -p raylib --doc --no-default-features --features software_renderer,SUPPORT_MODULE_RTEXTURES,SUPPORT_MODULE_RSHAPES,SUPPORT_MODULE_RTEXT,SUPPORT_MODULE_RMODELS,SUPPORT_MODULE_RAUDIO,SUPPORT_IMAGE_GENERATION,SUPPORT_MESH_GENERATION,SUPPORT_FILEFORMAT_TTF
+
+  # Proves the `nobuild` feature links + runs against the PREBUILT raylib 6.0
+  # release libraries (not the vendored cmake build). nobuild's link() emits only
+  # `dylib=raylib`, so the link-search path and the runtime loader path are
+  # supplied here from the downloaded archive. Tier-2 headless is impossible
+  # against stock prebuilt raylib (release archives have no Memory/rlsw
+  # platform), so this runs only the window-independent raylib-sys tests, which
+  # exercise the raymath shim symbols nobuild must provide (raymath_wrappers)
+  # plus a link-presence guard for raylib's exported fns (symbol_presence).
+  # ADDED, non-required: deliberately not wired into the unstable branch ruleset.
+  nobuild-prebuilt:
+    name: nobuild-prebuilt (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest] # macOS + Windows added incrementally once Linux is green
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # nobuild still runs bindgen against the vendored headers (-Iraylib/src).
+          submodules: recursive
+      # The prebuilt libraylib.so is dynamically loaded at process start (we link
+      # dylib=raylib), so its own deps (X11/GL/ALSA) must be present even though
+      # the tests only call raymath/shim symbols. No cmake — nobuild skips it.
+      - name: Install Linux runtime deps for prebuilt libraylib.so
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test-nobuild-prebuilt-${{ matrix.os }}
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - name: Download prebuilt raylib 6.0 (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          curl -sSL -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_linux_amd64.tar.gz
+          mkdir -p "$RUNNER_TEMP/raylib"
+          tar -xzf raylib.tar.gz --strip-components=1 -C "$RUNNER_TEMP/raylib"
+          echo "::group::extracted lib dir"
+          ls -R "$RUNNER_TEMP/raylib/lib"
+          echo "::endgroup::"
+      - name: Run window-independent tests against the prebuilt dylib (Linux)
+        if: runner.os == 'Linux'
+        env:
+          RUSTFLAGS: "-L native=${{ runner.temp }}/raylib/lib"
+          LD_LIBRARY_PATH: "${{ runner.temp }}/raylib/lib"
+        run: cargo nextest run -p raylib-sys --no-default-features --features nobuild -E 'binary(raymath_wrappers) + binary(symbol_presence)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,8 @@ jobs:
       - name: Download prebuilt raylib 6.0 (Linux)
         if: runner.os == 'Linux'
         run: |
-          curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_linux_amd64.tar.gz
+          # -f so an HTTP 504 is a retryable failure, not a saved error page.
+          curl -fsSL --retry 8 --retry-delay 10 --retry-all-errors --retry-max-time 180 -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_linux_amd64.tar.gz
           mkdir -p "$RUNNER_TEMP/raylib"
           tar -xzf raylib.tar.gz --strip-components=1 -C "$RUNNER_TEMP/raylib"
           echo "::group::extracted lib dir"
@@ -186,7 +187,7 @@ jobs:
       - name: Download prebuilt raylib 6.0 (macOS)
         if: runner.os == 'macOS'
         run: |
-          curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_macos.tar.gz
+          curl -fsSL --retry 8 --retry-delay 10 --retry-all-errors --retry-max-time 180 -o raylib.tar.gz https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_macos.tar.gz
           mkdir -p "$RUNNER_TEMP/raylib"
           tar -xzf raylib.tar.gz --strip-components=1 -C "$RUNNER_TEMP/raylib"
           echo "::group::extracted lib dir"
@@ -207,7 +208,7 @@ jobs:
         run: |
           # curl.exe (built into windows-latest) has --retry; Invoke-WebRequest
           # does not, and the GitHub release CDN intermittently 504s.
-          curl.exe -sSL --retry 5 --retry-all-errors --retry-delay 5 -o raylib.zip https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip
+          curl.exe -fsSL --retry 8 --retry-delay 10 --retry-all-errors --retry-max-time 180 -o raylib.zip https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip
           Expand-Archive raylib.zip -DestinationPath "$env:RUNNER_TEMP/raylib_extract" -Force
           $root = (Get-ChildItem "$env:RUNNER_TEMP/raylib_extract" -Directory | Select-Object -First 1).FullName
           # Link dynamically via the DLL import lib: the `dylib=raylib` directive


### PR DESCRIPTION
## What & why

Post-release queue **item 13**, part B (the cross-OS proof). Stacks on #333 (the `build.rs` shim-gating fix that makes `nobuild` linkable). Adds a non-required `nobuild-prebuilt` matrix job to `test.yml` that links + runs against the **prebuilt raylib 6.0 release archives** — the production path a `nobuild` consumer actually takes.

> **Depends on #333.** Based on that branch so the diff here is only the workflow change. Will rebase onto `unstable` once #333 merges.

## How it works

`nobuild`'s `link()` emits only `cargo:rustc-link-lib=dylib=raylib`, so the job supplies the link-search path (`RUSTFLAGS=-L`) and the runtime loader path (`LD_LIBRARY_PATH`) from the downloaded `raylib-6.0_linux_amd64.tar.gz`. It then runs the window-independent raylib-sys tests under `--features nobuild`:

- **`raymath_wrappers`** — exercises the raymath shim symbols (`Vector2Add`/…) the nobuild link must provide. This is the symbol set #333 fixes.
- **`symbol_presence`** — references the addresses of raylib's exported 6.0 fns, so it fails to link if the prebuilt lib is missing them.

The prebuilt `libraylib.so` is dynamically loaded at process start, so its own deps (X11/GL/ALSA) are installed even though the tests only touch raymath/shim symbols.

## Scope / rollout

- **Linux first** (this commit). macOS and Windows legs land as follow-up commits once Linux is green — each OS has its own loader-path quirks (`DYLD_LIBRARY_PATH` / `PATH` + import-lib), so they're added incrementally to keep the proof legible.
- **Tier-2 headless is intentionally not run** — stock prebuilt raylib has no Memory/rlsw platform, so the software-renderer suite can't run against it.
- **Non-required:** this job is deliberately not added to the `unstable` branch ruleset; it's informational until we choose to promote it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
