### PR TITLE
Fixing feature `"wayland"` to actually render on wayland #352

### DIFF
--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -97,7 +97,7 @@ sdl = []
 # CPU software renderer + windowless Memory platform (raylib 6.0 PLATFORM=Memory).
 # Mutually exclusive with every opengl_* backend and with `drm` (enforced in build.rs).
 software_renderer = []
-wayland = []
+wayland = ["GLFW_BUILD_WAYLAND"]
 
 # Curated "max capability" set for CI lint/test + users who want everything.
 # default + ecosystem adapters + raygui + every capability flag, EXCLUDING the


### PR DESCRIPTION
Setting the feature `"wayland"` did not use the correct GLFW flag for the cmake config anymore. When building for wayland, we should pass `"-DGLFW_BUILD_WAYLAND=ON"` to cmake according to the raylib docs. Currently we weren't passing anything, causing the default `OFF` for the flag and therefore rendering for x11. The feature `"GLFW_BUILD_WAYLAND"` is already available which sets the correct cmake flag, so we could use that with the `"wayland"` feature.