### PR TITLE
fix(sys): pin bindgen clang --target for *-windows-gnu cross builds (closes #324)

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -353,6 +353,15 @@ fn gen_bindings() {
         builder = builder.clang_arg("-D__STDC__");
     }
 
+    // MinGW cross builds: without an explicit `--target`, bindgen's libclang
+    // defaults to the *host* triple and mis-parses the MinGW system headers
+    // (e.g. `__mingw_ldbl_type_t`). Pin clang to the build target so it uses the
+    // right headers/ABI. Scoped to `*-windows-gnu` so host/MSVC/other targets
+    // are unaffected. Resolves #324; original workaround by @jgabaut (#325).
+    if target.ends_with("-windows-gnu") {
+        builder = builder.clang_arg(format!("--target={target}"));
+    }
+
     // nobuild bindings may be consumed cross-target via nobindgen +
     // RAYLIB_BINDGEN_LOCATION (e.g. the no-std CI leg compile-checks a
     // host-generated binding for thumbv7em). bindgen's layout asserts


### PR DESCRIPTION
Closes #324. Supersedes #325 (re-derived onto current `build.rs`).

Without an explicit `--target`, bindgen's libclang defaults to the host triple and mis-parses MinGW headers (`__mingw_ldbl_type_t`). This passes `--target=<triple>` when the build target ends with `-windows-gnu`, scoped so host/MSVC/other targets are unaffected (verified `cargo check -p raylib-sys` host bindgen unchanged).

A dedicated `*-windows-gnu` cross-compile CI leg to regression-guard this is a reasonable **post-6.0** follow-up (needs a MinGW toolchain on the runner). Original workaround by @jgabaut (#325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)