### PR TITLE
fix(audio): incorrect `AudioStream::is_processed` doc

### DIFF
--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -845,7 +845,7 @@ impl AudioStream<'_> {
         }
     }
 
-    /// Sets pitch for audio stream (`1.0` is base level).
+    /// Check if any audio stream buffers requires refill
     #[inline]
     #[must_use]
     pub fn is_processed(&self) -> bool {


### PR DESCRIPTION
Came across this minor issue while tinkering around with the audio API