### PR TITLE
Fix length in RaylibDraw::draw_text_codepoints()

### DIFF
--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -1862,7 +1862,7 @@ pub trait RaylibDraw {
             ffi::DrawTextCodepoints(
                 *font.as_ref(),
                 u,
-                text.len() as i32,
+                len,
                 position.into(),
                 font_size,
                 spacing,


### PR DESCRIPTION
A tiny fix in `RaylibDraw::draw_text_codepoints()`: raylib's DrawTextCodepoints() expects the number of codepoints to draw, not the string length in bytes.

It shouldn't have any other impact, but I ran the tests anyway on Linux (Debian trixie) and everything seems fine.
