### PR TITLE
ci: fix the merge queue (trigger required workflows on merge_group)

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [6.0-rc, unstable, master]
   pull_request:
+  # Required so the merge queue's required check (book `build`) runs on the
+  # merge_group event.
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [6.0-rc, unstable]
   pull_request:
+  # Required so the merge queue's required checks actually run on the
+  # merge_group event (the queue hangs otherwise — no workflow fired for it).
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [6.0-rc, unstable]
   pull_request:
+  # Required so the merge queue's required checks run on the merge_group event.
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [6.0-rc, unstable]
   pull_request:
+  # Required so the merge queue's required checks run on the merge_group event.
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem
`unstable` has a `merge_queue` ruleset rule whose required checks (fmt, clippy, docs, cargo-deny, msrv, typos, unit*, no-default*, software-render*, wasm-build, build) must run on the **`merge_group`** event. The old `CI` workflow that handled `merge_group` was retired in the WS6 layered-CI split, so **no workflow fired for `merge_group`** — every queued PR hung forever waiting for checks that never ran (#335/#336 had to be `--admin`-merged to land).

## Fix
Add `merge_group:` to the four workflows that own the required checks:
- **check** — fmt, clippy, docs, cargo-deny, typos, msrv
- **test** — unit*, no-default*, software-render*
- **web** — wasm-build (bare)
- **book** — build (bare)

(showcase's `build (os)` / `wasm-build (N)` are matrixed and not required, so it's intentionally left off the queue to save cost.)

After this lands, queued PRs will run the required checks on their merge_group entry and merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)