### PR TITLE
Dont force build option to SDL2 when SDL3 is available

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -187,7 +187,6 @@ fn build_with_cmake(src_path: &str) {
         Platform::Desktop => {
             #[cfg(feature = "sdl")]
             {
-                println!("cargo:rustc-link-lib=SDL2");
                 conf.define("PLATFORM", "SDL")
             }
             #[cfg(not(feature = "sdl"))]

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -187,6 +187,7 @@ fn build_with_cmake(src_path: &str) {
         Platform::Desktop => {
             #[cfg(feature = "sdl")]
             {
+                println!("cargo:rustc-link-lib=SDL3");
                 conf.define("PLATFORM", "SDL")
             }
             #[cfg(not(feature = "sdl"))]

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -187,8 +187,8 @@ fn build_with_cmake(src_path: &str) {
         Platform::Desktop => {
             #[cfg(feature = "sdl")]
             {
-                println!("cargo:rustc-link-lib=SDL3");
-                conf.define("PLATFORM", "SDL")
+                // println!("cargo:rustc-link-lib=SDL3");
+                conf.define("PLATFORM", "SDL3")
             }
             #[cfg(not(feature = "sdl"))]
             {


### PR DESCRIPTION
Raylib build auto detects SDL availability so forcing SDL2 causes build to fail on systems with SDL3. Instead we can directly rely to Raylib to figure out which SDL to link to from 6.0.0 onwards.