### PR TITLE
fix(ci): bump emsdk 3.1.64 -> 3.1.74 for rustc 1.88 wasm (fixes Pages deploy)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Set up emsdk
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.64
+          # >= 3.1.74 (Binaryen >= 121): rustc 1.88 emits the bulk-memory-opt /
+          # call-indirect-overlong wasm features, which older wasm-opt (3.1.64
+          # ships Binaryen 117) rejects with "Unknown option
+          # '--enable-bulk-memory-opt'", failing the emcc link of every example.
+          version: 3.1.74
           actions-cache-folder: emsdk-cache
       - name: Export bindgen sysroot for wasm32-emscripten
         run: echo "BINDGEN_EXTRA_CLANG_ARGS=--sysroot=$EMSDK/upstream/emscripten/cache/sysroot" >> $GITHUB_ENV

--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -95,7 +95,9 @@ jobs:
       - name: Set up emsdk
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.64
+          # >= 3.1.74 (Binaryen >= 121): rustc 1.88 emits bulk-memory-opt /
+          # call-indirect-overlong, which older wasm-opt rejects. See pages.yml.
+          version: 3.1.74
           actions-cache-folder: emsdk-cache
       - name: Verify emcc on PATH
         run: emcc --version

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Set up emsdk
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.64
+          # >= 3.1.74 (Binaryen >= 121): rustc 1.88 emits bulk-memory-opt /
+          # call-indirect-overlong, which older wasm-opt rejects. See pages.yml.
+          version: 3.1.74
           actions-cache-folder: emsdk-cache
       - name: Verify emcc on PATH
         run: emcc --version

--- a/book/src/getting-started/install-web.md
+++ b/book/src/getting-started/install-web.md
@@ -11,12 +11,12 @@ raylib-rs targets `wasm32-unknown-emscripten`, which compiles your game to WebAs
    rustup target add wasm32-unknown-emscripten
    ```
 
-3. **emsdk 3.1.64+** — the Emscripten SDK provides `emcc`, the compiler that cross-compiles C to WebAssembly. Follow the [official emsdk install instructions](https://emscripten.org/docs/getting_started/downloads.html):
+3. **emsdk 3.1.74+** — the Emscripten SDK provides `emcc`, the compiler that cross-compiles C to WebAssembly. 3.1.74+ bundles Binaryen ≥ 121, required by the wasm features rustc 1.88 emits (older emsdk fails the link with `Unknown option '--enable-bulk-memory-opt'`). Follow the [official emsdk install instructions](https://emscripten.org/docs/getting_started/downloads.html):
    ```text
    git clone https://github.com/emscripten-core/emsdk.git
    cd emsdk
-   ./emsdk install 3.1.64
-   ./emsdk activate 3.1.64
+   ./emsdk install 3.1.74
+   ./emsdk activate 3.1.74
    source ./emsdk_env.sh   # add emcc to PATH for this shell session
    ```
 


### PR DESCRIPTION
## Problem
The **Pages deploy has failed on every push since 2026-06-07** (the MSRV 1.85→1.88 bump, #330). Root cause: rustc 1.88 emits the `bulk-memory-opt` / `call-indirect-overlong` wasm target features, which require **Binaryen ≥ 121**. emsdk 3.1.64 ships **Binaryen 117**, so `wasm-opt` rejects `--enable-bulk-memory-opt` and the `emcc` link of every showcase example fails → blank example pages → the Playwright smoke gate sees **0/10 booted** → deploy blocked.

Why it hid: `xtask-wasm-build` tolerates per-example link failures (exits 0, the step shows green), the `showcase` wasm leg is `continue-on-error: true`, and `web` only builds the lib (no `emcc` example link). Only the Pages smoke runs the wasm, so only it caught the break.

## Fix
Bump emsdk **3.1.64 → 3.1.74** (Binaryen 121) in `pages.yml`, `web.yml`, `showcase.yml`, and the book install page.

## Verification
Diagnosed + verified out-of-band with a throwaway build+smoke workflow (no Pages env): **emsdk 3.1.74 → 10/10 pages booted clean**, no `bulk-memory-opt` errors (4.0.0 also works; 3.1.74 is the minimal jump). The `web`/`showcase` legs here exercise the new emsdk; Pages deploys on merge.

Refs: [PyO3/maturin#2549](https://github.com/PyO3/maturin/issues/2549), [dotnet/runtime#114723](https://github.com/dotnet/runtime/issues/114723).

🤖 Generated with [Claude Code](https://claude.com/claude-code)